### PR TITLE
Add restrict mode config example to audit report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,11 +67,15 @@ test_audit_mode: ## Run audit mode tests
 	@$(MAKE) clean
 
 .PHONY: test_unit
-test_unit: test_legacy test_qjs ## Run unit tests
+test_unit: test_legacy test_report test_qjs ## Run unit tests
 
 .PHONY: test_legacy
 test_legacy: ## Run legacy rules unit tests
 	@node --test setup/lib/legacy-rules.test.mjs
+
+.PHONY: test_report
+test_report: ## Run report unit tests
+	@node --test report/lib/build-example.test.mjs
 
 .PHONY: test_qjs
 test_qjs: ## Run unit tests in Docker

--- a/report/lib/build-example.mjs
+++ b/report/lib/build-example.mjs
@@ -1,0 +1,48 @@
+const ruleTypeToParam = {
+  HTTPS: "allowed_https_rules",
+  HTTP: "allowed_http_rules",
+  IP: "allowed_ip_rules",
+};
+
+/**
+ * Build a restrict-mode YAML configuration example from audited rows.
+ * Returns a markdown string wrapped in <details> tags, or "" if no rows.
+ *
+ * @param {Array<{host: string, port: string, ruleType: string}>} auditedRows
+ * @returns {string}
+ */
+export function buildRestrictExample(auditedRows, actionRepo) {
+  if (!auditedRows || auditedRows.length === 0) return "";
+
+  // Group by ruleType, preserving order of first appearance
+  const groups = new Map();
+  for (const r of auditedRows) {
+    const param = ruleTypeToParam[r.ruleType];
+    if (!param) continue;
+    if (!groups.has(param)) groups.set(param, []);
+    groups.get(param).push(`${r.host}:${r.port}`);
+  }
+
+  if (groups.size === 0) return "";
+
+  // Build YAML lines
+  let yaml = "";
+  yaml += "- name: Start Buildcage in restrict mode\n";
+  yaml += `  uses: ${actionRepo}/setup@v1\n`;
+  yaml += "  with:\n";
+  yaml += "    proxy_mode: restrict\n";
+  for (const [param, rules] of groups) {
+    yaml += `    ${param}: >-\n`;
+    for (const rule of rules) {
+      yaml += `      ${rule}\n`;
+    }
+  }
+
+  let md = "\n<details>\n";
+  md += "<summary>🛡️ Switch to restrict mode</summary>\n\n";
+  md += "```yaml\n";
+  md += yaml;
+  md += "```\n\n";
+  md += "</details>\n";
+  return md;
+}

--- a/report/lib/build-example.test.mjs
+++ b/report/lib/build-example.test.mjs
@@ -1,0 +1,133 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildRestrictExample } from "./build-example.mjs";
+
+const REPO = "dash14/buildcage";
+
+function wrap(yaml) {
+  return (
+    "\n<details>\n" +
+    "<summary>🛡️ Switch to restrict mode</summary>\n\n" +
+    "```yaml\n" +
+    yaml +
+    "```\n\n" +
+    "</details>\n"
+  );
+}
+
+describe("buildRestrictExample", () => {
+  it("empty array → empty string", () => {
+    assert.equal(buildRestrictExample([], REPO), "");
+  });
+
+  it("null/undefined → empty string", () => {
+    assert.equal(buildRestrictExample(null, REPO), "");
+    assert.equal(buildRestrictExample(undefined, REPO), "");
+  });
+
+  it("HTTPS only entries", () => {
+    const rows = [
+      { host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 5 },
+      { host: "github.com", port: "443", ruleType: "HTTPS", count: 2 },
+    ];
+    assert.equal(
+      buildRestrictExample(rows, REPO),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          `  uses: ${REPO}/setup@v1`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      registry.npmjs.org:443",
+          "      github.com:443",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+
+  it("HTTP + HTTPS mixed entries", () => {
+    const rows = [
+      { host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 3 },
+      { host: "deb.debian.org", port: "80", ruleType: "HTTP", count: 1 },
+    ];
+    assert.equal(
+      buildRestrictExample(rows, REPO),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          `  uses: ${REPO}/setup@v1`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      registry.npmjs.org:443",
+          "    allowed_http_rules: >-",
+          "      deb.debian.org:80",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+
+  it("IP entries", () => {
+    const rows = [
+      { host: "192.168.1.1", port: "443", ruleType: "IP", count: 1 },
+    ];
+    assert.equal(
+      buildRestrictExample(rows, REPO),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          `  uses: ${REPO}/setup@v1`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_ip_rules: >-",
+          "      192.168.1.1:443",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+
+  it("all three rule types", () => {
+    const rows = [
+      { host: "example.com", port: "443", ruleType: "HTTPS", count: 2 },
+      { host: "example.com", port: "80", ruleType: "HTTP", count: 1 },
+      { host: "10.0.0.1", port: "8080", ruleType: "IP", count: 1 },
+    ];
+    assert.equal(
+      buildRestrictExample(rows, REPO),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          `  uses: ${REPO}/setup@v1`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      example.com:443",
+          "    allowed_http_rules: >-",
+          "      example.com:80",
+          "    allowed_ip_rules: >-",
+          "      10.0.0.1:8080",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+
+  it("uses custom actionRepo", () => {
+    const rows = [
+      { host: "example.com", port: "443", ruleType: "HTTPS", count: 1 },
+    ];
+    assert.equal(
+      buildRestrictExample(rows, "myorg/myrepo"),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          "  uses: myorg/myrepo/setup@v1",
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      example.com:443",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+});

--- a/report/main.mjs
+++ b/report/main.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { buildRestrictExample } from "./lib/build-example.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -62,6 +63,7 @@ function markdownTable(rows, { showReason = false } = {}) {
   return lines.join("\n");
 }
 
+const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage";
 const isAudit = report.mode === "audit";
 let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
 
@@ -70,6 +72,7 @@ if (isAudit) {
   if (audited.length > 0) {
     markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n";
   }
+  markdown += buildRestrictExample(audited, actionRepo);
   const blocked = report.sections.blocked || [];
   if (blocked.length > 0) {
     if (audited.length > 0) markdown += "\n";
@@ -91,7 +94,6 @@ if (isAudit) {
 
 markdown += "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n";
 
-const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage";
 markdown += `\n*Reported by [Buildcage](https://github.com/${actionRepo})*\n`;
 
 // Write Job Summary


### PR DESCRIPTION
## Summary
- Display a collapsible YAML configuration example for restrict mode in the audit mode Job Summary
- Group detected hosts by rule type (HTTPS/HTTP/IP) and map them to `allowed_https_rules`, `allowed_http_rules`, and `allowed_ip_rules` parameters
- Dynamically resolve the `uses:` repository name from `GITHUB_ACTION_REPOSITORY`
