### PR TITLE
chore: extend Renovate coverage to GitHub Actions SHA pins in Markdown docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,15 @@
         "/^docker/Dockerfile$/"
       ],
       "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\nARG CNI_VERSION=(?<currentValue>v[\\d.]+)"]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["\\.md$"],
+      "matchStrings": [
+        "uses: (?<depName>[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)(?:/[^@\\s]+)?@(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>v[0-9.]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary

Extends Renovate's coverage to GitHub Actions SHA pins embedded in Markdown documentation. Previously, Renovate only tracked pins in \`.github/workflows/*.yml\`; action references in \`README.md\` and \`docs/\` were updated manually.

## Changes

- Add a \`customManagers\` regex entry in \`renovate.json\` targeting \`*.md\` files
- Extracts \`owner/repo\` as \`depName\` (stripping action subpaths such as \`/setup\` and \`/report\`), the 40-character commit digest, and the version from the inline \`# vX.Y.Z\` comment
- Uses \`github-tags\` datasource with \`semver\` versioning — consistent with how the existing github-actions manager tracks the same dependencies
- The existing \`packageRules\` exemption for \`dash14/buildcage\` applies automatically via prefix match, so self-referencing action pins in docs continue to receive zero \`minimumReleaseAge\`

Affected files: \`README.md\`, \`docs/self-hosting.md\`, \`docs/rules.md\`