### PR TITLE
Add property-based tests for core modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test_unit: test_setup test_report test_qjs ## Run unit tests
 
 .PHONY: test_setup
 test_setup: ## Run setup action unit tests
-	@node --test setup/src/main.test.mjs setup/src/lib/verify-image.test.mjs setup/src/lib/oci-registry.test.mjs setup/src/lib/sigstore.test.mjs
+	@node --test 'setup/src/**/*.test.mjs'
 
 .PHONY: test_report
 test_report: ## Run report unit tests

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^1.0.0",
+    "fast-check": "^4.8.0",
     "rollup": "^4.60.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       '@rollup/plugin-terser':
         specifier: ^1.0.0
         version: 1.0.0(rollup@4.61.1)
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       node:
         specifier: runtime:24.16.0
         version: runtime:24.16.0
@@ -517,6 +520,10 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -685,6 +692,9 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -922,6 +932,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -960,6 +974,8 @@ snapshots:
   path-parse@1.0.7: {}
 
   picomatch@4.0.4: {}
+
+  pure-rand@8.4.0: {}
 
   resolve@1.22.12:
     dependencies:

--- a/setup/src/lib/log-parser.property.test.mjs
+++ b/setup/src/lib/log-parser.property.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Property-based tests for docker/files/tools/lib/log-parser.mjs.
+ *
+ * Run with: node --test setup/src/lib/log-parser.property.test.mjs
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { parseEntries, aggregate } from "../../../docker/files/tools/lib/log-parser.mjs";
+
+// ---------------------------------------------------------------------------
+// parseEntries
+// ---------------------------------------------------------------------------
+
+describe("parseEntries – properties", () => {
+  // A well-formed log line always round-trips: parseEntries recovers all five fields.
+  it("valid log line always parses to exactly one entry with matching fields", () => {
+    const decision = fc.constantFrom("ALLOWED", "BLOCKED", "AUDIT");
+    // ruleType must match \w+ in the log pattern
+    const ruleType = fc.stringMatching(/^\w{1,10}$/);
+    // host: no '"' or ':' to keep the lastIndexOf split unambiguous
+    const host = fc.stringMatching(/^[a-z][a-z0-9.]{0,20}$/);
+    const port = fc.integer({ min: 1, max: 65535 }).map(String);
+    // reason: \S+ so the log pattern captures it in full
+    const reason = fc.oneof(fc.constant("-"), fc.stringMatching(/^\S{1,15}$/));
+
+    fc.assert(
+      fc.property(decision, ruleType, host, port, reason, (d, rt, h, p, r) => {
+        const line = `[2024-01-01] buildcage [${d}] (${rt}) "${h}:${p}" ${r}`;
+        const entries = parseEntries(line);
+        assert.equal(entries.length, 1);
+        assert.equal(entries[0].decision, d);
+        assert.equal(entries[0].ruleType, rt);
+        assert.equal(entries[0].host, h);
+        assert.equal(entries[0].port, p);
+        assert.equal(entries[0].reason, r);
+      }),
+    );
+  });
+
+  // The log pattern captures reason as \S* (no whitespace). A reason string
+  // containing an internal space is silently truncated to its first word.
+  it("reason with internal space is truncated to the first word", () => {
+    const word = fc.stringMatching(/^\S{1,10}$/);
+
+    fc.assert(
+      fc.property(word, word, (w1, w2) => {
+        const line = `[ts] buildcage [ALLOWED] (HTTPS) "example.com:443" ${w1} ${w2}`;
+        const entries = parseEntries(line);
+        assert.equal(entries.length, 1);
+        assert.equal(entries[0].reason, w1);
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregate
+// ---------------------------------------------------------------------------
+
+describe("aggregate – properties", () => {
+  // aggregate sorts by Number(port) as a tiebreaker. When port is non-numeric,
+  // Number(port) is NaN; the sort must not throw.
+  it("non-numeric port values never cause aggregate to throw", () => {
+    const entryWithAlphaPort = fc.record({
+      host: fc.constant("example.com"),
+      port: fc.stringMatching(/^[a-z]{1,5}$/),
+      ruleType: fc.constant("HTTPS"),
+      reason: fc.constant("-"),
+    });
+
+    fc.assert(
+      fc.property(fc.array(entryWithAlphaPort, { minLength: 1, maxLength: 5 }), (entries) => {
+        assert.doesNotThrow(() => aggregate(entries));
+      }),
+    );
+  });
+});

--- a/setup/src/lib/rules.property.test.mjs
+++ b/setup/src/lib/rules.property.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * Property-based tests for docker/files/tools/lib/rules.mjs.
+ *
+ * Run with: node --test setup/src/lib/rules.property.test.mjs
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { convertRule, buildRules } from "../../../docker/files/tools/lib/rules.mjs";
+
+// ---------------------------------------------------------------------------
+// convertRule / wildcardToRegex
+// ---------------------------------------------------------------------------
+
+describe("convertRule – properties", () => {
+  // For a plain domain (no wildcards, no regex metacharacters), the generated
+  // regex must match the original pattern and must NOT match a subdomain prefix.
+  it("exact pattern round-trips: regex matches original and rejects subdomain prefix", () => {
+    const simplePattern = fc
+      .tuple(
+        fc.stringMatching(/^[a-z][a-z0-9]{0,8}$/),
+        fc.stringMatching(/^[a-z]{2,4}$/),
+        fc.integer({ min: 1, max: 65535 }),
+      )
+      .map(([label, tld, port]) => `${label}.${tld}:${port}`);
+
+    fc.assert(
+      fc.property(simplePattern, (pattern) => {
+        const regex = new RegExp(convertRule(pattern));
+        assert.ok(regex.test(pattern), "regex must match original pattern");
+        assert.ok(!regex.test(`sub.${pattern}`), "regex must not match with extra subdomain prefix");
+      }),
+    );
+  });
+
+  // Domain labels may contain regex metacharacters in practice (e.g. from unusual
+  // hostnames). escapeRegex must neutralise them so the result always compiles.
+  it("patterns with regex metacharacters in the domain always produce a compilable regex", () => {
+    const metaChar = fc.constantFrom(".", "+", "^", "$", "(", ")", "[", "]", "{", "}", "|", "\\");
+    const patternWithMeta = fc
+      .tuple(
+        fc.stringMatching(/^[a-z]{1,5}$/),
+        metaChar,
+        fc.stringMatching(/^[a-z]{1,5}$/),
+        fc.integer({ min: 1, max: 65535 }),
+      )
+      .map(([prefix, meta, suffix, port]) => `${prefix}${meta}${suffix}.com:${port}`);
+
+    fc.assert(
+      fc.property(patternWithMeta, (pattern) => {
+        assert.doesNotThrow(() => new RegExp(convertRule(pattern)));
+      }),
+    );
+  });
+
+  // A domain label that contains '*' but is not exactly '*' or '**' is always invalid.
+  // Labels starting with '~' are excluded: they make the full pattern a raw-regex rule,
+  // which bypasses wildcard validation (same escape hatch as in buildACLRules).
+  it("label with * mixed with other characters always throws", () => {
+    const mixedWildcardLabel = fc
+      .string({ minLength: 1, maxLength: 8 })
+      .filter((s) => s.includes("*") && s !== "*" && s !== "**" && !s.startsWith("~"));
+
+    fc.assert(
+      fc.property(mixedWildcardLabel, (label) => {
+        assert.throws(
+          () => convertRule(`${label}.com:443`),
+          (err) => { assert.ok(err instanceof Error); return true; },
+        );
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRules
+// ---------------------------------------------------------------------------
+
+describe("buildRules – properties", () => {
+  // N valid rules joined with any whitespace separator always produce length N.
+  it("N valid rules joined by any whitespace always return an array of length N", () => {
+    const validRule = fc
+      .tuple(
+        fc.stringMatching(/^[a-z][a-z0-9]{0,8}\.[a-z]{2,4}$/),
+        fc.integer({ min: 1, max: 65535 }),
+      )
+      .map(([domain, port]) => `${domain}:${port}`);
+
+    const whitespace = fc.constantFrom(" ", "\t", "\n", "  ", " \t ");
+
+    fc.assert(
+      fc.property(
+        fc.array(validRule, { minLength: 0, maxLength: 5 }),
+        whitespace,
+        (rules, sep) => {
+          const result = buildRules(rules.join(sep));
+          assert.equal(result.length, rules.length);
+        },
+      ),
+    );
+  });
+});

--- a/setup/src/lib/verify-image.property.test.mjs
+++ b/setup/src/lib/verify-image.property.test.mjs
@@ -1,0 +1,64 @@
+/**
+ * Property-based tests for verify-image.mjs helpers.
+ *
+ * Run with: node --test setup/src/lib/verify-image.property.test.mjs
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { buildVerifyOptions } from "./verify-image.mjs";
+
+// ---------------------------------------------------------------------------
+// buildVerifyOptions
+// ---------------------------------------------------------------------------
+
+describe("buildVerifyOptions – properties", () => {
+  // SHA pin always produces certificateOIDs; the SAN URI ends with 'v' (accepts any v-tag).
+  it("40-char hex SHA always returns certificateOIDs and a compilable SAN regex", () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[0-9a-fA-F]{40}$/),
+        fc.stringMatching(/^[A-Za-z0-9-]{1,20}\/[A-Za-z0-9-]{1,20}$/),
+        (actionRef, actionRepo) => {
+          const result = buildVerifyOptions({ actionRef, actionRepo });
+          assert.ok(result !== null);
+          assert.ok(result.certificateOIDs !== undefined, "SHA ref must set certificateOIDs");
+          assert.ok(result.certificateIdentityURI.endsWith("v"), "SAN URI must accept any v-tag");
+          assert.doesNotThrow(() => new RegExp(result.certificateIdentityURI));
+        },
+      ),
+    );
+  });
+
+  // Version tag: even refs containing regex metacharacters must produce a compilable SAN regex.
+  // escapeRegex must neutralise chars like '.', '+', '(', ')' in the actionRef portion.
+  it("v-prefixed ref always returns no certificateOIDs and a compilable SAN regex", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }).map((s) => `v${s}`),
+        fc.stringMatching(/^[A-Za-z0-9-]{1,20}\/[A-Za-z0-9-]{1,20}$/),
+        (actionRef, actionRepo) => {
+          const result = buildVerifyOptions({ actionRef, actionRepo });
+          assert.ok(result !== null);
+          assert.equal(result.certificateOIDs, undefined, "version tag must not set certificateOIDs");
+          assert.doesNotThrow(() => new RegExp(result.certificateIdentityURI));
+        },
+      ),
+    );
+  });
+
+  // Non-SHA, non-v refs (branch names, etc.) are always unverifiable — must return null.
+  // Leading 'g' is not a hex char and not 'v', so this always hits the passthrough branch.
+  it("non-SHA non-v-prefixed ref always returns null", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 0, maxLength: 30 }).map((s) => `g${s}`),
+        fc.stringMatching(/^[A-Za-z0-9-]{1,20}\/[A-Za-z0-9-]{1,20}$/),
+        (actionRef, actionRepo) => {
+          assert.equal(buildVerifyOptions({ actionRef, actionRepo }), null);
+        },
+      ),
+    );
+  });
+});

--- a/setup/src/main.property.test.mjs
+++ b/setup/src/main.property.test.mjs
@@ -1,0 +1,149 @@
+/**
+ * Property-based tests for setup/main.mjs and its helpers.
+ *
+ * Run with: node --test setup/src/main.property.test.mjs
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { imageTagFromRef } from "./lib/verify-image.mjs";
+import { buildACLRules, resolveBuildcageImageRef } from "./main.mjs";
+
+// ---------------------------------------------------------------------------
+// imageTagFromRef
+// ---------------------------------------------------------------------------
+
+describe("imageTagFromRef – properties", () => {
+  it("40-char hex SHA always produces sha-<lowercase sha>", () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[0-9a-fA-F]{40}$/),
+        (sha) => {
+          assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}`);
+        },
+      ),
+    );
+  });
+
+  it("v-prefixed ref always strips the leading v", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1 }).map((s) => `v${s}`),
+        (ref) => {
+          assert.equal(imageTagFromRef(ref), ref.slice(1));
+        },
+      ),
+    );
+  });
+
+  // Leading 'g' is not a hex char and not 'v', so this always hits the passthrough branch.
+  it("non-SHA non-v-prefixed ref always passes through unchanged", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 0, maxLength: 50 }).map((s) => `g${s}`),
+        (ref) => {
+          assert.equal(imageTagFromRef(ref), ref);
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildACLRules
+// ---------------------------------------------------------------------------
+
+describe("buildACLRules – properties", () => {
+  it("empty / whitespace-only inputs always return empty arrays", () => {
+    const blank = fc.oneof(
+      fc.constant(""),
+      fc.constant(undefined),
+      fc.constant("   "),
+      fc.constant("\t\n"),
+    );
+    fc.assert(
+      fc.property(blank, blank, blank, (h, p, i) => {
+        const result = buildACLRules({
+          httpsRulesInput: h,
+          httpRulesInput: p,
+          ipRulesInput: i,
+        });
+        assert.deepEqual(result.httpsRules, []);
+        assert.deepEqual(result.httpRules, []);
+        assert.deepEqual(result.ipRules, []);
+      }),
+    );
+  });
+
+  it("valid host:port rules produce an array matching the input token count", () => {
+    const validRule = fc
+      .tuple(
+        fc.stringMatching(/^[a-z][a-z0-9-]{0,10}\.[a-z]{2,4}$/),
+        fc.integer({ min: 80, max: 65535 }),
+      )
+      .map(([host, port]) => `${host}:${port}`);
+
+    fc.assert(
+      fc.property(fc.array(validRule, { minLength: 0, maxLength: 5 }), (rules) => {
+        const result = buildACLRules({
+          httpsRulesInput: rules.join(" "),
+          httpRulesInput: "",
+          ipRulesInput: "",
+        });
+        assert.equal(result.httpsRules.length, rules.length);
+      }),
+    );
+  });
+
+  // '~'-prefixed tokens are treated as raw regexes and bypass host:port validation.
+  it("any token without a colon and without ~ prefix always throws", () => {
+    fc.assert(
+      fc.property(
+        fc.stringMatching(/^[^\s:~]{1,30}$/),
+        (token) => {
+          assert.throws(
+            () =>
+              buildACLRules({
+                httpsRulesInput: token,
+                httpRulesInput: "",
+                ipRulesInput: "",
+              }),
+            (err) => {
+              assert.ok(err instanceof Error);
+              return true;
+            },
+          );
+        },
+      ),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBuildcageImageRef
+// ---------------------------------------------------------------------------
+
+describe("resolveBuildcageImageRef – properties", () => {
+  it("with digest: repository part is always lowercased regardless of actionRepository casing", () => {
+    const digest = fc.stringMatching(/^sha256:[0-9a-f]{64}$/);
+    const repoName = fc
+      .tuple(
+        fc.stringMatching(/^[A-Za-z0-9-]{1,20}$/),
+        fc.stringMatching(/^[A-Za-z0-9-]{1,20}$/),
+      )
+      .map(([owner, repo]) => `${owner}/${repo}`);
+
+    fc.assert(
+      fc.property(repoName, digest, (actionRepository, imageDigest) => {
+        const result = resolveBuildcageImageRef({
+          imageDigest,
+          actionRepository,
+          actionRef: "v1.0.0",
+        });
+        const [repoPart] = result.split("@");
+        assert.equal(repoPart, `ghcr.io/${actionRepository.toLowerCase()}`);
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Introduces property-based tests using [fast-check](https://github.com/dubzzz/fast-check) for modules with non-trivial transformation or parsing logic. Unlike example-based tests that check specific inputs, property-based tests generate hundreds of random inputs and assert invariants that must hold universally — making them well-suited to catch edge cases in format conversion, escaping, and parsing functions.

## Changes

- **`package.json`**: Add `fast-check` as a dev dependency.
- **`setup/src/main.property.test.mjs`**: Properties for `imageTagFromRef` (SHA formatting, v-prefix stripping, passthrough), `buildACLRules` (empty inputs, token count, colon-less tokens), and `resolveBuildcageImageRef` (repository lowercasing with digest).
- **`setup/src/lib/verify-image.property.test.mjs`**: Properties for `buildVerifyOptions` — verifies that version strings containing regex metacharacters are correctly escaped and produce a compilable SAN regex, and that SHA refs always set `certificateOIDs` while branch refs always return `null`.
- **`setup/src/lib/rules.property.test.mjs`**: Properties for `wildcardToRegex` / `convertRule` (round-trip correctness, metacharacter escaping, mixed-wildcard error boundary) and `buildRules` (whitespace-separator tolerance).
- **`setup/src/lib/log-parser.property.test.mjs`**: Properties for `parseEntries` (round-trip for valid log lines, reason truncation on whitespace) and `aggregate` (non-numeric port values do not cause a sort error).
- **`Makefile`**: Replace the explicit file list in `test_setup` with `setup/src/**/*.test.mjs` so new test files are picked up automatically.