### PR TITLE
Fix documentation inconsistencies introduced with image provenance verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Starts the Buildcage builder container.
 | `allowed_ip_rules` | No | empty | IP address allow rules (wildcard or regex, port required) |
 
 > **Security:** The Docker image is always pulled from `ghcr.io/<action-owner>/<action-repo>` and its
-> provenance is verified via cosign keyless signing. External image overrides are not supported to
-> preserve this guarantee. For best security, pin the action to a commit SHA:
-> `uses: dash14/buildcage/setup@<40-char-sha> # vX.Y.Z`
+> build provenance is cryptographically verified (keyless signature) before the image is pulled.
+> External image overrides are not supported to preserve this guarantee. For best security, pin the
+> action to a commit SHA: `uses: dash14/buildcage/setup@<40-char-sha> # vX.Y.Z`
 >
 > Self-hosting with a custom image requires forking the repository. See the [Self-Hosting Guide](./docs/self-hosting.md).
 > If the action package is private (self-hosted in a private repository), run

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ jobs:
 
       - name: Start Buildcage in audit mode
         id: buildcage
-        uses: dash14/buildcage/setup@v2
+        uses: dash14/buildcage/setup@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
         with:
           proxy_mode: audit  # Log everything, block nothing
 
@@ -109,7 +109,7 @@ jobs:
 
       - name: Show Buildcage report
         if: always()
-        uses: dash14/buildcage/report@v2
+        uses: dash14/buildcage/report@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
         with:
           fail_on_blocked: false  # Don't fail, just show the report
 ```
@@ -139,7 +139,7 @@ jobs:
 
       - name: Start Buildcage in restrict mode
         id: buildcage
-        uses: dash14/buildcage/setup@v2
+        uses: dash14/buildcage/setup@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
         with:
           proxy_mode: restrict  # Block everything except allowed domains
           allowed_https_rules: >-
@@ -160,7 +160,7 @@ jobs:
 
       - name: Show Buildcage report
         if: always()
-        uses: dash14/buildcage/report@v2
+        uses: dash14/buildcage/report@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
         # Build fails if any unexpected connections were blocked
 ```
 
@@ -177,7 +177,7 @@ Starts the Buildcage builder container.
 ```yaml
 - name: Start Buildcage builder
   id: buildcage
-  uses: dash14/buildcage/setup@v2
+  uses: dash14/buildcage/setup@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
   with:
     proxy_mode: restrict
     allowed_https_rules: registry.npmjs.org:443 github.com:443
@@ -269,7 +269,7 @@ Displays communication logs after builds and optionally fails if any BLOCKED con
 ```yaml
 - name: Show proxy report
   if: always()
-  uses: dash14/buildcage/report@v2
+  uses: dash14/buildcage/report@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
 ```
 
 #### Job Summary

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,8 +59,8 @@ make test_restrict_mode
 ### Image provenance verification bypass
 
 When running the setup action locally against a branch ref or a local `./setup` path, the
-action cannot resolve the ref to a published release and image provenance verification is
-skipped by default (the ref is "unverifiable").
+action cannot resolve the ref to a published release. Because the setup action is fail-closed
+by default, it will exit with an error for such "unverifiable" refs.
 
 For development use, you can allow the action to pull the image without verification by
 setting:
@@ -113,13 +113,22 @@ Fields: `[timestamp] buildcage [status] "domain:port" reason`
 ```
 .
 ├── setup/                       # GitHub Actions setup
-│   ├── action.yml               # GitHub Action: dash14/buildcage/setup@v2
+│   ├── action.yml               # Action entry (node24 → dist/main.js, dist/post.js)
 │   ├── compose.yaml             # Compose config for GitHub Actions (with image tag)
-│   ├── main.mjs                 # Main: verify image provenance, resolve image ref, compose up
-│   └── post.mjs                 # Post-action cleanup
+│   ├── src/                     # Source (ESM .mjs)
+│   │   ├── main.mjs             # Verify image provenance, resolve image ref, compose up
+│   │   ├── post.mjs             # Post-action cleanup
+│   │   └── lib/                 # Helpers: OCI registry, Sigstore verification, error types
+│   └── dist/                    # Bundled output (rollup → CommonJS)
+│       ├── main.js
+│       └── post.js
 ├── report/                      # GitHub Actions report
-│   ├── action.yml               # GitHub Action: dash14/buildcage/report@v2
-│   └── main.mjs                 # Log analysis and Job Summary output
+│   ├── action.yml               # Action entry (node24 → dist/main.js)
+│   ├── src/                     # Source (ESM .mjs)
+│   │   ├── main.mjs             # Log analysis and Job Summary output
+│   │   └── lib/                 # Helpers: Job Summary rendering
+│   └── dist/                    # Bundled output (rollup → CommonJS)
+│       └── main.js
 ├── docker/
 │   ├── Dockerfile               # Multi-stage BuildKit + haproxy + dnsmasq + s6-overlay
 │   └── files/

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -67,7 +67,7 @@ Since the regex is tested against the `domain:port` string, include a port patte
 
 ```yaml
 - name: Start Buildcage
-  uses: dash14/buildcage/setup@v2
+  uses: dash14/buildcage/setup@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
   with:
     proxy_mode: restrict
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -136,7 +136,8 @@ Buildcage uses [Sigstore](https://sigstore.dev) keyless signing to cryptographic
        }, expectedDigest)
             ↓
 5. Signed digest assertion (fail-closed)
-       Parse DSSE payload → critical.image.docker-manifest-digest
+       Parse DSSE payload → subject[].digest.sha256 (in-toto v1, --new-bundle-format)
+                          or critical.image.docker-manifest-digest (legacy simple-signing)
        Must equal the digest fetched in step 1 (strict string equality)
        Mismatch → VERIFY_FAILED (closes the Referrers API attribution gap)
 ```
@@ -147,12 +148,37 @@ All identity checks — OIDC issuer, signing workflow, ref/SHA claim, and manife
 
 ### Identity matching by reference type
 
-| How the action is pinned | Identity check | Mechanism |
-|---|---|---|
-| `@<40-char SHA>` | Source Repository Digest **strictly equals** the pinned SHA | `certificateOIDs` — Fulcio OID `1.3.6.1.4.1.57264.1.13`, raw byte match |
-| `@v2.1.0` (exact version) | SAN matches `...@refs/tags/v2\.1\.0(\.|$)` | `certificateIdentityURI` regexp |
-| `@v2` (major-floating) | SAN matches `...@refs/tags/v2(\.|$)` | `certificateIdentityURI` regexp |
-| Branch name or local `./setup` | **Hard fail** — pin to a version tag or commit SHA | — |
+<table>
+<thead>
+<tr>
+<th>How the action is pinned</th>
+<th>Identity check</th>
+<th>Mechanism</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>@&lt;40-char SHA&gt;</code></td>
+<td>Source Repository Digest <strong>strictly equals</strong> the pinned SHA</td>
+<td><code>certificateOIDs</code> — Fulcio OID <code>1.3.6.1.4.1.57264.1.13</code>, raw byte match</td>
+</tr>
+<tr>
+<td><code>@v2.1.0</code> (exact version)</td>
+<td>SAN matches <code>...@refs/tags/v2\.1\.0(\.|$)</code></td>
+<td><code>certificateIdentityURI</code> regexp</td>
+</tr>
+<tr>
+<td><code>@v2</code> (major-floating)</td>
+<td>SAN matches <code>...@refs/tags/v2(\.|$)</code></td>
+<td><code>certificateIdentityURI</code> regexp</td>
+</tr>
+<tr>
+<td>Branch name or local <code>./setup</code></td>
+<td><strong>Hard fail</strong> — pin to a version tag or commit SHA</td>
+<td>—</td>
+</tr>
+</tbody>
+</table>
 
 For strongest guarantees, pin to a **commit SHA**:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -79,13 +79,15 @@ jobs:
 
       - name: Start Buildcage
         id: buildcage
-        uses: <your_org>/buildcage/setup@v2
+        uses: <your_org>/buildcage/setup@<40-char-sha> # vX.Y.Z
         with:
           proxy_mode: audit
       # ... rest of your workflow
 ```
 
-Note that `uses:` now points to `<your_org>/buildcage/setup@v2` instead of `dash14/buildcage/setup@v2`. The same applies to the report action (`<your_org>/buildcage/report@v2`).
+Note that `uses:` now points to `<your_org>/buildcage/setup@<40-char-sha> # vX.Y.Z` instead of
+`dash14/buildcage/setup@...`. Replace `<40-char-sha>` with the commit SHA of the release tag in
+your fork. The same applies to the report action (`<your_org>/buildcage/report@<40-char-sha> # vX.Y.Z`).
 
 ### Image provenance verification
 
@@ -93,7 +95,7 @@ The setup action automatically verifies the Docker image's build provenance befo
 
 - The `docker-publish.yml` workflow in your fork will sign images with **your fork's** GitHub Actions OIDC identity.
 - The setup action will verify against your fork's workflow identity, so verification passes correctly.
-- If you use `uses: <your_org>/buildcage/setup@v2`, `github.action_repository` resolves to `<your_org>/buildcage` and the image is pulled from `ghcr.io/<your_org>/buildcage` automatically.
+- If you use `uses: <your_org>/buildcage/setup@<40-char-sha>`, `github.action_repository` resolves to `<your_org>/buildcage` and the image is pulled from `ghcr.io/<your_org>/buildcage` automatically.
 
 > **Note:** The `buildcage_image` and `buildcage_version` parameters have been **removed** as of v2.1.
 > External image overrides are no longer supported because they would bypass the provenance

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -87,21 +87,21 @@ jobs:
 
 Note that `uses:` now points to `<your_org>/buildcage/setup@v2` instead of `dash14/buildcage/setup@v2`. The same applies to the report action (`<your_org>/buildcage/report@v2`).
 
-### Image provenance and cosign verification
+### Image provenance verification
 
-The setup action automatically verifies the Docker image using cosign keyless signing before pulling it. When you fork the repository:
+The setup action automatically verifies the Docker image's build provenance before pulling it. When you fork the repository:
 
 - The `docker-publish.yml` workflow in your fork will sign images with **your fork's** GitHub Actions OIDC identity.
 - The setup action will verify against your fork's workflow identity, so verification passes correctly.
 - If you use `uses: <your_org>/buildcage/setup@v2`, `github.action_repository` resolves to `<your_org>/buildcage` and the image is pulled from `ghcr.io/<your_org>/buildcage` automatically.
 
 > **Note:** The `buildcage_image` and `buildcage_version` parameters have been **removed** as of v2.1.
-> External image overrides are no longer supported because they would bypass the cosign verification
-> that guarantees image provenance. Self-hosting via fork is the supported alternative.
+> External image overrides are no longer supported because they would bypass the provenance
+> verification that guarantees image integrity. Self-hosting via fork is the supported alternative.
 
-If cosign verification fails, the action will exit with an error. Make sure you have published at least one signed release in your fork before using a version tag.
+If provenance verification fails, the action will exit with an error. Make sure you have published at least one signed release in your fork before using a version tag.
 
-To confirm that a specific image digest has a valid signature in your fork, run:
+You can independently confirm that a specific image digest has a valid signature using standard signing tooling, e.g. the cosign CLI:
 
 ```bash
 cosign verify \


### PR DESCRIPTION
## Summary

Documentation-only cleanup following PR #69 (Sigstore provenance verification). No functional change — all code, tests, and dist files are untouched.

Four inaccuracies found during review:

- **Incorrect default behavior**: `development.md` described unverifiable refs as "skipped by default," but the setup action is fail-closed: it exits with an error unless `BUILDCAGE_ALLOW_UNVERIFIED=1` is set.
- **Misleading tool attribution**: `README.md` and `self-hosting.md` described the action as verifying images "via cosign keyless signing." Signing uses cosign; verification runs entirely in-process via `@sigstore/verify` with no cosign binary. High-level docs now use abstract provenance language; technical detail remains in `security.md`.
- **SHA pin recommendation not reflected in examples**: All action usage examples used `@v2` despite the docs recommending commit SHA pinning as best practice. All examples are now pinned to `v2.1.0` (`b9d14782`), matching the style of the third-party action pins already in the repo.
- **`security.md` verification flow incomplete**: Step 5 listed only the legacy simple-signing payload format; the in-toto v1 format (`subject[].digest.sha256`, produced by `cosign sign --new-bundle-format`) was missing.

Additional improvements:
- Fixed broken Markdown table in `security.md` (pipe characters in regex cells) using an HTML table.
- Expanded the Directory Structure in `development.md` to show the `src/` and `dist/` layout introduced in PR #71.