### PR TITLE
Fix attestation bundle filename extension

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -157,5 +157,5 @@ jobs:
           BUNDLE_CONTENT: ${{ needs.build-and-push.outputs.bundle-content }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "$BUNDLE_CONTENT" > buildcage-container.intoto.jsonl
-          gh release upload --repo "$GITHUB_REPOSITORY" "$TAG" buildcage-container.intoto.jsonl
+          echo "$BUNDLE_CONTENT" > buildcage-container.sigstore.json
+          gh release upload --repo "$GITHUB_REPOSITORY" "$TAG" buildcage-container.sigstore.json


### PR DESCRIPTION
## Summary

The release attestation bundle produced by `actions/attest` was uploaded as `buildcage-container.intoto.jsonl`, but the extension didn't match its actual content: the file is a single-object [Sigstore Bundle](https://docs.sigstore.dev/about/bundle/) (`mediaType` + `verificationMaterial` + `dsseEnvelope`), not JSON Lines, and the in-toto statement sits one level inside the DSSE envelope rather than being the top-level content itself.

## Changes

- Rename the uploaded release asset from `buildcage-container.intoto.jsonl` to `buildcage-container.sigstore.json`, matching Sigstore's own naming convention for single Bundle files (e.g. `sigstore-java-1.0.0.jar.sigstore.json`)
- No functional change — verification tooling (`cosign`, `gh attestation verify`) is pointed at the bundle via an explicit path/flag, not by filename