### PR TITLE
fix: resolve gh release upload failure in checkout-less job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -147,4 +147,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "$BUNDLE_CONTENT" > buildcage-container.intoto.jsonl
-          gh release upload "$TAG" buildcage-container.intoto.jsonl
+          gh release upload --repo "$GITHUB_REPOSITORY" "$TAG" buildcage-container.intoto.jsonl


### PR DESCRIPTION
## Summary

Fixes a failure in the `upload-release-assets` job where `gh release upload` exits with `fatal: not a git repository`. The job runs on `ubuntu-slim` without a `Checkout` step, so the `gh` CLI cannot detect the repository from the git context. Passing `--repo "$GITHUB_REPOSITORY"` resolves the lookup explicitly without requiring a full clone.

## Changes

- **`.github/workflows/docker-publish.yml`**: Add `--repo "$GITHUB_REPOSITORY"` to the `gh release upload` invocation in the `upload-release-assets` job.