### PR TITLE
fix: fetch manifest digest via OCI registry API instead of docker buildx

### DIFF
--- a/setup/dist/main.js
+++ b/setup/dist/main.js
@@ -7093,7 +7093,7 @@ function imageTagFromRef(actionRef) {
 }
 
 async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo}) {
-  const image = `ghcr.io/${actionRepo}`.toLowerCase(), repoPath = actionRepo.toLowerCase(), verifyOptions = function({actionRef: actionRef, actionRepo: actionRepo}) {
+  const repoPath = actionRepo.toLowerCase(), verifyOptions = function({actionRef: actionRef, actionRepo: actionRepo}) {
     const sanPrefix = `^${escapeRegex(`https://github.com/${actionRepo}/.github/workflows/docker-publish.yml@refs/tags/`)}`, base = {
       certificateIssuer: "https://token.actions.githubusercontent.com",
       tlogThreshold: 1,
@@ -7115,21 +7115,7 @@ async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo})
     actionRepo: actionRepo
   });
   if (!verifyOptions) return null;
-  const digest = function(imageRef, _exec = node_child_process.execFileSync) {
-    try {
-      const digest = _exec("docker", [ "buildx", "imagetools", "inspect", imageRef, "--format", "{{.Manifest.Digest}}" ], {
-        stdio: "pipe",
-        encoding: "utf8"
-      }).trim();
-      if (!digest) throw new SetupError(`Docker image not found: ${imageRef}. Make sure the action ref corresponds to a published release.`, "NOT_FOUND");
-      return digest;
-    } catch (err) {
-      if (err instanceof SetupError) throw err;
-      const msg = (err.stderr || err.message || "").toString();
-      if (msg.includes("not found")) throw new SetupError(`Docker image not found: ${imageRef}. Make sure the action ref corresponds to a published release.`, "NOT_FOUND");
-      throw new SetupError(`Transient error fetching image digest for ${imageRef}: ${msg}`, "TRANSIENT");
-    }
-  }(`${image}:${imageTagFromRef(actionRef)}`), regToken = await async function(registry, repo, basicAuth, _fetch = fetch) {
+  const tag = imageTagFromRef(actionRef), regToken = await async function(registry, repo, basicAuth, _fetch = fetch) {
     const url = `https://${registry}/token?scope=repository:${repo}:pull&service=${registry}`;
     if (basicAuth) try {
       const resp = await _fetch(url, {
@@ -7161,7 +7147,28 @@ async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo})
     } catch {
       return null;
     }
-  }()), bundle = await async function(registry, repo, digest, token, _fetch = fetch) {
+  }()), digest = await async function(registry, repo, tag, token, _fetch = fetch) {
+    const url = `https://${registry}/v2/${repo}/manifests/${tag}`, headers = {
+      Authorization: `Bearer ${token}`,
+      Accept: [ "application/vnd.oci.image.index.v1+json", "application/vnd.docker.distribution.manifest.list.v2+json" ].join(", ")
+    };
+    try {
+      const resp = await _fetch(url, {
+        method: "HEAD",
+        headers: headers
+      });
+      if (404 === resp.status) throw new SetupError(`Docker image not found: ${registry}/${repo}:${tag}. Make sure the action ref corresponds to a published release.`, "NOT_FOUND");
+      if (resp.status >= 500) throw new SetupError(`Transient error fetching manifest for ${registry}/${repo}:${tag}: HTTP ${resp.status}`, "TRANSIENT");
+      if (401 === resp.status || 403 === resp.status) throw new SetupError(`Registry denied access to manifest for ${registry}/${repo}:${tag}: HTTP ${resp.status}. For private repositories, ensure the runner is authenticated to the registry.`, "TRANSIENT");
+      if (!resp.ok) throw new SetupError(`Failed to fetch manifest for ${registry}/${repo}:${tag}: HTTP ${resp.status}`, "TRANSIENT");
+      const digest = resp.headers.get("Docker-Content-Digest");
+      if (!digest) throw new SetupError(`No digest in manifest response for ${registry}/${repo}:${tag}`, "TRANSIENT");
+      return digest;
+    } catch (err) {
+      if (err instanceof SetupError) throw err;
+      throw new SetupError(`Transient error fetching manifest digest for ${registry}/${repo}:${tag}: ${err.message}`, "TRANSIENT");
+    }
+  }("ghcr.io", repoPath, tag, regToken), bundle = await async function(registry, repo, digest, token, _fetch = fetch) {
     const api = `https://${registry}/v2/${repo}`, headers = {
       Authorization: `Bearer ${token}`
     };

--- a/setup/src/lib/oci-registry.mjs
+++ b/setup/src/lib/oci-registry.mjs
@@ -5,7 +5,6 @@
  * Callers do not need to catch and re-wrap; just let them propagate.
  */
 
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -36,45 +35,66 @@ export function readGhcrBasicAuth(_env = process.env, _readFileSync = readFileSy
 }
 
 /**
- * Get the manifest list digest using docker buildx imagetools.
+ * Fetch the manifest digest for a container image tag via the OCI registry API.
+ * Uses HEAD /v2/{repo}/manifests/{tag} and reads the Docker-Content-Digest header.
+ *
  * Throws SetupError(NOT_FOUND) when the tag does not exist.
- * Throws SetupError(TRANSIENT) on network/registry errors.
+ * Throws SetupError(TRANSIENT) on network or 5xx errors.
  */
-export function getManifestDigest(imageRef, _exec = execFileSync) {
+export async function fetchManifestDigest(registry, repo, tag, token, _fetch = fetch) {
+  const url = `https://${registry}/v2/${repo}/manifests/${tag}`;
+  // Accept only index/manifest-list types so the registry returns the image index
+  // digest — not a per-platform manifest digest. The Sigstore bundle is signed
+  // against the index digest, so content-negotiating down to a platform manifest
+  // would cause the bundle lookup to fail.
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: [
+      "application/vnd.oci.image.index.v1+json",
+      "application/vnd.docker.distribution.manifest.list.v2+json",
+    ].join(", "),
+  };
+
   try {
-    const result = _exec(
-      "docker",
-      [
-        "buildx",
-        "imagetools",
-        "inspect",
-        imageRef,
-        "--format",
-        "{{.Manifest.Digest}}",
-      ],
-      { stdio: "pipe", encoding: "utf8" },
-    );
-    const digest = result.trim();
-    if (!digest) {
+    const resp = await _fetch(url, { method: "HEAD", headers });
+    if (resp.status === 404) {
       throw new SetupError(
-        `Docker image not found: ${imageRef}. ` +
+        `Docker image not found: ${registry}/${repo}:${tag}. ` +
           `Make sure the action ref corresponds to a published release.`,
         "NOT_FOUND",
+      );
+    }
+    if (resp.status >= 500) {
+      throw new SetupError(
+        `Transient error fetching manifest for ${registry}/${repo}:${tag}: HTTP ${resp.status}`,
+        "TRANSIENT",
+      );
+    }
+    if (resp.status === 401 || resp.status === 403) {
+      throw new SetupError(
+        `Registry denied access to manifest for ${registry}/${repo}:${tag}: HTTP ${resp.status}. ` +
+          `For private repositories, ensure the runner is authenticated to the registry.`,
+        "TRANSIENT",
+      );
+    }
+    if (!resp.ok) {
+      throw new SetupError(
+        `Failed to fetch manifest for ${registry}/${repo}:${tag}: HTTP ${resp.status}`,
+        "TRANSIENT",
+      );
+    }
+    const digest = resp.headers.get("Docker-Content-Digest");
+    if (!digest) {
+      throw new SetupError(
+        `No digest in manifest response for ${registry}/${repo}:${tag}`,
+        "TRANSIENT",
       );
     }
     return digest;
   } catch (err) {
     if (err instanceof SetupError) throw err;
-    const msg = (err.stderr || err.message || "").toString();
-    if (msg.includes("not found")) {
-      throw new SetupError(
-        `Docker image not found: ${imageRef}. ` +
-          `Make sure the action ref corresponds to a published release.`,
-        "NOT_FOUND",
-      );
-    }
     throw new SetupError(
-      `Transient error fetching image digest for ${imageRef}: ${msg}`,
+      `Transient error fetching manifest digest for ${registry}/${repo}:${tag}: ${err.message}`,
       "TRANSIENT",
     );
   }

--- a/setup/src/lib/oci-registry.test.mjs
+++ b/setup/src/lib/oci-registry.test.mjs
@@ -9,48 +9,89 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  getManifestDigest,
+  fetchManifestDigest,
   fetchRegistryToken,
   fetchBundle,
   readGhcrBasicAuth,
 } from "./oci-registry.mjs";
 
-// ── getManifestDigest ─────────────────────────────────────────────────────
+// ── fetchManifestDigest ───────────────────────────────────────────────────
 
-describe("getManifestDigest", () => {
-  it("returns digest on success", () => {
-    const digest = "sha256:" + "a".repeat(64);
-    const execOk = () => `${digest}\n`;
-    assert.equal(getManifestDigest("ghcr.io/owner/repo:2.1.0", execOk), digest);
-  });
+describe("fetchManifestDigest", () => {
+  const digest = "sha256:" + "a".repeat(64);
 
-  it("trims whitespace from the output", () => {
-    const execWhitespace = () => "  sha256:abc123  \n";
-    assert.equal(getManifestDigest("ghcr.io/owner/repo:2.1.0", execWhitespace), "sha256:abc123");
-  });
-
-  it("throws NOT_FOUND when docker reports 'not found'", () => {
-    const execFail = () => {
-      const err = new Error("ghcr.io/owner/repo:v99: not found");
-      err.stderr = "ERROR: ghcr.io/owner/repo:v99: not found";
-      throw err;
+  function makeResp(status, digestValue) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: (name) => name === "Docker-Content-Digest" ? digestValue : null },
     };
+  }
+
+  it("returns digest from Docker-Content-Digest header on success", async () => {
+    let capturedOpts;
+    const mockFetch = async (url, opts) => { capturedOpts = opts; return makeResp(200, digest); };
+    const result = await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
+    assert.equal(result, digest);
+    assert.equal(capturedOpts.method, "HEAD");
+  });
+
+  it("throws NOT_FOUND on 404", async () => {
+    const mockFetch = async () => makeResp(404, null);
     try {
-      getManifestDigest("ghcr.io/owner/repo:v99", execFail);
+      await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
       assert.equal(err.code, "NOT_FOUND");
     }
   });
 
-  it("throws TRANSIENT for non-404 errors", () => {
-    const execFail = () => {
-      const err = new Error("connection refused");
-      err.stderr = "connection refused";
-      throw err;
-    };
+  it("throws TRANSIENT on 5xx", async () => {
+    const mockFetch = async () => makeResp(500, null);
     try {
-      getManifestDigest("ghcr.io/owner/repo:2.1.0", execFail);
+      await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.equal(err.code, "TRANSIENT");
+    }
+  });
+
+  it("throws TRANSIENT with auth hint on 401", async () => {
+    const mockFetch = async () => makeResp(401, null);
+    try {
+      await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.equal(err.code, "TRANSIENT");
+      assert.ok(err.message.includes("authenticated"), "error message should hint at authentication");
+    }
+  });
+
+  it("throws TRANSIENT with auth hint on 403", async () => {
+    const mockFetch = async () => makeResp(403, null);
+    try {
+      await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.equal(err.code, "TRANSIENT");
+      assert.ok(err.message.includes("authenticated"), "error message should hint at authentication");
+    }
+  });
+
+  it("throws TRANSIENT when Docker-Content-Digest header is absent", async () => {
+    const mockFetch = async () => makeResp(200, null);
+    try {
+      await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.equal(err.code, "TRANSIENT");
+    }
+  });
+
+  it("throws TRANSIENT on network error", async () => {
+    const mockFetch = async () => { throw new Error("ECONNREFUSED"); };
+    try {
+      await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
       assert.equal(err.code, "TRANSIENT");

--- a/setup/src/lib/verify-image.mjs
+++ b/setup/src/lib/verify-image.mjs
@@ -9,7 +9,7 @@
  *   - Unverifiable ref (branch / local ./setup) → returns null.
  */
 
-import { getManifestDigest, fetchRegistryToken, fetchBundle, readGhcrBasicAuth } from "./oci-registry.mjs";
+import { fetchManifestDigest, fetchRegistryToken, fetchBundle, readGhcrBasicAuth } from "./oci-registry.mjs";
 import { derUtf8, verifyBundle } from "./sigstore.mjs";
 
 const REGISTRY = "ghcr.io";
@@ -83,15 +83,14 @@ export function buildVerifyOptions({ actionRef, actionRepo }) {
  * @param {{ actionRef: string, actionRepo: string }} opts
  */
 export async function verifyImageDigest({ actionRef, actionRepo }) {
-  const image = `${REGISTRY}/${actionRepo}`.toLowerCase();
   const repoPath = actionRepo.toLowerCase();
 
   const verifyOptions = buildVerifyOptions({ actionRef, actionRepo });
   if (!verifyOptions) return null;
 
-  const imageTagRef = `${image}:${imageTagFromRef(actionRef)}`;
-  const digest = getManifestDigest(imageTagRef);
+  const tag = imageTagFromRef(actionRef);
   const regToken = await fetchRegistryToken(REGISTRY, repoPath, readGhcrBasicAuth());
+  const digest = await fetchManifestDigest(REGISTRY, repoPath, tag, regToken);
   const bundle = await fetchBundle(REGISTRY, repoPath, digest, regToken);
   await verifyBundle(bundle, verifyOptions, digest);
   return digest;


### PR DESCRIPTION
## Problem

When an external user ran this action before `docker/setup-buildx-action`, `docker buildx imagetools inspect --format {{.Manifest.Digest}}` returned the full human-readable inspect output instead of just the digest on some Docker Buildx versions. The full output was then passed as-is to the bundle lookup, causing the OCI registry requests to use a malformed URL. Both the Referrers API and the fallback tag lookup returned 404, resulting in:

```
Error: No Sigstore bundle found for digest Name:      ghcr.io/dash14/buildcage:sha-...
```

## Root cause

This action is designed to run **before** `docker/setup-buildx-action`, so the Docker Buildx version available on the runner is whatever the OS ships — potentially older than expected. Relying on `docker buildx imagetools inspect --format` to return a stable, parseable digest was fragile.

## Fix

Replace `getManifestDigest` (which shelled out to `docker buildx imagetools inspect`) with `fetchManifestDigest`, which calls the OCI Distribution Spec endpoint directly:

```
HEAD https://ghcr.io/v2/{repo}/manifests/{tag}
→ Docker-Content-Digest: sha256:...
```

This uses the same `fetch`-based infrastructure already in place for token and bundle retrieval, and has no dependency on Docker CLI or Buildx version.

## Changes

- `oci-registry.mjs`: remove `getManifestDigest` and `child_process` import; add `fetchManifestDigest`
- `verify-image.mjs`: fetch registry token first, then call `fetchManifestDigest` with it
- `oci-registry.test.mjs`: replace `getManifestDigest` tests with `fetchManifestDigest` tests (6 cases)