### PR TITLE
Add --ignore-scripts to npm install in example Dockerfiles

### DIFF
--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -27,7 +27,7 @@ jobs:
           cat <<'EOF' > /tmp/build-context/Dockerfile
           FROM node:24-alpine
           WORKDIR /app
-          RUN npm init -y && npm install express
+          RUN npm init -y && npm install --ignore-scripts express
           EOF
 
       - name: Build test image

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -30,7 +30,7 @@ jobs:
           cat <<'EOF' > /tmp/build-context/Dockerfile
           FROM node:24-alpine
           WORKDIR /app
-          RUN npm init -y && npm install express
+          RUN npm init -y && npm install --ignore-scripts express
           RUN wget -q -O /dev/null --timeout=5 https://example.com/ || true
           EOF
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ run_audit_example: ## Run audit mode example tests
 	@printf '%s\n' \
 	  "FROM node:24-alpine" \
 	  "WORKDIR /app" \
-	  "RUN npm init -y && npm install express" \
+	  "RUN npm init -y && npm install --ignore-scripts express" \
 	  > /tmp/build-context/Dockerfile
 	docker buildx build --no-cache \
 	  --builder buildcage \
@@ -107,7 +107,7 @@ run_restrict_example: ## Run restrict mode example tests
 	@printf '%s\n' \
 	  "FROM node:24-alpine" \
 	  "WORKDIR /app" \
-	  "RUN npm init -y && npm install express" \
+	  "RUN npm init -y && npm install --ignore-scripts express" \
 	  "RUN wget -q -O /dev/null --timeout=5 https://example.com/ || true" \
 	  > /tmp/build-context/Dockerfile
 	docker buildx build --no-cache \


### PR DESCRIPTION
## Summary

- Add `--ignore-scripts` flag to `npm install` in example Dockerfiles
- Update CI workflows (`example-audit.yml`, `example-restrict.yml`) and `Makefile`
- Prevent package lifecycle scripts from running during build, reducing supply chain attack risk
