### PR TITLE
Add Dependabot configuration for GitHub Actions and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker"
+      - "/test"
+      - "/test/test-dns"
+      - "/test/test-server"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,7 @@
-ARG BUILDKIT_VERSION=v0.28.0
-ARG BUILDKIT_DIGEST=sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
 ARG CNI_VERSION=v1.9.0
-ARG ALPINE_RELEASE=3.23
-ARG ALPINE_DIGEST=sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 # Prepare dependencies
-FROM alpine:${ALPINE_RELEASE}@${ALPINE_DIGEST} AS deps
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS deps
 ARG CNI_VERSION
 RUN apk add --no-cache curl gettext && \
     mkdir -p /opt/cni/bin && \
@@ -14,7 +10,7 @@ RUN apk add --no-cache curl gettext && \
       | tar -C /opt/cni/bin -xz ./bridge ./host-local ./loopback
 
 # Final image
-FROM moby/buildkit:${BUILDKIT_VERSION}@${BUILDKIT_DIGEST}
+FROM moby/buildkit:v0.28.0@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
 
 LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.description="Secure Docker build environment with network access control" \


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency updates for GitHub Actions and Docker base images
- Inline base image references in `docker/Dockerfile` by removing ARG indirection, so Dependabot can detect and propose updates to pinned digests

## Changed files
- `.github/dependabot.yml` — New Dependabot config for `github-actions` and `docker` ecosystems (weekly, 7-day cooldown)
- `docker/Dockerfile` — Replace ARG-based `FROM` references with direct image:tag@digest format