### PR TITLE
Bump dash14/buildcage from 2.1.0 to 2.1.1 in example workflows

### DIFF
--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Start Buildcage builder
         # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>
-        uses: dash14/buildcage/setup@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
+        uses: dash14/buildcage/setup@250f24f2f0105b27f04eb33d0a275ba5e90472af # v2.1.1
         with:
           proxy_mode: audit
 
@@ -53,4 +53,4 @@ jobs:
       - name: Show proxy report
         if: always()
         # For self-hosting, replace with: <your-org>/buildcage/report@<SHA>
-        uses: dash14/buildcage/report@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
+        uses: dash14/buildcage/report@250f24f2f0105b27f04eb33d0a275ba5e90472af # v2.1.1

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Start Buildcage builder
         # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>
-        uses: dash14/buildcage/setup@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
+        uses: dash14/buildcage/setup@250f24f2f0105b27f04eb33d0a275ba5e90472af # v2.1.1
         with:
           proxy_mode: restrict
           allowed_https_rules: >-
@@ -57,6 +57,6 @@ jobs:
       - name: Show proxy report
         if: always()
         # For self-hosting, replace with: <your-org>/buildcage/report@<SHA>
-        uses: dash14/buildcage/report@b9d14782cead3b80b89244ce718174e699bcd759 # v2.1.0
+        uses: dash14/buildcage/report@250f24f2f0105b27f04eb33d0a275ba5e90472af # v2.1.1
         with:
           fail_on_blocked: false


### PR DESCRIPTION
Bumps `dash14/buildcage/setup` and `dash14/buildcage/report` from `b9d14782` (v2.1.0) to `250f24f2` (v2.1.1) in the example workflow files.

| File | Action | Before | After |
|------|--------|--------|-------|
| `example-audit.yml` | setup, report | `b9d14782` (v2.1.0) | `250f24f2` (v2.1.1) |
| `example-restrict.yml` | setup, report | `b9d14782` (v2.1.0) | `250f24f2` (v2.1.1) |

**Release notes for v2.1.1**: https://github.com/dash14/buildcage/releases/tag/v2.1.1