### PR TITLE
Replace privileged: true with minimum required capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,16 @@ services:
     build:
       context: docker
       dockerfile: Dockerfile
-    privileged: true
+    # BuildKit OCI worker requires SYS_ADMIN for mount, namespaces, and cgroups.
+    # iptables and CNI networking require NET_ADMIN.
+    cap_add:
+      - SYS_ADMIN
+      - NET_ADMIN
+    # BuildKit/runc needs syscalls (mount, unshare, pivot_root) blocked by
+    # default seccomp and AppArmor profiles.
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
     ports:
       - "${PORT:-1234}:1234"
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -15,8 +15,10 @@ services:
     security_opt:
       - seccomp=unconfined
       - apparmor=unconfined
-    # /sys/fs/cgroup is read-only in non-privileged containers, but BuildKit
-    # needs write access to create cgroups for build containers.
+    # Share the host's cgroup namespace so BuildKit can manage cgroups for
+    # build containers. The volume mount makes /sys/fs/cgroup writable
+    # (read-only by default in non-privileged containers).
+    cgroup: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -3,6 +3,10 @@ services:
     build:
       context: docker
       dockerfile: Dockerfile
+    # Instead of privileged: true, grant only the minimum privileges required
+    # to run BuildKit and iptables. This avoids granting full device access
+    # and unrestricted /sys write permissions that privileged mode includes.
+    #
     # BuildKit OCI worker requires SYS_ADMIN for mount, namespaces, and cgroups.
     # iptables and CNI networking require NET_ADMIN.
     # runc needs SYS_PTRACE to access /proc/PID/ns/mnt for mount namespace setup.

--- a/compose.yml
+++ b/compose.yml
@@ -5,14 +5,20 @@ services:
       dockerfile: Dockerfile
     # BuildKit OCI worker requires SYS_ADMIN for mount, namespaces, and cgroups.
     # iptables and CNI networking require NET_ADMIN.
+    # runc needs SYS_PTRACE to access /proc/PID/ns/mnt for mount namespace setup.
     cap_add:
       - SYS_ADMIN
       - NET_ADMIN
+      - SYS_PTRACE
     # BuildKit/runc needs syscalls (mount, unshare, pivot_root) blocked by
     # default seccomp and AppArmor profiles.
     security_opt:
       - seccomp=unconfined
       - apparmor=unconfined
+    # /sys/fs/cgroup is read-only in non-privileged containers, but BuildKit
+    # needs write access to create cgroups for build containers.
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     ports:
       - "${PORT:-1234}:1234"
     environment:

--- a/setup/compose.yml
+++ b/setup/compose.yml
@@ -1,6 +1,10 @@
 services:
   builder:
     image: ${BUILDCAGE_IMAGE}:${BUILDCAGE_VERSION:-1}
+    # Instead of privileged: true, grant only the minimum privileges required
+    # to run BuildKit and iptables. This avoids granting full device access
+    # and unrestricted /sys write permissions that privileged mode includes.
+    #
     # BuildKit OCI worker requires SYS_ADMIN for mount, namespaces, and cgroups.
     # iptables and CNI networking require NET_ADMIN.
     # runc needs SYS_PTRACE to access /proc/PID/ns/mnt for mount namespace setup.

--- a/setup/compose.yml
+++ b/setup/compose.yml
@@ -13,8 +13,10 @@ services:
     security_opt:
       - seccomp=unconfined
       - apparmor=unconfined
-    # /sys/fs/cgroup is read-only in non-privileged containers, but BuildKit
-    # needs write access to create cgroups for build containers.
+    # Share the host's cgroup namespace so BuildKit can manage cgroups for
+    # build containers. The volume mount makes /sys/fs/cgroup writable
+    # (read-only by default in non-privileged containers).
+    cgroup: host
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     ports:

--- a/setup/compose.yml
+++ b/setup/compose.yml
@@ -3,14 +3,20 @@ services:
     image: ${BUILDCAGE_IMAGE}:${BUILDCAGE_VERSION:-1}
     # BuildKit OCI worker requires SYS_ADMIN for mount, namespaces, and cgroups.
     # iptables and CNI networking require NET_ADMIN.
+    # runc needs SYS_PTRACE to access /proc/PID/ns/mnt for mount namespace setup.
     cap_add:
       - SYS_ADMIN
       - NET_ADMIN
+      - SYS_PTRACE
     # BuildKit/runc needs syscalls (mount, unshare, pivot_root) blocked by
     # default seccomp and AppArmor profiles.
     security_opt:
       - seccomp=unconfined
       - apparmor=unconfined
+    # /sys/fs/cgroup is read-only in non-privileged containers, but BuildKit
+    # needs write access to create cgroups for build containers.
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
     ports:
       - "${PORT:-1234}:1234"
     environment:

--- a/setup/compose.yml
+++ b/setup/compose.yml
@@ -1,7 +1,16 @@
 services:
   builder:
     image: ${BUILDCAGE_IMAGE}:${BUILDCAGE_VERSION:-1}
-    privileged: true
+    # BuildKit OCI worker requires SYS_ADMIN for mount, namespaces, and cgroups.
+    # iptables and CNI networking require NET_ADMIN.
+    cap_add:
+      - SYS_ADMIN
+      - NET_ADMIN
+    # BuildKit/runc needs syscalls (mount, unshare, pivot_root) blocked by
+    # default seccomp and AppArmor profiles.
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
     ports:
       - "${PORT:-1234}:1234"
     environment:


### PR DESCRIPTION
## Summary
- Replace `privileged: true` in `compose.yml` and `setup/compose.yml` with the minimum privileges required to run BuildKit and iptables
- Drop full device access and unrestricted `/sys` write permissions that privileged mode includes

### Privileges granted
| Setting | Reason |
|---|---|
| `cap_add: SYS_ADMIN` | BuildKit OCI worker needs mount, namespace, and cgroup operations |
| `cap_add: NET_ADMIN` | iptables rules and CNI network setup |
| `cap_add: SYS_PTRACE` | runc needs access to `/proc/PID/ns/mnt` for mount namespace setup |
| `security_opt: seccomp=unconfined` | runc requires syscalls (mount, unshare, pivot_root) blocked by the default seccomp profile |
| `security_opt: apparmor=unconfined` | Mount operations blocked by the default AppArmor profile |
| `cgroup: host` | Share the host's cgroup namespace so BuildKit can create cgroups for build containers |
| `volumes: /sys/fs/cgroup:rw` | `/sys/fs/cgroup` is read-only in non-privileged containers; BuildKit needs write access |

## Test plan
- [x] `make test_restrict_mode` passed locally
- [ ] `Test` CI passed on GitHub Actions