### PR TITLE
Add third-party license notices for GPL and other bundled components

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,8 +440,9 @@ If you find buildcage helpful, please consider giving it a star ⭐ on GitHub!
 This software is provided "as is", without warranty of any kind, express or implied. The authors and contributors are not liable for any damages, losses, or security incidents arising from the use of this software. Use at your own risk.
 
 ## License
-Licensed under the MIT License.
-See [LICENSE](./LICENSE) file for more details.
+The buildcage source code is licensed under the MIT License. See [LICENSE](./LICENSE) file for details.
+
+The Docker image includes third-party components under their own licenses (GPL, Apache 2.0, ISC, etc.). See [THIRD_PARTY_LICENSES](./THIRD_PARTY_LICENSES) for the full list.
 
 ## Acknowledgments
 

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,65 @@
+Third-Party Licenses
+====================
+
+The buildcage Docker image includes the following third-party software.
+Each component retains its original license. The buildcage source code
+itself is licensed under the MIT License (see LICENSE file).
+
+------------------------------------------------------------------------------
+
+HAProxy
+  Website : https://www.haproxy.org/
+  License : GNU General Public License v2.0 or later (GPL-2.0-or-later)
+  Source  : https://git.haproxy.org/ or via Alpine Linux source packages
+
+------------------------------------------------------------------------------
+
+dnsmasq
+  Website : https://thekelleys.org.uk/dnsmasq/doc.html
+  License : GNU General Public License v2.0 or v3.0 (GPL-2.0-only OR GPL-3.0-only)
+  Source  : https://thekelleys.org.uk/gitweb/?p=dnsmasq.git or via Alpine Linux
+            source packages
+
+------------------------------------------------------------------------------
+
+BuildKit (base image: moby/buildkit)
+  Website : https://github.com/moby/buildkit
+  License : Apache License 2.0 (Apache-2.0)
+  Source  : https://github.com/moby/buildkit
+
+------------------------------------------------------------------------------
+
+CNI Plugins
+  Website : https://github.com/containernetworking/plugins
+  License : Apache License 2.0 (Apache-2.0)
+  Source  : https://github.com/containernetworking/plugins
+
+------------------------------------------------------------------------------
+
+s6-overlay
+  Website : https://github.com/just-containers/s6-overlay
+  License : ISC License
+  Source  : https://github.com/just-containers/s6-overlay
+
+------------------------------------------------------------------------------
+
+QuickJS
+  Website : https://bellard.org/quickjs/
+  License : MIT License
+  Source  : https://github.com/nicedoc/nicedoc.io or https://bellard.org/quickjs/
+
+------------------------------------------------------------------------------
+
+Note on GPL components (HAProxy, dnsmasq):
+
+These components are installed from the Alpine Linux official package
+repository. Their source code is available through:
+
+  1. The upstream project repositories listed above
+  2. Alpine Linux source packages:
+     https://pkgs.alpinelinux.org/packages
+
+The buildcage source code (MIT License) is not derived from, linked to,
+or combined with the GPL-licensed components. They are independent programs
+distributed together in a Docker image as an aggregate work, consistent
+with GPL v2 Section 2.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ FROM moby/buildkit:${BUILDKIT_VERSION}
 
 LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.description="Secure Docker build environment with network access control" \
-      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.licenses="MIT AND GPL-2.0-or-later" \
       org.opencontainers.image.source="https://github.com/dash14/buildcage"
 
 RUN apk add --no-cache \
@@ -61,6 +61,9 @@ COPY files/haproxy.cfg.template /etc/haproxy/haproxy.cfg.template
 
 # Tools (QuickJS scripts)
 COPY files/tools/ /opt/buildcage/tools/
+
+# License
+COPY files/THIRD_PARTY_LICENSES /opt/buildcage/THIRD_PARTY_LICENSES
 
 # s6 service definitions and init scripts
 COPY files/s6-rc.d/ /etc/s6-overlay/s6-rc.d/

--- a/docker/files/THIRD_PARTY_LICENSES
+++ b/docker/files/THIRD_PARTY_LICENSES
@@ -1,0 +1,65 @@
+Third-Party Licenses
+====================
+
+The buildcage Docker image includes the following third-party software.
+Each component retains its original license. The buildcage source code
+itself is licensed under the MIT License (see LICENSE file).
+
+------------------------------------------------------------------------------
+
+HAProxy
+  Website : https://www.haproxy.org/
+  License : GNU General Public License v2.0 or later (GPL-2.0-or-later)
+  Source  : https://git.haproxy.org/ or via Alpine Linux source packages
+
+------------------------------------------------------------------------------
+
+dnsmasq
+  Website : https://thekelleys.org.uk/dnsmasq/doc.html
+  License : GNU General Public License v2.0 or v3.0 (GPL-2.0-only OR GPL-3.0-only)
+  Source  : https://thekelleys.org.uk/gitweb/?p=dnsmasq.git or via Alpine Linux
+            source packages
+
+------------------------------------------------------------------------------
+
+BuildKit (base image: moby/buildkit)
+  Website : https://github.com/moby/buildkit
+  License : Apache License 2.0 (Apache-2.0)
+  Source  : https://github.com/moby/buildkit
+
+------------------------------------------------------------------------------
+
+CNI Plugins
+  Website : https://github.com/containernetworking/plugins
+  License : Apache License 2.0 (Apache-2.0)
+  Source  : https://github.com/containernetworking/plugins
+
+------------------------------------------------------------------------------
+
+s6-overlay
+  Website : https://github.com/just-containers/s6-overlay
+  License : ISC License
+  Source  : https://github.com/just-containers/s6-overlay
+
+------------------------------------------------------------------------------
+
+QuickJS
+  Website : https://bellard.org/quickjs/
+  License : MIT License
+  Source  : https://github.com/nicedoc/nicedoc.io or https://bellard.org/quickjs/
+
+------------------------------------------------------------------------------
+
+Note on GPL components (HAProxy, dnsmasq):
+
+These components are installed from the Alpine Linux official package
+repository. Their source code is available through:
+
+  1. The upstream project repositories listed above
+  2. Alpine Linux source packages:
+     https://pkgs.alpinelinux.org/packages
+
+The buildcage source code (MIT License) is not derived from, linked to,
+or combined with the GPL-licensed components. They are independent programs
+distributed together in a Docker image as an aggregate work, consistent
+with GPL v2 Section 2.


### PR DESCRIPTION
## Summary

- Add `THIRD_PARTY_LICENSES` file documenting licenses for all bundled components (HAProxy, dnsmasq, BuildKit, CNI Plugins, s6-overlay, QuickJS) with source code links for GPL compliance
- Include `THIRD_PARTY_LICENSES` in the Docker image at `/opt/buildcage/THIRD_PARTY_LICENSES`
- Update Dockerfile image label from `MIT` to `MIT AND GPL-2.0-or-later` (SPDX)
- Clarify the License section in README to distinguish buildcage source code (MIT) from third-party components