### PR TITLE
docs: clarify `proxy_mode` parameter in Operation Modes table

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,18 +232,20 @@ Pass the container name to [`docker/setup-buildx-action`](https://github.com/doc
 
 #### Operation Modes
 
+Set the `proxy_mode` parameter to control how Buildcage handles outbound connections:
+
 <table>
 <thead>
-<tr><th>Mode</th><th>When to use</th><th>Behavior</th></tr>
+<tr><th><code>proxy_mode</code></th><th>When to use</th><th>Behavior</th></tr>
 </thead>
 <tbody>
 <tr>
-<td><b>Audit</b> (<code>proxy_mode: audit</code>)</td>
+<td><code>audit</code></td>
 <td>First-time setup, adding new dependencies, or investigating issues</td>
 <td><ul><li>Allows all HTTP/HTTPS connections (except requests missing a Host header or SNI)</li><li>Logs every domain accessed during the build</li></ul></td>
 </tr>
 <tr>
-<td><b>Restrict</b> (<code>proxy_mode: restrict</code>)</td>
+<td><code>restrict</code></td>
 <td>Production builds, CI/CD pipelines, security-critical environments</td>
 <td><ul><li>Allows connections only to domains in <code>allowed_http_rules</code> / <code>allowed_https_rules</code></li><li>Blocks all other connections</li><li>Logs allowed and blocked attempts</li></ul></td>
 </tr>


### PR DESCRIPTION
## Summary

The Operation Modes section listed `audit` and `restrict` as mode names without explicitly connecting them to the `proxy_mode` parameter. A reader landing directly on this section might not immediately know which parameter to set.

- Add an introductory sentence linking the section to the `proxy_mode` parameter
- Change the table's first column header from `Mode` to `` `proxy_mode` `` and use the bare values (`audit`, `restrict`) as row entries, making the table self-documenting
