### PR TITLE
fix: add missing regex delimiters to Markdown managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["\\.md$"],
+      "managerFilePatterns": ["/\\.md$/"],
       "matchStrings": [
         "uses: (?<depName>[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)(?:/[^@\\s]+)?@(?<currentDigest>[a-f0-9]{40}) # (?<currentValue>v[0-9.]+)"
       ],


### PR DESCRIPTION
## Summary

Follow-up to #112. The \`managerFilePatterns\` entry for Markdown files was missing the \`/\` regex delimiters used consistently elsewhere in the config, which could cause the pattern to be interpreted incorrectly.

## Changes

- Wrap the Markdown file pattern in regex delimiters: \`"\\.md$"\` → \`"/\\.md$/"\` to match the format used by the existing Dockerfile entry