### PR TITLE
Exclude dash14/buildcage from Dependabot cooldown to pick up releases immediately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
+      exclude:
+        - "dash14/buildcage*"
   
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Summary

Adds `exclude` to the `github-actions` cooldown so that new Buildcage releases are picked up immediately rather than waiting the default 14-day window.

## Problem

The `cooldown.default-days: 14` setting applies to all GitHub Actions, including `dash14/buildcage/setup` and `dash14/buildcage/report`. New Buildcage releases were delayed up to two weeks before a Dependabot PR appeared.

## Change

- `.github/dependabot.yml`: add `exclude: ["dash14/buildcage*"]` under the `github-actions` cooldown — covers both `dash14/buildcage/setup` and `dash14/buildcage/report` with a single wildcard pattern. All other actions remain subject to the 14-day default cooldown.