### PR TITLE
docs: clarify Sigstore trust model and reframe self-hosting as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,21 +329,21 @@ All containers spawned by BuildKit `RUN` steps are placed on an isolated network
 
 Buildcage is a security tool — so it's fair to ask: *how do you trust Buildcage itself?*
 
-A pre-built image from a third party could be modified or rebuilt at any time without your knowledge. For a tool that sits in your build pipeline, that's a risk worth addressing.
-
-**Self-hosting (recommended for production)**
-
-You can fork or import this repository into your own GitHub organization, review the source code, and build the Docker image entirely within your own infrastructure. This gives you:
-
-- Full visibility into what the tool contains
-- Control over when and how updates are applied
-- A reproducible, tamper-proof build artifact that you own
-
-See the [Self-Hosting Guide](./docs/self-hosting.md) for setup instructions.
+The upstream image is verified at action startup via Sigstore: the signature cryptographically binds the published image to the exact source commit SHA, so a tampered or substituted image fails verification before use. Both options below rely on this guarantee.
 
 **Using the upstream image**
 
-If you don't need that level of control, you can use the image published from this repository directly. This is the simplest option and keeps you up to date with the latest fixes and improvements automatically.
+The simplest option. Pin to a commit SHA (or version tag) and update on your own schedule — the Sigstore verification ensures you are always running exactly what was built from that commit.
+
+**Self-hosting**
+
+Import this repository into your own GitHub organization and build the Docker image within your own infrastructure. Useful when you need to:
+
+- Keep build infrastructure private within your organization
+- Control exactly which version is deployed and when updates are applied
+- Meet compliance requirements that mandate use of an internal container registry
+
+See the [Self-Hosting Guide](./docs/self-hosting.md) for setup instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ Starts the Buildcage builder container.
 | `allowed_http_rules` | No | empty | HTTP allow rules (wildcard or regex, port required) |
 | `allowed_ip_rules` | No | empty | IP address allow rules (wildcard or regex, port required) |
 
-> **Security:** The Docker image is always pulled from `ghcr.io/<action-owner>/<action-repo>` and its
+> [!NOTE]
+> The Docker image is always pulled from `ghcr.io/<action-owner>/<action-repo>` and its
 > build provenance is cryptographically verified (keyless signature) before the image is pulled.
 > External image overrides are not supported to preserve this guarantee. For best security, pin the
 > action to a commit SHA: `uses: dash14/buildcage/setup@<40-char-sha> # vX.Y.Z`
@@ -326,7 +327,8 @@ All containers spawned by BuildKit `RUN` steps are placed on an isolated network
 
 ## Security Considerations
 
-> **Important:** Buildcage controls *where* your builds can connect, not *what code* they run. If a malicious package is delivered through a legitimate repository (e.g., a compromised npm package hosted on `registry.npmjs.org`), Buildcage cannot detect or prevent it — the connection goes to an allowed domain.
+> [!IMPORTANT]
+> Buildcage controls *where* your builds can connect, not *what code* they run. If a malicious package is delivered through a legitimate repository (e.g., a compromised npm package hosted on `registry.npmjs.org`), Buildcage cannot detect or prevent it — the connection goes to an allowed domain.
 >
 > Do not rely on Buildcage as your sole supply chain security measure. Use it as one layer in a defense-in-depth strategy — a last line of defense. If something slips through your other measures, at least it can't call home.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Pass the container name to [`docker/setup-buildx-action`](https://github.com/doc
 </tbody>
 </table>
 
-#### Tips
+#### Usage notes
 
 - Start with audit mode to discover required domains, then switch to restrict mode.
 - Separate HTTP and HTTPS domains — some services use different hosts for each protocol.
@@ -320,7 +320,7 @@ Buildcage creates a controlled network environment for your Docker builds:
 
 ### Architecture Diagram
 
-<img src="assets/diagram-architecture.png" alt="Buildcage architecture" width="611" height="544">
+<img src="assets/diagram-architecture.png" alt="Buildcage architecture" width="611" height="490">
 
 All containers spawned by BuildKit `RUN` steps are placed on an isolated network (CNI). DNS queries are redirected to the proxy IP, and the proxy checks each request's SNI (HTTPS) or Host header (HTTP) against the allowlist before forwarding or blocking.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Buildcage runs as a [remote driver](https://docs.docker.com/build/builders/drive
 - 🔍 **Audit mode**: Discover dependencies before enforcing restrictions
 - 🛡️ **Restrict mode**: Production-ready access control
 - 📊 **Detailed logging**: Complete visibility into all network connections during builds
-- 🔐 **Self-hostable**: Fork or import the repo to build and manage the image in your own GitHub environment — full control over what you trust
 
 ## Quick Start
 
@@ -325,28 +324,6 @@ All containers spawned by BuildKit `RUN` steps are placed on an isolated network
 
 ---
 
-## Trust & Self-Hosting
-
-Buildcage is a security tool — so it's fair to ask: *how do you trust Buildcage itself?*
-
-The upstream image is verified at action startup via Sigstore: the signature cryptographically binds the published image to the exact source commit SHA, so a tampered or substituted image fails verification before use. Both options below rely on this guarantee.
-
-**Using the upstream image**
-
-The simplest option. Pin to a commit SHA (or version tag) and update on your own schedule — the Sigstore verification ensures you are always running exactly what was built from that commit.
-
-**Self-hosting**
-
-Import this repository into your own GitHub organization and build the Docker image within your own infrastructure. Useful when you need to:
-
-- Keep build infrastructure private within your organization
-- Control exactly which version is deployed and when updates are applied
-- Meet compliance requirements that mandate use of an internal container registry
-
-See the [Self-Hosting Guide](./docs/self-hosting.md) for setup instructions.
-
----
-
 ## Security Considerations
 
 > **Important:** Buildcage controls *where* your builds can connect, not *what code* they run. If a malicious package is delivered through a legitimate repository (e.g., a compromised npm package hosted on `registry.npmjs.org`), Buildcage cannot detect or prevent it — the connection goes to an allowed domain.
@@ -371,11 +348,31 @@ For full technical details, see the [Security Details](./docs/security.md) docum
 
 The only known bypass is **domain fronting** — a technique where an attacker sets the SNI to an allowed domain but routes the actual request to a different server on the same CDN. This requires the attacker's server to share infrastructure with an allowed domain, making it a narrow attack surface. See [Known Limitations](./docs/security.md#known-limitations) for details and mitigation strategies.
 
+### Trusting the Buildcage image
+
+Buildcage is a security tool — so it's fair to ask: *how do you trust Buildcage itself?*
+
+The upstream image is verified at action startup via Sigstore: the signature cryptographically binds the published image to the exact source commit SHA, so a tampered or substituted image fails verification before use. Both options below rely on this guarantee.
+
+**Using the upstream image**
+
+The simplest option. Pin to a commit SHA (or version tag) and update on your own schedule — the Sigstore verification ensures you are always running exactly what was built from that commit.
+
+**Self-hosting**
+
+Import this repository into your own GitHub organization and build the Docker image within your own infrastructure. Useful when you need to:
+
+- Keep build infrastructure private within your organization
+- Control exactly which version is deployed and when updates are applied
+- Meet compliance requirements that mandate use of an internal container registry
+
+See the [Self-Hosting Guide](./docs/self-hosting.md) for setup instructions.
+
 ## FAQ
 
 - **Can I host Buildcage in my own private repository?**
 
-  Yes. See [Trust & Self-Hosting](#trust--self-hosting) for details.
+  Yes. See [Trusting the Buildcage image](#trusting-the-buildcage-image) for details.
 
 - **Does this slow down my builds?**
 

--- a/README.md
+++ b/README.md
@@ -232,22 +232,23 @@ Pass the container name to [`docker/setup-buildx-action`](https://github.com/doc
 
 #### Operation Modes
 
-##### Audit Mode (`proxy_mode: audit`)
-
-**When to use:** First-time setup, adding new dependencies, or investigating issues.
-
-**What it does:**
-- Allows all HTTP/HTTPS connections (except requests missing a Host header or SNI)
-- Logs every domain accessed during the build
-
-##### Restrict Mode (`proxy_mode: restrict`)
-
-**When to use:** Production builds, CI/CD pipelines, security-critical environments.
-
-**What it does:**
-- Allows connections only to domains in `allowed_http_rules` / `allowed_https_rules`
-- Blocks all other connections
-- Logs allowed and blocked attempts
+<table>
+<thead>
+<tr><th>Mode</th><th>When to use</th><th>Behavior</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><b>Audit</b> (<code>proxy_mode: audit</code>)</td>
+<td>First-time setup, adding new dependencies, or investigating issues</td>
+<td><ul><li>Allows all HTTP/HTTPS connections (except requests missing a Host header or SNI)</li><li>Logs every domain accessed during the build</li></ul></td>
+</tr>
+<tr>
+<td><b>Restrict</b> (<code>proxy_mode: restrict</code>)</td>
+<td>Production builds, CI/CD pipelines, security-critical environments</td>
+<td><ul><li>Allows connections only to domains in <code>allowed_http_rules</code> / <code>allowed_https_rules</code></li><li>Blocks all other connections</li><li>Logs allowed and blocked attempts</li></ul></td>
+</tr>
+</tbody>
+</table>
 
 #### Tips
 

--- a/README.md
+++ b/README.md
@@ -373,10 +373,6 @@ See the [Self-Hosting Guide](./docs/self-hosting.md) for setup instructions.
 
 ## FAQ
 
-- **Can I host Buildcage in my own private repository?**
-
-  Yes. See [Trusting the Buildcage image](#trusting-the-buildcage-image) for details.
-
 - **Does this slow down my builds?**
 
   Minimal impact. The proxy adds negligible latency (<1ms per request). DNS caching and connection pooling keep overhead low.
@@ -404,6 +400,10 @@ See the [Self-Hosting Guide](./docs/self-hosting.md) for setup instructions.
 - **Does this protect against malicious code execution?**
 
   No. Buildcage only controls network access. It doesn't prevent malicious code from running—it prevents that code from communicating with external servers.
+
+- **Can I host Buildcage in my own private repository?**
+
+  Yes. See [Trusting the Buildcage image](#trusting-the-buildcage-image) for details.
 
 ## Troubleshooting
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -194,6 +194,8 @@ An attacker who can push a malicious image to `ghcr.io/dash14/buildcage` without
 
 This is **one layer of a defense-in-depth strategy**, not a complete guarantee. It reduces the attack surface to the registry layer and forces attackers to compromise the GitHub account or the repository itself — raising the cost significantly and leaving an audit trail in the Rekor transparency log.
 
+The cryptographic binding of the image digest to the exact source commit SHA also serves as an alternative to reproducible builds. The primary purpose of reproducible builds is to establish that a published artifact was produced from a specific source commit; here, that assurance is provided cryptographically by the Sigstore bundle rather than by requiring an independent rebuild to produce a bit-for-bit identical artifact.
+
 ### Self-hosting with a private package
 
 When self-hosting Buildcage from a **private** GHCR package, run `docker/login-action` with `packages: read` before this action. Credentials written to Docker's config by the login step are read automatically — no `token` input is required. Public packages are verified without any credentials.
@@ -201,7 +203,6 @@ When self-hosting Buildcage from a **private** GHCR package, run `docker/login-a
 ### Known limitations
 
 - **Account compromise**: If the repository owner's GitHub account or the repository itself is compromised, an attacker could trigger the release workflow and produce a legitimately-signed malicious image.
-- **Build non-reproducibility**: Buildcage does not currently publish reproducible builds, so the signed image cannot be independently rebuilt from source.
 - **Trust in Sigstore infrastructure**: Verification relies on the availability and integrity of the Rekor transparency log and the Fulcio certificate authority. The TUF-backed trust root is fetched at verification time; a network outage will cause the main phase to hard-fail.
 - **TOCTOU window**: The manifest digest is fetched before the bundle is pulled. A highly targeted attack that replaces the registry content in the window between these two steps would still succeed — though such an attack requires compromising the registry itself. Note that the subsequent `docker pull` is digest-pinned (`image@sha256:…`), so there is no TOCTOU between verification and the actual image pull; the residual window is limited to between the manifest-digest fetch and the bundle fetch.
 - **Development bypass**: `BUILDCAGE_ALLOW_UNVERIFIED=1` skips verification for unverifiable refs (branch names, local `./setup`). This flag is **for local development only** and must never be used in CI or production workflows. See [development.md](./development.md#local-development) for details.

--- a/docs/security.md
+++ b/docs/security.md
@@ -194,11 +194,7 @@ An attacker who can push a malicious image to `ghcr.io/dash14/buildcage` without
 
 This is **one layer of a defense-in-depth strategy**, not a complete guarantee. It reduces the attack surface to the registry layer and forces attackers to compromise the GitHub account or the repository itself — raising the cost significantly and leaving an audit trail in the Rekor transparency log.
 
-The cryptographic binding of the image digest to the exact source commit SHA also serves as an alternative to reproducible builds. The primary purpose of reproducible builds is to establish that a published artifact was produced from a specific source commit; here, that assurance is provided cryptographically by the Sigstore bundle rather than by requiring an independent rebuild to produce a bit-for-bit identical artifact.
-
-### Self-hosting with a private package
-
-When self-hosting Buildcage from a **private** GHCR package, run `docker/login-action` with `packages: read` before this action. Credentials written to Docker's config by the login step are read automatically — no `token` input is required. Public packages are verified without any credentials.
+The binding of the image digest to the exact source commit SHA also serves as an alternative to reproducible builds: it establishes that the published artifact was produced from a specific source commit without requiring an independent rebuild.
 
 ### Known limitations
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -6,7 +6,8 @@ This guide explains how to host your own Buildcage Docker image in a private Git
 - Control exactly which version of Buildcage is deployed and when updates are applied
 - Meet compliance requirements that mandate use of an internal container registry
 
-> **Note:** The upstream image (`ghcr.io/dash14/buildcage`) is verified at action startup via Sigstore, confirming it was built from the exact source commit of the release — sufficient provenance assurance for most use cases. Self-hosting adds operational overhead: keeping your fork in sync with upstream and managing your own signing pipeline.
+> [!NOTE]
+> The upstream image (`ghcr.io/dash14/buildcage`) is verified at action startup via Sigstore, confirming it was built from the exact source commit of the release — sufficient provenance assurance for most use cases. Self-hosting adds operational overhead: keeping your fork in sync with upstream and managing your own signing pipeline.
 
 ## Prerequisites
 
@@ -99,7 +100,8 @@ The setup action automatically verifies the Docker image's build provenance befo
 - The setup action will verify against your fork's workflow identity, so verification passes correctly.
 - If you use `uses: <your_org>/buildcage/setup@<40-char-sha>`, `github.action_repository` resolves to `<your_org>/buildcage` and the image is pulled from `ghcr.io/<your_org>/buildcage` automatically.
 
-> **Note:** The `buildcage_image` and `buildcage_version` parameters have been **removed** as of v2.1.
+> [!NOTE]
+> The `buildcage_image` and `buildcage_version` parameters have been **removed** as of v2.1.
 > External image overrides are no longer supported because they would bypass the provenance
 > verification that guarantees image integrity. Self-hosting via fork is the supported alternative.
 
@@ -138,4 +140,5 @@ git push origin HEAD --tags --force
 
 After pushing a new version tag, the **Build and Push Docker Image** workflow will automatically trigger and publish the updated image.
 
-> **Note:** If the workflow does not trigger automatically, run it manually from **Actions** > **Build and Push Docker Image** > **Run workflow**. The branch selection can be left as `main` — the workflow will build from the latest version tag.
+> [!NOTE]
+> If the workflow does not trigger automatically, run it manually from **Actions** > **Build and Push Docker Image** > **Run workflow**. The branch selection can be left as `main` — the workflow will build from the latest version tag.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -3,8 +3,10 @@
 This guide explains how to host your own Buildcage Docker image in a private GitHub repository. This is useful when you want to:
 
 - Keep the build infrastructure private within your organization
-- Control exactly which version of Buildcage is deployed
-- Audit the source code before using it in your CI/CD pipelines
+- Control exactly which version of Buildcage is deployed and when updates are applied
+- Meet compliance requirements that mandate use of an internal container registry
+
+> **Note:** The upstream image (`ghcr.io/dash14/buildcage`) is verified at action startup via Sigstore, confirming it was built from the exact source commit of the release — sufficient provenance assurance for most use cases. Self-hosting adds operational overhead: keeping your fork in sync with upstream and managing your own signing pipeline.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Reframe the Sigstore provenance guarantee as the primary trust mechanism, positioning self-hosting as one of two equally-valid options rather than the recommended default
- Replace blockquote callouts with GitHub Alert syntax (`[!NOTE]`, `[!IMPORTANT]`) for consistent rendering on GitHub
- Consolidate Operation Modes into a comparison table and rename "Tips" to "Usage notes"
- In `docs/security.md`: add note that the Sigstore SHA binding serves as an alternative to reproducible builds; remove the now-outdated "Build non-reproducibility" known limitation
- In `docs/self-hosting.md`: update the reasons-to-self-host list to reflect compliance use cases; add a note that the upstream image already carries sufficient provenance assurance for most users

## Changes

| File | Change |
|------|--------|
| `README.md` | Sigstore trust model clarification, self-hosting reframed, GitHub Alerts, table for operation modes |
| `docs/security.md` | SHA–commit binding note added, build non-reproducibility limitation removed |
| `docs/self-hosting.md` | Use-case list updated, upstream provenance note added |
