### PR TITLE
Scan all severities on non-main branches and add trivyignore entries

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -63,4 +63,3 @@ jobs:
           trivyignores: .trivyignore
           scanners: vuln
           format: table
-          severity: CRITICAL,HIGH

--- a/.trivyignore
+++ b/.trivyignore
@@ -61,3 +61,15 @@ CVE-2026-22184
 # Go stdlib net/url: incorrect parsing of IPv6 host literals.
 # CNI plugins do not parse user-supplied URLs.
 CVE-2026-25679
+
+# zlib: DoS via infinite loop in crc32_combine functions.
+# No code path in this product calls crc32_combine directly.
+CVE-2026-27171
+
+# Go stdlib html/template: URL escaping issue in meta content attribute.
+# CNI plugins do not generate or serve HTML.
+CVE-2026-27142
+
+# Go stdlib os: FileInfo can escape from a Root in ReadDir.
+# CNI plugins do not use the os.Root sandboxed filesystem API.
+CVE-2026-27139


### PR DESCRIPTION
## Summary
- Remove `severity: CRITICAL,HIGH` filter from the image-scan workflow on non-main branches so all severity levels (including MEDIUM and LOW) are reported
- Add three new CVEs to `.trivyignore` after confirming no practical impact on this product:
  - **CVE-2026-27171** (MEDIUM): zlib `crc32_combine` infinite loop — no code path calls `crc32_combine` directly
  - **CVE-2026-27142** (MEDIUM): Go `html/template` meta tag URL escaping — CNI plugins do not generate or serve HTML
  - **CVE-2026-27139** (LOW): Go `os` FileInfo Root escape — CNI plugins do not use the `os.Root` API