### PR TITLE
Pin Docker base image digests for supply chain security

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,11 @@
 ARG BUILDKIT_VERSION=v0.28.0
+ARG BUILDKIT_DIGEST=sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
 ARG CNI_VERSION=v1.9.0
 ARG ALPINE_RELEASE=3.23
+ARG ALPINE_DIGEST=sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+
 # Prepare dependencies
-FROM alpine:$ALPINE_RELEASE AS deps
+FROM alpine:${ALPINE_RELEASE}@${ALPINE_DIGEST} AS deps
 ARG CNI_VERSION
 RUN apk add --no-cache curl gettext && \
     mkdir -p /opt/cni/bin && \
@@ -11,7 +14,7 @@ RUN apk add --no-cache curl gettext && \
       | tar -C /opt/cni/bin -xz ./bridge ./host-local ./loopback
 
 # Final image
-FROM moby/buildkit:${BUILDKIT_VERSION}
+FROM moby/buildkit:${BUILDKIT_VERSION}@${BUILDKIT_DIGEST}
 
 LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.description="Secure Docker build environment with network access control" \

--- a/test/Dockerfile.audit
+++ b/test/Dockerfile.audit
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \

--- a/test/Dockerfile.restrict
+++ b/test/Dockerfile.restrict
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \

--- a/test/test-dns/Dockerfile
+++ b/test/test-dns/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 RUN apk add --no-cache dnsmasq
 

--- a/test/test-server/Dockerfile
+++ b/test/test-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:stable-alpine3.23-slim@sha256:b33eedfdf089be1f83759ced27b4deec5b6f1b6fc2a6819ebce0ae351a4406e5
 
 RUN apk add --no-cache openssl
 


### PR DESCRIPTION
## Summary
- Pin all Dockerfile base images using manifest list digests (`@sha256:...`) to prevent silent image replacement while maintaining multi-architecture support
- Pin `alpine:latest` to `alpine:3.23` and `nginx:alpine` to `nginx:stable-alpine3.23-slim` to avoid floating tags
- Add `ARG BUILDKIT_DIGEST` and `ARG ALPINE_DIGEST` to `docker/Dockerfile` for build-time override

## Changed files
- `docker/Dockerfile` — Add digest ARGs, pin `alpine` and `moby/buildkit`
- `test/Dockerfile.audit` — Pin `alpine:3.23` with digest
- `test/Dockerfile.restrict` — Pin `alpine:3.23` with digest
- `test/test-dns/Dockerfile` — Pin `alpine:3.23` with digest
- `test/test-server/Dockerfile` — Pin `nginx:stable-alpine3.23-slim` with digest