### PR TITLE
Add path filter to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,15 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'docker/**'
+      - 'setup/**'
+      - 'report/**'
+      - 'test/**'
+      - 'compose.yml'
+      - 'compose.test.yml'
+      - 'Makefile'
+      - '.github/workflows/test.yml'
 
 jobs:
   unit_test:


### PR DESCRIPTION
## Summary

- Add `paths` filter to the `pull_request` trigger in the test workflow
- Tests now only run when PRs change files related to the build, setup, report, or test logic
- `workflow_dispatch` trigger is unchanged, so manual runs are always available
