### PR TITLE
Clarify OCI artifactType fallback and bundle verification comments in setup action

### DIFF
--- a/setup/src/lib/oci-registry.mjs
+++ b/setup/src/lib/oci-registry.mjs
@@ -191,9 +191,10 @@ export async function fetchBundle(registry, repo, digest, token, _fetch = fetch)
   }
 
   // Fallback: sha256-<hex> tag scheme.
-  // GHCR maintains this as an OCI Image Index (Referrers Tag Schema) whose
-  // manifests[] entries point to individual referrer artifacts.  Accept both
-  // the image-index and the legacy direct-manifest-with-layers formats.
+  // The OCI Referrers Tag Schema represents this as an OCI Image Index whose
+  // manifests[] entries point to individual referrer artifacts (as served by
+  // registries such as GHCR).  Accept both the image-index and the legacy
+  // direct-manifest-with-layers formats.
   const fallbackTag = digest.replace(":", "-");
   try {
     const tagResp = await _fetch(`${api}/manifests/${fallbackTag}`, {
@@ -247,9 +248,11 @@ export async function fetchBundle(registry, repo, digest, token, _fetch = fetch)
         if (m.artifactType === BUNDLE_MEDIA_TYPE) {
           return fetchBundleFromManifestDigest(api, m.digest, headers, _fetch);
         }
-        // GHCR stores config.mediaType ("application/vnd.oci.empty.v1+json")
-        // as artifactType in the index instead of the manifest's own artifactType.
-        // Inspect each sub-manifest to find the actual Sigstore bundle.
+        // Per the OCI Distribution Spec, a referrer descriptor's artifactType falls back to the
+        // manifest's config.mediaType when the manifest has no top-level artifactType. As a result
+        // the descriptor may carry the empty-config type ("application/vnd.oci.empty.v1+json")
+        // rather than the bundle type (observed with GHCR). This is a spec-valid fallback, so resolve
+        // the real type by inspecting the sub-manifest's own artifactType / layer mediaType.
         const subResp = await _fetch(`${api}/manifests/${m.digest}`, {
           headers: {
             ...headers,

--- a/setup/src/lib/sigstore.mjs
+++ b/setup/src/lib/sigstore.mjs
@@ -139,5 +139,9 @@ export async function verifyBundle(bundleJson, options, expectedDigest) {
   // The Referrers API that links a bundle to a digest is registry metadata,
   // not a cryptographic binding — an attacker with package-write access could
   // re-attach a valid bundle to a different image.  This check closes that gap.
+  // The DSSE payload parsed by assertSignedDigest is the exact byte sequence covered by the
+  // signature that verifier.verify() above just cryptographically verified (same in-memory
+  // bundle). @sigstore/verify exposes no accessor for the verified payload, so parsing it
+  // directly is both necessary and sound — it is read only after verification succeeds.
   assertSignedDigest(bundleJson, expectedDigest);
 }


### PR DESCRIPTION
## Summary

Documentation-only cleanup of two comments in the setup action's image provenance verification. No functional change — code paths, signatures, error codes, and tests are untouched.

## Background

While reviewing the verification flow, two comments were found to be inaccurate or to omit their rationale:

- The fallback-tag handling described the empty-config `artifactType` as a GHCR-specific storage quirk. This is actually a spec-defined fallback, not proprietary behavior.
- `assertSignedDigest` parses the DSSE payload directly, which looked like a redundant re-read of the bundle without explanation.

## Change

**`setup/src/lib/oci-registry.mjs`**

- Reword the fallback-tag comment to cite the OCI Distribution Spec: a referrer descriptor's `artifactType` falls back to the manifest's `config.mediaType` when no top-level `artifactType` is present, and `application/vnd.oci.empty.v1+json` is the OCI empty-descriptor value. The sub-manifest inspection is therefore the spec-recommended way to resolve the real artifact type, not a GHCR-only workaround.

**`setup/src/lib/sigstore.mjs`**

- Add a comment explaining that `@sigstore/verify` provides no accessor for the verified payload (`verify()` returns only the `Signer`; `SignedEntity` keeps the DSSE envelope private), so parsing the payload directly is necessary. Note that it is read only after verification succeeds, from the same in-memory bundle that was verified, so the digest assertion remains sound.
