### PR TITLE
Drop dnsmasq and haproxy privileges after socket binding to reduce attack surface

### DIFF
--- a/docker/files/dnsmasq.conf
+++ b/docker/files/dnsmasq.conf
@@ -23,6 +23,10 @@ no-hosts
 # Port configuration
 port=53
 
+# Drop privileges after binding to port 53
+user=dnsmasq
+group=dnsmasq
+
 # Interface to bind to
 bind-interfaces
 listen-address=0.0.0.0

--- a/docker/files/haproxy.cfg.template
+++ b/docker/files/haproxy.cfg.template
@@ -1,6 +1,8 @@
 global
     log stdout format raw local0
     maxconn 2048
+    user haproxy
+    group haproxy
 
 resolvers my_dns
 ${HAPROXY_NAMESERVERS}


### PR DESCRIPTION
## Summary

Configures dnsmasq and haproxy to drop root privileges after binding their sockets, limiting the blast radius of any vulnerability in either daemon.

## Problem

Both dnsmasq and haproxy ran as root for their entire lifetime. Neither daemon requires root after the initial socket binding phase:

- **dnsmasq**: root is needed only to bind port 53 (privileged port). Once the socket is open, all DNS query processing runs unnecessarily as root.
- **haproxy**: no root is needed at all — port 10024 is non-privileged. Root was effectively granted for free due to the absence of any `user`/`group` directive.

Both daemons face the network directly (DNS responses and egress proxy connections), making them the highest-risk processes in the container for privilege escalation if a vulnerability were exploited.

## Change

- `docker/files/dnsmasq.conf`: add `user=dnsmasq` and `group=dnsmasq` — dnsmasq binds port 53 as root then drops to the `dnsmasq` system user (created by the Alpine package pre-install script).
- `docker/files/haproxy.cfg.template`: add `user haproxy` and `group haproxy` to the `global` section — haproxy binds `*:10024` and the health Unix socket as root then drops to the `haproxy` system user (created by the Alpine package pre-install script).

No changes to `run` scripts or `Dockerfile` are required; both system users are already present via `apk add dnsmasq haproxy`.