### PR TITLE
Prevent alias tag overwrite on concurrent Docker publishes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: docker-publish
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -41,6 +45,21 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+          # Check if this version is the latest within the same major/major.minor
+          VERSION="${TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+
+          LATEST_IN_MAJOR=$(git tag --list "v${MAJOR}.*.*" --sort=-version:refname | head -1)
+          if [ "$TAG" != "$LATEST_IN_MAJOR" ]; then
+            echo "skip_major=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          LATEST_IN_MINOR=$(git tag --list "v${MINOR}.*" --sort=-version:refname | head -1)
+          if [ "$TAG" != "$LATEST_IN_MINOR" ]; then
+            echo "skip_minor=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
@@ -54,8 +73,8 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.tag }}
-            type=semver,pattern={{major}},value=${{ steps.version.outputs.tag }}
+            ${{ steps.version.outputs.skip_minor != 'true' && format('type=semver,pattern={{{{major}}}}.{{{{minor}}}},value={0}', steps.version.outputs.tag) || '' }}
+            ${{ steps.version.outputs.skip_major != 'true' && format('type=semver,pattern={{{{major}}}},value={0}', steps.version.outputs.tag) || '' }}
             type=raw,value=sha-${{ steps.version.outputs.sha }},priority=100
 
       - name: Login to GHCR


### PR DESCRIPTION
## Summary

When multiple version tags (e.g., `v1.0.0` and `v1.1.0`) are pushed simultaneously, parallel workflow runs could overwrite the `major` and `major.minor` alias tags with an older version.

- Add `concurrency` group to serialize Docker publish workflow runs
- Add Git tag-based semver comparison to skip alias tag generation when the current version is not the latest within its major or major.minor range
- `version` (e.g., `1.0.0`) and `sha-xxx` tags are always pushed as they are unique

## How it works

| Tag | v1.0.0 build | v1.1.0 build |
|-----|-------------|-------------|
| `1.0.0` / `1.1.0` | push | push |
| `sha-xxx` | push | push |
| `1.0` / `1.1` | push | push |
| `1` | **skip** (v1.1.0 is latest) | push |
