### PR TITLE
Increase HAProxy inspect-delay to fix dns-failed errors under slow DNS

### DIFF
--- a/docker/files/haproxy.cfg.template
+++ b/docker/files/haproxy.cfg.template
@@ -24,7 +24,7 @@ frontend health
 # --- Frontend ---
 frontend outbound_proxy
     bind *:10024
-    tcp-request inspect-delay 1s
+    tcp-request inspect-delay 5s
 
     # Default variables
     # sess.decision defaults to BLOCKED — any reject/deny leaves it unchanged,


### PR DESCRIPTION
## Summary

Fixes intermittent `dns-failed` errors that occur in restrict mode when HAProxy cannot resolve the SNI hostname within the current `inspect-delay` window.

## Problem

In restrict mode, HAProxy uses `do-resolve` to resolve the SNI hostname via an external DNS resolver (1.1.1.1 / 8.8.8.8). The resolution result is used to override the destination IP for the TCP connection.

The previous `tcp-request inspect-delay 1s` was insufficient because:

- HAProxy's resolver defaults: `timeout.resolve = 1000ms`, `resolve_retries = 3`
- A single DNS query can take up to 1000ms before the first retry fires
- The full retry cycle (`process_resolvers` task) can span ~3 seconds
- `inspect-delay` is the only window in which `do-resolve` can yield and wait for a DNS response; once it expires, `ACT_OPT_FINAL` is set and the unresolved connection is rejected with `reason=dns-failed`

This affects both audit and restrict modes, since `do-resolve` runs in both. 

## Change

- `docker/files/haproxy.cfg.template`: `tcp-request inspect-delay 1s` → `5s`

The value 5s provides sufficient margin over the maximum retry cycle (~3s) while keeping connection setup latency low for the common case where DNS responds within milliseconds.

## References

- HAProxy `do-resolve` + `inspect-delay` interaction: `src/resolvers.c` (`resolv_action_do_resolve`, `ACT_OPT_FINAL` handling)
- Default resolver timers: `timeout.resolve = 1000ms`, `resolve_retries = 3` (`src/resolvers.c`)