### PR TITLE
fix: tighten mixed-wildcard label generator in property test

### DIFF
--- a/setup/src/lib/rules.property.test.mjs
+++ b/setup/src/lib/rules.property.test.mjs
@@ -60,7 +60,7 @@ describe("convertRule – properties", () => {
   it("label with * mixed with other characters always throws", () => {
     const mixedWildcardLabel = fc
       .string({ minLength: 1, maxLength: 8 })
-      .filter((s) => s.includes("*") && s !== "*" && s !== "**" && !s.startsWith("~"));
+      .filter((s) => s.includes("*") && s !== "*" && s !== "**" && !s.startsWith("~") && !s.includes("."));
 
     fc.assert(
       fc.property(mixedWildcardLabel, (label) => {


### PR DESCRIPTION
## Summary

Fixes a gap in the mixed-wildcard property test generator where a label containing `.` (e.g. `"*. "`) could slip through the filter. When such a label is appended as `` `${label}.com:443` ``, the `.` inside the label splits the domain into extra segments, placing `*` in its own segment — so `domainToRegex` never sees a mixed-wildcard part and no error is thrown.

The fix adds `!s.includes(".")` to the generator filter, ensuring the generated string is treated as a single domain segment when concatenated into the test pattern.

## Changes

- **`setup/src/lib/rules.property.test.mjs`**: Add `!s.includes(".")` to the `mixedWildcardLabel` filter.