### PR TITLE
Fix image-scan workflow failing on schedule trigger

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -16,7 +16,6 @@ jobs:
 
     steps:
       - name: Checkout
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
## Summary
- Fix Image Security Scan workflow failing on schedule trigger with `cannot find ignorefile '.trivyignore'` error
- The Checkout step was conditionally skipped for schedule events, so the `.trivyignore` file was not available when Trivy ran
- Remove the condition to ensure checkout runs for all trigger types
