### PR TITLE
Pin third-party action references to commit SHAs in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Start Buildcage in audit mode
         id: buildcage
@@ -96,13 +96,13 @@ jobs:
           proxy_mode: audit  # Log everything, block nothing
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           driver: remote
           endpoint: docker-container://buildcage
 
       - name: Build and discover dependencies
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: false  # Set to true to push the built image
@@ -135,7 +135,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Start Buildcage in restrict mode
         id: buildcage
@@ -147,13 +147,13 @@ jobs:
             fonts.googleapis.com:443
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           driver: remote
           endpoint: docker-container://buildcage
 
       - name: Build with protection
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           push: false  # Set to true to push the built image
@@ -216,7 +216,7 @@ Pass the container name to [`docker/setup-buildx-action`](https://github.com/doc
 
 ```yaml
 - name: Set up Docker Buildx
-  uses: docker/setup-buildx-action@v4
+  uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
   with:
     driver: remote
     endpoint: docker-container://buildcage

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -68,10 +68,10 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Pin third-party GitHub Actions references in documentation code examples to full commit SHAs, matching the format used in actual workflow YAML files under `.github/workflows/`
- Affected files: `README.md`, `docs/self-hosting.md`

### Changes
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@de0fac2e...` (v6.0.2) |
| `docker/setup-buildx-action` | `@v4` | `@4d04d5d9...` (v4.0.0) |
| `docker/build-push-action` | `@v6` | `@d08e5c35...` (v7.0.0) |
| `docker/login-action` | `@v3` | `@b45d80f8...` (v4.0.0) |

## Motivation
Using mutable version tags in documentation examples encourages users to copy insecure patterns. SHA pinning prevents supply chain attacks via tag manipulation and is consistent with the project's own workflows.
