### PR TITLE
Verify CNI plugins download integrity with hardcoded SHA256 checksums

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,21 @@
+# renovate: datasource=github-releases depName=containernetworking/plugins
 ARG CNI_VERSION=v1.9.1
+ARG CNI_SHA256_AMD64=b98f74a0f8522f0a83867178729c1aa70f2158f90c45a2ca8fa791db1c76b303
+ARG CNI_SHA256_ARM64=56171987d3947707c3563db2f4001bccaf50fd63468611b9f3cbecb1375ee7ec
 
 # Prepare dependencies
 FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4 AS deps
 ARG CNI_VERSION
+ARG CNI_SHA256_AMD64
+ARG CNI_SHA256_ARM64
 RUN apk add --no-cache curl gettext && \
     mkdir -p /opt/cni/bin && \
     ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') && \
+    EXPECTED_SHA256=$([ "$ARCH" = "amd64" ] && echo "$CNI_SHA256_AMD64" || echo "$CNI_SHA256_ARM64") && \
     curl -fsSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" \
-      | tar -C /opt/cni/bin -xz ./bridge ./host-local ./loopback
+      -o /tmp/cni.tgz && \
+    echo "${EXPECTED_SHA256}  /tmp/cni.tgz" | sha256sum -c && \
+    tar -C /opt/cni/bin -xz -f /tmp/cni.tgz ./bridge ./host-local ./loopback
 
 # Final image
 FROM moby/buildkit:v0.30.0@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
   "schedule": ["* * * * 1"],
   "minimumReleaseAge": "14 days",
   "internalChecksFilter": "strict",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^docker/Dockerfile$"],
+      "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\nARG CNI_VERSION=(?<currentValue>v[\\d.]+)"]
+    }
+  ],
   "packageRules": [
     {
       "description": "Self-referencing actions (dash14/buildcage*) are exempt from minimumReleaseAge, matching the previous Dependabot cooldown exclusion.",


### PR DESCRIPTION
## Problem

The CNI plugins tarball was downloaded and piped directly into `tar` without any integrity check. A compromised or tampered binary would be silently installed into the image.

## Change

- Add `CNI_SHA256_AMD64` and `CNI_SHA256_ARM64` ARGs to `docker/Dockerfile` with the SHA256 checksums for
`containernetworking/plugins` v1.9.1
- Verify the downloaded tarball against the expected checksum using `sha256sum -c` before extraction — build fails immediately on mismatch
- Add a `# renovate: datasource=...` annotation and a custom manager in `renovate.json` to track `CNI_VERSION` updates

## Note

The hardcoded checksums are reviewed at PR merge time and serve as a detection mechanism: when Renovate bumps `CNI_VERSION`, the SHA256 mismatch causes the build to fail, requiring a manual checksum update as part of the version upgrade PR.