### PR TITLE
Add Rule Type (HTTP/HTTPS/IP) field to proxy logs and report

### DIFF
--- a/docker/files/haproxy.cfg.template
+++ b/docker/files/haproxy.cfg.template
@@ -32,6 +32,7 @@ frontend outbound_proxy
     tcp-request content set-var(sess.decision) str(BLOCKED)
     tcp-request content set-var(sess.reason) str(-)
     tcp-request content set-var-fmt(sess.target) %[dst]:%[dst_port]
+    tcp-request content set-var(sess.rule_type) str(UNKNOWN)
 
     # ACL: DNS-routed vs IP direct
     acl is_dns_routed dst 172.20.0.1
@@ -56,6 +57,7 @@ frontend outbound_proxy
     # ---------------------------------------------------------
     # 1. IP direct access (non DNS-routed)
     # ---------------------------------------------------------
+    tcp-request content set-var(sess.rule_type) str(IP) if !is_dns_routed
     tcp-request content set-var(sess.decision) str(${HAPROXY_DECISION_LABEL}) if !is_dns_routed is_ip_match
     tcp-request content accept if !is_dns_routed is_ip_match
 
@@ -66,6 +68,7 @@ frontend outbound_proxy
     # ---------------------------------------------------------
     # 2. TLS without SNI
     # ---------------------------------------------------------
+    tcp-request content set-var(sess.rule_type) str(HTTPS) if is_tls
     tcp-request content set-var(sess.reason) str(missing-sni) if is_tls !has_sni
     tcp-request content reject if is_tls !has_sni
 
@@ -94,7 +97,7 @@ frontend outbound_proxy
     default_backend http_filter_backend
 
     # Set log format
-    log-format "[%T] buildcage [%[var(sess.decision)]] \"%[var(sess.target)]\" %[var(sess.reason)]"
+    log-format "[%T] buildcage [%[var(sess.decision)]] (%[var(sess.rule_type)]) \"%[var(sess.target)]\" %[var(sess.reason)]"
 
 # --- IP direct passthrough backend ---
 backend ip_passthrough
@@ -110,6 +113,7 @@ backend tls_passthrough
 # deny responses leave sess.decision as BLOCKED (set in frontend).
 backend http_filter_backend
     mode http
+    http-request set-var(sess.rule_type) str(HTTP)
 
     # Host header check
     acl has_host hdr(host) -m found

--- a/report/main.mjs
+++ b/report/main.mjs
@@ -23,14 +23,15 @@ console.log();
 
 // 3. Parse log lines
 const logPattern =
-  /^\[.*?\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+"([^"]+)"\s*(\S*)/;
+  /^\[.*?\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+\((\w+)\)\s+"([^"]+)"\s*(\S*)/;
 
 const entries = [];
 for (const line of logs.split("\n")) {
   const m = line.match(logPattern);
   if (m) {
-    const hostPort = m[2];
-    const reason = m[3] || "-";
+    const ruleType = m[2];
+    const hostPort = m[3];
+    const reason = m[4] || "-";
     const colonIdx = hostPort.lastIndexOf(":");
     let host, port;
     if (colonIdx > 0) {
@@ -42,6 +43,7 @@ for (const line of logs.split("\n")) {
     }
     entries.push({
       decision: m[1],
+      ruleType,
       host,
       port,
       reason,
@@ -65,13 +67,13 @@ const isAudit = entries.some((e) => e.decision === "AUDIT");
 function aggregate(filtered) {
   const map = new Map();
   for (const e of filtered) {
-    const key = `${e.host}\t${e.port}\t${e.reason}`;
+    const key = `${e.host}\t${e.port}\t${e.ruleType}\t${e.reason}`;
     map.set(key, (map.get(key) || 0) + 1);
   }
   return [...map.entries()]
     .map(([key, count]) => {
-      const [host, portStr, reason] = key.split("\t");
-      return { host, port: Number(portStr), reason, count };
+      const [host, portStr, ruleType, reason] = key.split("\t");
+      return { host, port: Number(portStr), ruleType, reason, count };
     })
     .sort(
       (a, b) =>
@@ -83,15 +85,15 @@ function aggregate(filtered) {
 
 function markdownTable(rows, { showReason = false } = {}) {
   if (showReason) {
-    const lines = ["| Host | Port | Reason | Count |", "| --- | --- | --- | ---: |"];
+    const lines = ["| Host | Port | Type | Reason | Count |", "| --- | --- | --- | --- | ---: |"];
     for (const r of rows) {
-      lines.push(`| ${r.host} | ${r.port || ""} | ${r.reason} | ${r.count} |`);
+      lines.push(`| ${r.host} | ${r.port || ""} | ${r.ruleType} | ${r.reason} | ${r.count} |`);
     }
     return lines.join("\n");
   }
-  const lines = ["| Host | Port | Count |", "| --- | --- | ---: |"];
+  const lines = ["| Host | Port | Type | Count |", "| --- | --- | --- | ---: |"];
   for (const r of rows) {
-    lines.push(`| ${r.host} | ${r.port || ""} | ${r.count} |`);
+    lines.push(`| ${r.host} | ${r.port || ""} | ${r.ruleType} | ${r.count} |`);
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Proxy report tables now include a "Type" column showing how each request was matched (HTTP, HTTPS, or IP)
- Log lines include the rule type between decision and target: `[ALLOWED] (HTTPS) "example.com:443"`
- HAProxy frontend classifies each request into a `rule_type` session variable (HTTP, HTTPS, IP, UNKNOWN) used for logging
