### PR TITLE
Fix tag pattern in docker-publish workflow to match semver format

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,7 @@ run-name: Build and Push Docker Image (${{ github.ref_name }})
 on:
   push:
     tags:
-      - "v*.*"
+      - "v*.*.*"
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Fix the tag trigger pattern from `v*.*` to `v*.*.*` to match full semver tags (e.g., `v1.2.3`)
- The previous pattern `v*.*` was inconsistent with the actual tag format used in this repository
