### PR TITLE
feat: add OSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,38 @@
+name: Scorecard supply-chain security
+run-name: Scorecard supply-chain security
+
+on:
+  schedule:
+    # Every Saturday at 00:00 UTC
+    - cron: '0 0 * * 6'
+
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload to GitHub Security
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Adds an [OSSF Scorecard](https://scorecard.dev/) workflow to continuously assess the repository's supply chain security posture. Results are published to scorecard.dev and surfaced in the GitHub Security tab via SARIF upload.

## Changes

- Add `.github/workflows/scorecard.yml` that runs every Saturday and on `workflow_dispatch`
- All actions are pinned to full commit SHAs (managed by Renovate with the existing 14-day \`minimumReleaseAge\` cooldown)
- Publish results to scorecard.dev via \`publish_results: true\`
- Upload SARIF output to GitHub Code Scanning for visibility in the Security tab