### PR TITLE
Bump base image deps and improve image-scan workflow

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -37,7 +37,7 @@ jobs:
           tags: buildcage:scan
 
       - name: Scan image with Trivy
-        id: trivy-scan
+        if: github.ref == 'refs/heads/main'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ github.event_name == 'schedule' && format('ghcr.io/{0}:latest', github.repository) || 'buildcage:scan' }}
@@ -49,6 +49,18 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy scan results to GitHub Security
+        if: github.ref == 'refs/heads/main'
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: trivy-results.sarif
+
+      - name: Scan image with Trivy
+        if: github.ref != 'refs/heads/main'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: buildcage:scan
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          scanners: vuln
+          format: table
+          severity: CRITICAL,HIGH

--- a/.trivyignore
+++ b/.trivyignore
@@ -48,3 +48,16 @@ CVE-2026-1229
 # libexpat: XML_ExternalEntityParserCreate does not copy encoding handler user data.
 # No external XML entity processing path exists in this product.
 CVE-2026-24515
+
+# QuickJS stack overflow via deeply nested JS input.
+# Only internal tool scripts (convert-rule.mjs, report.mjs) are executed;
+# no untrusted JavaScript is evaluated.
+CVE-2023-31922
+
+# zlib: buffer overflow in standalone untgz demo utility.
+# The core zlib library (libz) is unaffected; untgz is not used in this image.
+CVE-2026-22184
+
+# Go stdlib net/url: incorrect parsing of IPv6 host literals.
+# CNI plugins do not parse user-supplied URLs.
+CVE-2026-25679

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG CNI_VERSION=v1.9.0
+ARG CNI_VERSION=v1.9.1
 
 # Prepare dependencies
 FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS deps
@@ -10,7 +10,7 @@ RUN apk add --no-cache curl gettext && \
       | tar -C /opt/cni/bin -xz ./bridge ./host-local ./loopback
 
 # Final image
-FROM moby/buildkit:v0.28.0@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
+FROM moby/buildkit:v0.29.0@sha256:0039c1d47e8748b5afea56f4e85f14febaf34452bd99d9552d2daa82262b5cc5
 
 LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.description="Secure Docker build environment with network access control" \


### PR DESCRIPTION
## Summary
- Bump BuildKit from v0.28.0 to v0.29.0 and CNI plugins from v1.9.0 to v1.9.1
- Output Trivy scan results as table in workflow logs for non-main branches, instead of uploading to GitHub Security
- Add three new CVEs to `.trivyignore` after confirming no practical impact on this product:
  - **CVE-2023-31922**: QuickJS stack overflow — only internal scripts are executed; no untrusted JS input
  - **CVE-2026-22184**: zlib `untgz` demo utility buffer overflow — core libz   is unaffected; `untgz` is not used
  - **CVE-2026-25679**: Go `net/url` IPv6 parsing — CNI plugins do not parse user-supplied URLs