### PR TITLE
chore: change Renovate run schedule from Monday to Saturday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
-  "schedule": ["* * * * 1"],
+  "schedule": ["* * * * 6"],
   "minimumReleaseAge": "14 days",
   "internalChecksFilter": "strict",
   "customManagers": [


### PR DESCRIPTION
## Summary

Change the Renovate schedule from Monday (`* * * * 1`) to Saturday (`* * * * 6`) so that dependency update PRs are opened on weekends rather than the start of the work week.

## Changes

- **`renovate.json`**: Update `schedule` from `["* * * * 1"]` to `["* * * * 6"]`