### PR TITLE
Fix inaccurate descriptions and broken link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,8 @@ Pass this port to [`docker/setup-buildx-action`](https://github.com/docker/setup
 **When to use:** First-time setup, adding new dependencies, or investigating issues.
 
 **What it does:**
-- Allows all HTTP/HTTPS connections
+- Allows all HTTP/HTTPS connections (except requests missing a Host header or SNI)
 - Logs every domain accessed during the build
-- Does NOT block anything
 
 ##### Restrict Mode (`proxy_mode: restrict`)
 
@@ -263,12 +262,6 @@ Pass this port to [`docker/setup-buildx-action`](https://github.com/docker/setup
   allowed_https_rules: registry.npmjs.org:443
   ```
 
-- If your build needs to access non-standard ports, specify the port in the rule:
-
-  ```yaml
-  allowed_http_rules: "example.com:8080"
-  allowed_https_rules: "example.com:8443"
-  ```
 
 ### Report Action (`dash14/buildcage/report`)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 I welcome reports about:
 
-- **Proxy bypass** — ways to make network connections from `RUN` steps that evade the buildcage proxy (other than the [known domain fronting limitation](./README.md#domain-fronting))
+- **Proxy bypass** — ways to make network connections from `RUN` steps that evade the buildcage proxy (other than the [known domain fronting limitation](./README.md#known-limitations))
 - **Network isolation escape** — bypassing CNI isolation or iptables rules to reach the internet directly
 - **GitHub Actions setup** — vulnerabilities in the `setup` or `report` actions (e.g., injection, credential leak)
 - **DNS filtering bypass** — bypassing the DNS redirect mechanism


### PR DESCRIPTION
## Summary      

- Clarify that audit mode blocks requests missing a Host header or SNI, rather than claiming it "does NOT block anything"
- Remove the non-standard ports tip from README since port specification is always required in rules
- Fix broken anchor link (`#domain-fronting` → `#known-limitations`) in SECURITY.md