### PR TITLE
Improve documentation for report step naming and self-hosting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
           context: .
           push: false  # Set to true to push the built image
 
-      - name: Show what domains were accessed
+      - name: Show buildcage report
         if: always()
         uses: dash14/buildcage/report@v1
         with:
@@ -158,7 +158,7 @@ jobs:
           context: .
           push: false  # Set to true to push the built image
 
-      - name: Security report
+      - name: Show buildcage report
         if: always()
         uses: dash14/buildcage/report@v1
         # Build fails if any unexpected connections were blocked

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -110,3 +110,5 @@ git push origin HEAD --tags --force
 ```
 
 After pushing a new version tag, the **Build and Push Docker Image** workflow will automatically trigger and publish the updated image.
+
+> **Note:** If the workflow does not trigger automatically, run it manually from **Actions** > **Build and Push Docker Image** > **Run workflow**. The branch selection can be left as `main` — the workflow will build from the latest version tag.


### PR DESCRIPTION
## Summary
- Rename report step to "Show buildcage report" across all README examples for consistent naming with "Start buildcage in ..." setup steps
- Add note to self-hosting guide about manually triggering the Docker image build workflow when automatic triggering does not occur, and clarify that the branch selection can be left as `main`