### PR TITLE
feat: attach SLSA build provenance to GitHub releases via actions/attest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,11 @@ jobs:
       id-token: write
       contents: read
       packages: write
+      attestations: write
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      digest: ${{ steps.build.outputs.digest }}
+      bundle-content: ${{ steps.bundle.outputs.content }}
 
     steps:
       - name: Checkout
@@ -107,5 +112,39 @@ jobs:
       - name: Sign Docker image
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
+          REPO: ${{ github.repository }}
         run: |
-          cosign sign --yes --new-bundle-format ghcr.io/${{ github.repository }}@${DIGEST}
+          cosign sign --yes --new-bundle-format ghcr.io/${REPO}@${DIGEST}
+
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Read bundle content
+        id: bundle
+        env:
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          echo "content<<EOF" >> "$GITHUB_OUTPUT"
+          cat "$BUNDLE" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+  upload-release-assets:
+    needs: [build-and-push]
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+
+    steps:
+      - name: Upload to Release
+        env:
+          TAG: ${{ needs.build-and-push.outputs.tag }}
+          BUNDLE_CONTENT: ${{ needs.build-and-push.outputs.bundle-content }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$BUNDLE_CONTENT" > buildcage-container.intoto.jsonl
+          gh release upload "$TAG" buildcage-container.intoto.jsonl


### PR DESCRIPTION
## Summary

Generates a SLSA build provenance attestation for each container image release and attaches it to the corresponding GitHub Release as `buildcage-container.intoto.jsonl`.

The attestation is created by `actions/attest` (GitHub's first-party action, SHA-pinned), which signs the provenance using GitHub's OIDC identity via Sigstore and pushes it to both the GHCR registry and the GitHub Attestation store.

## Changes

- **`docker-publish.yml`**: Add `attestations: write` permission to the build job and introduce a dedicated `upload-release-assets` job with `contents: write` to upload the provenance file to the GitHub Release, keeping write access scoped to only the job that requires it.
  - `Attest build provenance`: calls `actions/attest@v4.1.0` with `push-to-registry: true` to attest the container image digest
  - `upload-release-assets`: runs on `ubuntu-slim` and uploads `buildcage-container.intoto.jsonl` to the GitHub Release