### PR TITLE
fix: restrict default token permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ concurrency:
   group: docker-publish
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -7,6 +7,8 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   unit_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -11,12 +11,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   update-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Problem

Three workflows had no top-level `permissions` block, leaving the default token permissions unrestricted. One workflow had `contents: write` at the top level, granting write access to all jobs in the workflow even though only one job required it.

## Changes

- **`docker-publish.yml`**: Add top-level `permissions: {}`. Job-level permissions (`id-token: write`, `contents: read`, `packages: write`) were already in place and remain unchanged.
- **`image-scan.yml`**: Add top-level `permissions: {}`. Job-level permissions (`contents: read`, `security-events: write`) were already in place and remain unchanged.
- **`test.yml`**: Add top-level `permissions: {}`. All jobs already declared `contents: read` at the job level and remain unchanged.
- **`update-major-tag.yml`**: Replace top-level `contents: write` with `permissions: {}` and move `contents: write` to the `update-tag` job level, scoping write access to only the job that needs it.