### PR TITLE
feat: implement immutable release workflow via draft release lifecycle

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,21 +63,6 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-          # Check if this version is the latest within the same major/major.minor
-          VERSION="${TAG#v}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-
-          LATEST_IN_MAJOR=$(git tag --list "v${MAJOR}.*.*" --sort=-version:refname | head -1)
-          if [ "$TAG" != "$LATEST_IN_MAJOR" ]; then
-            echo "skip_major=true" >> "$GITHUB_OUTPUT"
-          fi
-
-          LATEST_IN_MINOR=$(git tag --list "v${MINOR}.*" --sort=-version:refname | head -1)
-          if [ "$TAG" != "$LATEST_IN_MINOR" ]; then
-            echo "skip_minor=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
@@ -91,8 +76,6 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}
-            ${{ steps.version.outputs.skip_minor != 'true' && format('type=semver,pattern={{{{major}}}}.{{{{minor}}}},value={0}', steps.version.outputs.tag) || '' }}
-            ${{ steps.version.outputs.skip_major != 'true' && format('type=semver,pattern={{{{major}}}},value={0}', steps.version.outputs.tag) || '' }}
             type=raw,value=sha-${{ steps.version.outputs.sha }},priority=100
 
       - name: Login to GHCR

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -144,26 +144,35 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
   upload-release-assets:
-    if: github.event_name != 'push'
     needs: [build-and-push]
     runs-on: ubuntu-slim
     permissions:
       contents: write
 
     steps:
+      - name: Check release
+        id: check
+        env:
+          TAG: ${{ needs.build-and-push.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft 2>&1) || {
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          if [ "$(echo "$RELEASE" | jq -r '.isDraft')" != "true" ]; then
+            echo "::warning::Release $TAG is already published, skipping upload"
+            echo "upload=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "upload=true" >> "$GITHUB_OUTPUT"
+
       - name: Upload to Release
+        if: steps.check.outputs.upload == 'true'
         env:
           TAG: ${{ needs.build-and-push.outputs.tag }}
           BUNDLE_CONTENT: ${{ needs.build-and-push.outputs.bundle-content }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,url 2>&1) || {
-            echo "::error::No release found for $TAG"
-            exit 1
-          }
-          if [ "$(echo "$RELEASE" | jq -r '.isDraft')" != "true" ]; then
-            echo "::error::Release $TAG is already published. Refusing to upload to an immutable release."
-            exit 1
-          fi
           echo "$BUNDLE_CONTENT" > buildcage-container.intoto.jsonl
           gh release upload --repo "$GITHUB_REPOSITORY" "$TAG" buildcage-container.intoto.jsonl

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,11 @@ on:
       - "v*.*.*"
 
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (leave empty to use latest)'
+        required: false
+        type: string
 
 concurrency:
   group: docker-publish
@@ -39,12 +44,17 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            TAG=$(git tag --sort=-version:refname --list 'v*.*' | head -1)
-            if [ -z "$TAG" ]; then
-              echo "::error::No version tag found"
-              exit 1
+            if [ -n "$INPUT_TAG" ]; then
+              TAG="$INPUT_TAG"
+            else
+              TAG=$(git tag --sort=-version:refname --list 'v*.*' | head -1)
+              if [ -z "$TAG" ]; then
+                echo "::error::No version tag found"
+                exit 1
+              fi
             fi
             git checkout "$TAG"
           else
@@ -134,6 +144,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
   upload-release-assets:
+    if: github.event_name != 'push'
     needs: [build-and-push]
     runs-on: ubuntu-slim
     permissions:
@@ -146,5 +157,13 @@ jobs:
           BUNDLE_CONTENT: ${{ needs.build-and-push.outputs.bundle-content }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          RELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isDraft,url 2>&1) || {
+            echo "::error::No release found for $TAG"
+            exit 1
+          }
+          if [ "$(echo "$RELEASE" | jq -r '.isDraft')" != "true" ]; then
+            echo "::error::Release $TAG is already published. Refusing to upload to an immutable release."
+            exit 1
+          fi
           echo "$BUNDLE_CONTENT" > buildcage-container.intoto.jsonl
           gh release upload --repo "$GITHUB_REPOSITORY" "$TAG" buildcage-container.intoto.jsonl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     environment: release
     permissions:
       contents: write
-      actions: write
+      actions: read
 
     steps:
       - name: Checkout
@@ -63,17 +63,27 @@ jobs:
           git tag "$TAG"
           git push "https://x-access-token:${PAT}@github.com/${REPO}.git" "refs/tags/${TAG}"
 
+      - name: Wait for docker-publish
         env:
           TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          STARTED_AT: ${{ github.run_started_at }}
         run: |
-          RUN_ID=$(printf '{"ref":"refs/tags/%s","inputs":{"tag":"%s"},"return_run_details":true}' "$TAG" "$TAG" \
-            | gh api "repos/${REPO}/actions/workflows/docker-publish.yml/dispatches" \
-                --method POST --input - \
-                --jq '.workflow_run_id')
-
-          echo "Watching run https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          RUN_ID=""
+          for i in $(seq 1 24); do
+            RUN_ID=$(gh run list --repo "$REPO" --workflow docker-publish.yml \
+              --branch "$TAG" --limit 5 --json databaseId,createdAt \
+              --jq --arg since "$STARTED_AT" \
+              '[.[] | select(.createdAt >= $since)] | .[0].databaseId // empty' \
+              2>/dev/null)
+            [ -n "$RUN_ID" ] && break
+            sleep 5
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::docker-publish run for $TAG not found within 2 minutes"
+            exit 1
+          fi
           gh run watch "$RUN_ID" --exit-status
 
       - name: Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+run-name: Release ${{ inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Semver tag (e.g. v1.2.3)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate tag format
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid semver format: $TAG (expected vX.Y.Z)"
+            exit 1
+          fi
+
+      - name: Check tag does not exist
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+
+      - name: Push tag
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          git tag "$TAG"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "refs/tags/${TAG}"
+
+      - name: Create draft release
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --generate-notes
+
+      - name: Trigger docker-publish
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          RUN_ID=$(printf '{"ref":"refs/tags/%s","inputs":{"tag":"%s"},"return_run_details":true}' "$TAG" "$TAG" \
+            | gh api "repos/${REPO}/actions/workflows/docker-publish.yml/dispatches" \
+                --method POST --input - \
+                --jq '.workflow_run_id')
+
+          echo "Watching run https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          gh run watch "$RUN_ID" --exit-status
+
+      - name: Summary
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_URL=$(gh release view "$TAG" --json url --jq '.url')
+          echo "### $TAG draft release is ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Review and publish: $RELEASE_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   release:
     runs-on: ubuntu-slim
+    environment: release
     permissions:
       contents: write
       actions: write
@@ -43,15 +44,6 @@ jobs:
             exit 1
           fi
 
-      - name: Push tag
-        env:
-          TAG: ${{ inputs.tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          git tag "$TAG"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "refs/tags/${TAG}"
-
       - name: Create draft release
         env:
           TAG: ${{ inputs.tag }}
@@ -62,7 +54,15 @@ jobs:
             --title "$TAG" \
             --generate-notes
 
-      - name: Trigger docker-publish
+      - name: Push tag
+        env:
+          TAG: ${{ inputs.tag }}
+          PAT: ${{ secrets.TAG_CREATION_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          git tag "$TAG"
+          git push "https://x-access-token:${PAT}@github.com/${REPO}.git" "refs/tags/${TAG}"
+
         env:
           TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           PAT: ${{ secrets.TAG_CREATION_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
+          echo "PUSH_SINCE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_ENV"
           git tag "$TAG"
           git push "https://x-access-token:${PAT}@github.com/${REPO}.git" "refs/tags/${TAG}"
 
@@ -68,15 +69,13 @@ jobs:
           TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          STARTED_AT: ${{ github.run_started_at }}
         run: |
           RUN_ID=""
           for i in $(seq 1 24); do
             RUN_ID=$(gh run list --repo "$REPO" --workflow docker-publish.yml \
-              --branch "$TAG" --limit 5 --json databaseId,createdAt \
-              --jq --arg since "$STARTED_AT" \
-              '[.[] | select(.createdAt >= $since)] | .[0].databaseId // empty' \
-              2>/dev/null)
+              --branch "$TAG" --limit 5 --json databaseId,createdAt 2>/dev/null \
+              | jq -r --arg since "$PUSH_SINCE" \
+              '[.[] | select(.createdAt >= $since)] | .[0].databaseId // empty') || true
             [ -n "$RUN_ID" ] && break
             sleep 5
           done
@@ -84,7 +83,7 @@ jobs:
             echo "::error::docker-publish run for $TAG not found within 2 minutes"
             exit 1
           fi
-          gh run watch "$RUN_ID" --exit-status
+          gh run watch "$RUN_ID" --exit-status --interval 5 --compact
 
       - name: Summary
         env:

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -16,6 +16,7 @@ permissions: {}
 jobs:
   update-tag:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     env:

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -4,6 +4,13 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v1.0.0)'
+        required: true
+        type: string
+
 permissions: {}
 
 jobs:
@@ -13,7 +20,7 @@ jobs:
       contents: write
       packages: write
     env:
-      TAG: ${{ github.event.release.tag_name }}
+      TAG: ${{ inputs.tag || github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -4,23 +4,16 @@ on:
   release:
     types: [published]
 
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Release tag (e.g. v1.0.0)'
-        required: true
-        type: string
-
 permissions: {}
 
 jobs:
   update-tag:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
+      packages: write
     env:
-      TAG: ${{ inputs.tag || github.event.release.tag_name }}
+      TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -44,3 +37,32 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
           git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
           git push origin "$MAJOR" --force
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Docker major/minor tags
+        env:
+          MAJOR: ${{ steps.version.outputs.major }}
+          REPO: ghcr.io/${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${TAG#v}"
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+
+          TAGS=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" \
+            --jq '.[].ref | ltrimstr("refs/tags/")')
+
+          LATEST_IN_MAJOR=$(echo "$TAGS" | grep -E "^v${MAJOR#v}\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
+          LATEST_IN_MINOR=$(echo "$TAGS" | grep -E "^v${MINOR}\.[0-9]+$" | sort -V | tail -1)
+
+          if [ "$TAG" = "$LATEST_IN_MINOR" ]; then
+            docker buildx imagetools create --tag "${REPO}:${MINOR}" "${REPO}:${VERSION}"
+          fi
+          if [ "$TAG" = "$LATEST_IN_MAJOR" ]; then
+            docker buildx imagetools create --tag "${REPO}:${MAJOR#v}" "${REPO}:${VERSION}"
+          fi


### PR DESCRIPTION
## Summary

Introduces an immutable release workflow that ensures Docker images and attestations are built from a tagged commit, with major/minor Docker tags deferred to publish time.

## Changes

- Add a gated release trigger that creates a draft release, waits for the downstream build to complete, and requires reviewer approval before proceeding. (`release.yml`)
- Make the attestation upload optional so that `docker-publish` continues to work in self-hosted environments where no GitHub Release exists. Skips gracefully when no release is found and warns rather than errors when the release is already published. (`docker-publish.yml`)
- Defer major/minor Docker tag updates to release publish time so that floating tags (`:2`, `:2.1`) are only promoted after the release is intentionally made public. Removed from build time and moved to the publish event. (`docker-publish.yml`, `update-major-tag.yml`)