### PR TITLE
Bump docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache curl gettext && \
       | tar -C /opt/cni/bin -xz ./bridge ./host-local ./loopback
 
 # Final image
-FROM moby/buildkit:v0.29.0@sha256:0039c1d47e8748b5afea56f4e85f14febaf34452bd99d9552d2daa82262b5cc5
+FROM moby/buildkit:v0.30.0@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
 
 LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.description="Secure Docker build environment with network access control" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG CNI_VERSION=v1.9.1
 
 # Prepare dependencies
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS deps
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS deps
 ARG CNI_VERSION
 RUN apk add --no-cache curl gettext && \
     mkdir -p /opt/cni/bin && \

--- a/test/Dockerfile.audit
+++ b/test/Dockerfile.audit
@@ -1,4 +1,4 @@
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \

--- a/test/Dockerfile.restrict
+++ b/test/Dockerfile.restrict
@@ -1,4 +1,4 @@
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \

--- a/test/test-dns/Dockerfile
+++ b/test/test-dns/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 RUN apk add --no-cache dnsmasq
 

--- a/test/test-server/Dockerfile
+++ b/test/test-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine3.23-slim@sha256:b33eedfdf089be1f83759ced27b4deec5b6f1b6fc2a6819ebce0ae351a4406e5
+FROM nginx:stable-alpine3.23-slim@sha256:2c605dbeab79a6b2a63340474fe58119d0ef95bdc4b1f41df0aa689659b3d13b
 
 RUN apk add --no-cache openssl
 


### PR DESCRIPTION
* Bump nginx from b33eedf to 2c605dbe in /test/test-server
* Bump alpine from 3.23 to 3.23.4 in /docker and /test
* Bump moby/buildkit from v0.29.0 to v0.30.0 in /docker