### PR TITLE
chore: update .trivyignore after CVE triage and buildkit bump

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -140,3 +140,52 @@ CVE-2026-32282
 # Container image layers use POSIX/PAX tar format; old GNU sparse map headers
 # are not part of the OCI or Docker image layer specification and are not processed by buildkitd.
 CVE-2026-32288
+
+# golang.org/x/net/html: XSS and DoS via parsing/rendering arbitrary HTML.
+# No component in this product (buildkitd, buildkit-runc) parses or renders untrusted HTML.
+CVE-2026-42506
+CVE-2026-42502
+CVE-2026-27136
+CVE-2026-25681
+CVE-2026-25680
+CVE-2025-58190
+CVE-2025-47911
+
+# containerd CRI plugin vulnerabilities (image cache poisoning via checkpoint/restore,
+# CDI annotation injection, unbounded memory on crafted image, LABEL passthrough).
+# buildkitd embeds containerd only as a client/worker library for its own build execution;
+# it never runs the CRI plugin, and checkpoint/restore (CRIU) and CDI are not enabled.
+CVE-2026-50195
+CVE-2026-47262
+CVE-2026-53492
+CVE-2026-53489
+CVE-2026-53488
+
+# golang.org/x/net/idna: privilege escalation via incorrect Punycode label processing.
+# Only present in buildkit-runc, which handles namespaces/cgroups/rootfs setup and
+# never parses or authorizes hostnames; the idna package is an unused transitive
+# dependency in this binary.
+CVE-2026-39821
+
+# golang.org/x/sys/windows: integer overflow in NewNTUnicodeString — Windows only.
+# This product runs exclusively in Linux containers; the Windows code path is never executed.
+CVE-2026-39824
+
+# libexpat: additional XML parsing vulnerabilities (same rationale as
+# CVE-2026-25210/CVE-2026-24515 above). No external XML processing path exists
+# in this product.
+CVE-2026-56409
+CVE-2026-56408
+CVE-2026-56407
+CVE-2026-56131
+CVE-2026-41080
+CVE-2026-56412
+CVE-2026-56411
+CVE-2026-56410
+CVE-2026-56406
+CVE-2026-56405
+CVE-2026-56404
+CVE-2026-56403
+CVE-2026-56132
+CVE-2026-50219
+CVE-2026-45186


### PR DESCRIPTION
## Summary

Triages the currently open Trivy code-scanning alerts (https://github.com/dash14/buildcage/security/code-scanning) and adds the ones confirmed to have no practical impact on Buildcage to `.trivyignore`, following the same per-CVE justification style as the existing entries.

Each addition was checked against how the affected package is actually used in this image (not just whether it's present) — e.g. by inspecting `docker/Dockerfile`, `haproxy.cfg.template`, and the packages' reverse dependencies via `apk info -R` — rather than assuming a bundled dependency is automatically reachable.

## Changes

- **golang.org/x/net/html** (XSS/DoS via HTML parsing): buildkitd/buildkit-runc never parse or render untrusted HTML
- **containerd CRI plugin** (image cache poisoning, CDI injection, unbounded memory, LABEL passthrough): buildkitd embeds containerd only as a client/worker library and never runs the CRI plugin, checkpoint/restore (CRIU), or CDI
- **golang.org/x/net/idna** (Punycode privilege escalation): only present in buildkit-runc, which never parses or authorizes hostnames — unused transitive dependency
- **golang.org/x/sys/windows** (NewNTUnicodeString overflow): Windows-only code path, never executed in this Linux-only container
- **libexpat** (additional XML parsing CVEs): extends the existing libexpat rationale — no external XML processing path exists in this product
