### PR TITLE
fix: use github.event.release.tag_name to avoid intermittent empty ref in update-major-tag

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      TAG: ${{ inputs.tag || github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ env.TAG }}
           persist-credentials: false
 
       - name: Extract major version
         id: version
-        env:
-          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           MAJOR="${TAG%%.*}"
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
@@ -36,7 +36,6 @@ jobs:
       - name: Update major version tag
         env:
           MAJOR: ${{ steps.version.outputs.major }}
-          TAG: ${{ inputs.tag || github.ref_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

Fixes an intermittent failure where `TAG` becomes empty in the `update-major-tag` workflow. `github.ref_name` and `github.ref` are known to return empty strings for `release` events due to a runner bug ([actions/runner#2788](https://github.com/actions/runner/issues/2788)), causing the major version tag to be incorrectly named or pushed. Switching to `github.event.release.tag_name`, which is sourced directly from the release payload, avoids this issue.

As a secondary improvement, the expression is defined once at the job level via `env:` rather than repeated in three separate places.

## Changes

- **`.github/workflows/update-major-tag.yml`**: Replace `github.ref_name` / `github.ref` with `github.event.release.tag_name` and consolidate `TAG` into a single job-level `env` definition.