### PR TITLE
Misc cleanup: remove redundant test trigger and document non-TCP blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ run-name: Test (${{ github.ref_name }})
 on:
   workflow_dispatch:
 
-  push:
-    branches:
-      - main
-
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ buildcage runs as a [remote driver](https://docs.docker.com/build/builders/drive
 - HTTPS: SNI (Server Name Indication) for domain matching — TLS is not terminated
 - HTTP: Host header for domain matching
 - Direct IP access: blocked unless explicitly allowed
+- Non-TCP protocols (UDP, ICMP, etc.): all blocked — only TCP connections are supported
 
 **Two modes available** (see [Reference](#reference) for details):
 


### PR DESCRIPTION
## Summary

- Remove `push` trigger on `main` from the test workflow to avoid redundant CI runs (PRs already trigger tests)
- Add a note to the "How It Works" section in README clarifying that non-TCP protocols (UDP, ICMP, etc.) are all blocked and only TCP connections are supported