### PR TITLE
fix: default build platform follows runner architecture by removing hardcoded platforms from buildkitd.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,3 +118,82 @@ jobs:
         env:
           BUILDER_NAME: ${{ matrix.builder_name }}
         run: docker compose down -v --rmi all 2>/dev/null || true
+
+  test_multiarch:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    name: test (multiarch)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Build containers
+        run: docker compose build
+
+      - name: Start containers
+        env:
+          PROXY_MODE: audit
+          BUILDER_NAME: buildcage-multiarch
+        run: docker compose up -d --wait
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver: remote
+          endpoint: docker-container://buildcage-multiarch
+
+      - name: Build without specifying platforms
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: test
+          file: test/Dockerfile.multiarch
+          push: false
+          load: true
+          no-cache: true
+          tags: buildcage-multiarch-test:default
+
+      - name: Verify default platform is arm64
+        run: |
+          ARCH=$(docker run --rm buildcage-multiarch-test:default uname -m)
+          echo "Default platform architecture: $ARCH"
+          [ "$ARCH" = "aarch64" ] || (echo "Expected aarch64 (native), got $ARCH" && exit 1)
+          echo "✓ Default platform is linux/arm64 (native runner architecture)"
+
+      - name: Build for linux/amd64
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: test
+          file: test/Dockerfile.multiarch
+          platforms: linux/amd64
+          push: false
+          load: true
+          no-cache: true
+          tags: buildcage-multiarch-test:amd64
+
+      - name: Verify amd64 cross-platform build
+        run: |
+          ARCH=$(docker run --rm --platform linux/amd64 buildcage-multiarch-test:amd64 uname -m)
+          echo "linux/amd64 image architecture: $ARCH"
+          [ "$ARCH" = "x86_64" ] || (echo "Expected x86_64, got $ARCH" && exit 1)
+          echo "✓ linux/amd64 cross-platform build verified"
+
+      - name: Cleanup
+        if: always()
+        env:
+          BUILDER_NAME: buildcage-multiarch
+        run: docker compose down -v --rmi all 2>/dev/null || true

--- a/docker/files/buildkitd.toml
+++ b/docker/files/buildkitd.toml
@@ -5,7 +5,6 @@ nameservers = ["172.20.0.1"]
 
 [worker.oci]
 enabled = true
-platforms = ["linux/amd64", "linux/arm64"]
 snapshotter = "auto"
 networkMode = "cni"
 cniConfigPath = "/etc/buildkit/cni.conflist"

--- a/test/Dockerfile.multiarch
+++ b/test/Dockerfile.multiarch
@@ -1,0 +1,2 @@
+FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+RUN uname -m


### PR DESCRIPTION
## Problem

`buildkitd.toml` had `platforms = ["linux/amd64", "linux/arm64"]` hardcoded in `[worker.oci]`. BuildKit uses the first entry in this list as the default platform when no platform is specified by the client. This caused **arm64 runners to build amd64 images by default**, ignoring the runner's native architecture.

## Root cause analysis

BuildKit's platform detection (`util/archutil/detect.go`) always places the native platform first — but only when `platforms` is not set in config. With an explicit list, the config value overrides auto-detection entirely, making `linux/amd64` the permanent default regardless of where buildcage runs.

## Changes

- **`docker/files/buildkitd.toml`**: Remove `platforms` from `[worker.oci]`. BuildKit now auto-detects supported platforms at startup: native platform first, then any additional architectures available via QEMU/binfmt_misc.
- **`test/Dockerfile.multiarch`**: Minimal test image that prints the build-time architecture via `RUN uname -m`.
- **`.github/workflows/test.yml`**: Add `test_multiarch` job running on `ubuntu-24.04-arm` to verify:
  1. Building without `platforms` produces a native arm64 image (validates the fix)
  2. Building with `platforms: linux/amd64` on an arm64 runner produces an amd64 image (validates cross-platform builds via QEMU)