### PR TITLE
feat: reflect the invoking action's ref in the restrict-mode example

### DIFF
--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -156,7 +156,7 @@ function markdownTable(rows, {showReason: showReason = !1} = {}) {
   return lines.join("\n");
 }
 
-const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", isAudit = "audit" === report.mode, isExplicit = void 0 !== report.deniedTimeline;
+const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", actionRef = process.env.GITHUB_ACTION_REF || "v2", isAudit = "audit" === report.mode, isExplicit = void 0 !== report.deniedTimeline;
 
 let builds = [];
 
@@ -219,16 +219,16 @@ let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} m
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
   audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n"), 
-  markdown += function(auditedRows, actionRepo) {
+  markdown += function(auditedRows, actionRepo, actionRef) {
     if (!auditedRows || 0 === auditedRows.length) return "";
-    const groups = new Map;
+    const ref = /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef, groups = new Map;
     for (const r of auditedRows) {
       const param = ruleTypeToParam[r.ruleType];
       param && (groups.has(param) || groups.set(param, []), groups.get(param).push(`${r.host}:${r.port}`));
     }
     if (0 === groups.size) return "";
     let yaml = "";
-    yaml += "- name: Start Buildcage in restrict mode\n", yaml += `  uses: ${actionRepo}/setup@v2\n`, 
+    yaml += "- name: Start Buildcage in restrict mode\n", yaml += `  uses: ${actionRepo}/setup@${ref}\n`, 
     yaml += "  with:\n", yaml += "    proxy_mode: restrict\n";
     for (const [param, rules] of groups) {
       yaml += `    ${param}: >-\n`;
@@ -237,7 +237,7 @@ if (isAudit) {
     let md = "\n<details>\n";
     return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", 
     md += yaml, md += "```\n\n", md += "</details>\n", md;
-  }(audited, actionRepo);
+  }(audited, actionRepo, actionRef);
   const blocked = report.sections.blocked || [];
   blocked.length > 0 && (audited.length > 0 && (markdown += "\n"), markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, {
     showReason: !0

--- a/report/src/lib/build-example.js
+++ b/report/src/lib/build-example.js
@@ -9,10 +9,16 @@ const ruleTypeToParam = {
  * Returns a markdown string wrapped in <details> tags, or "" if no rows.
  *
  * @param {Array<{host: string, port: string, ruleType: string}>} auditedRows
+ * @param {string} actionRepo
+ * @param {string} actionRef - the ref (tag or commit SHA) this action was invoked with
  * @returns {string}
  */
-export function buildRestrictExample(auditedRows, actionRepo) {
+export function buildRestrictExample(auditedRows, actionRepo, actionRef) {
   if (!auditedRows || auditedRows.length === 0) return "";
+
+  // A 40-char SHA is opaque to the reader and specific to this run, so show a
+  // placeholder instead; a tag (e.g. v2, v2.1.0) is stable and useful as-is.
+  const ref = /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef;
 
   // Group by ruleType, preserving order of first appearance
   const groups = new Map();
@@ -28,7 +34,7 @@ export function buildRestrictExample(auditedRows, actionRepo) {
   // Build YAML lines
   let yaml = "";
   yaml += "- name: Start Buildcage in restrict mode\n";
-  yaml += `  uses: ${actionRepo}/setup@v2\n`;
+  yaml += `  uses: ${actionRepo}/setup@${ref}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";
   for (const [param, rules] of groups) {

--- a/report/src/lib/build-example.test.js
+++ b/report/src/lib/build-example.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { buildRestrictExample } from "./build-example.js";
 
 const REPO = "dash14/buildcage";
+const REF = "v2";
 
 function wrap(yaml) {
   return (
@@ -31,11 +32,11 @@ describe("buildRestrictExample", () => {
       { host: "github.com", port: "443", ruleType: "HTTPS", count: 2 },
     ];
     assert.equal(
-      buildRestrictExample(rows, REPO),
+      buildRestrictExample(rows, REPO, REF),
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
-          `  uses: ${REPO}/setup@v2`,
+          `  uses: ${REPO}/setup@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
           "    allowed_https_rules: >-",
@@ -52,11 +53,11 @@ describe("buildRestrictExample", () => {
       { host: "deb.debian.org", port: "80", ruleType: "HTTP", count: 1 },
     ];
     assert.equal(
-      buildRestrictExample(rows, REPO),
+      buildRestrictExample(rows, REPO, REF),
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
-          `  uses: ${REPO}/setup@v2`,
+          `  uses: ${REPO}/setup@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
           "    allowed_https_rules: >-",
@@ -73,11 +74,11 @@ describe("buildRestrictExample", () => {
       { host: "192.168.1.1", port: "443", ruleType: "IP", count: 1 },
     ];
     assert.equal(
-      buildRestrictExample(rows, REPO),
+      buildRestrictExample(rows, REPO, REF),
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
-          `  uses: ${REPO}/setup@v2`,
+          `  uses: ${REPO}/setup@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
           "    allowed_ip_rules: >-",
@@ -94,11 +95,11 @@ describe("buildRestrictExample", () => {
       { host: "10.0.0.1", port: "8080", ruleType: "IP", count: 1 },
     ];
     assert.equal(
-      buildRestrictExample(rows, REPO),
+      buildRestrictExample(rows, REPO, REF),
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
-          `  uses: ${REPO}/setup@v2`,
+          `  uses: ${REPO}/setup@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
           "    allowed_https_rules: >-",
@@ -117,11 +118,50 @@ describe("buildRestrictExample", () => {
       { host: "example.com", port: "443", ruleType: "HTTPS", count: 1 },
     ];
     assert.equal(
-      buildRestrictExample(rows, "myorg/myrepo"),
+      buildRestrictExample(rows, "myorg/myrepo", REF),
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
-          "  uses: myorg/myrepo/setup@v2",
+          `  uses: myorg/myrepo/setup@${REF}`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      example.com:443",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+
+  it("renders a tag actionRef as-is", () => {
+    const rows = [
+      { host: "example.com", port: "443", ruleType: "HTTPS", count: 1 },
+    ];
+    assert.equal(
+      buildRestrictExample(rows, REPO, "v2.1.0"),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          `  uses: ${REPO}/setup@v2.1.0`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      example.com:443",
+        ].join("\n") + "\n",
+      )
+    );
+  });
+
+  it("renders a commit SHA actionRef as a <sha> placeholder", () => {
+    const rows = [
+      { host: "example.com", port: "443", ruleType: "HTTPS", count: 1 },
+    ];
+    const sha = "abc1234567890def1234567890abcdef12345678";
+    assert.equal(
+      buildRestrictExample(rows, REPO, sha),
+      wrap(
+        [
+          "- name: Start Buildcage in restrict mode",
+          `  uses: ${REPO}/setup@<sha>`,
           "  with:",
           "    proxy_mode: restrict",
           "    allowed_https_rules: >-",

--- a/report/src/main.js
+++ b/report/src/main.js
@@ -83,6 +83,7 @@ function markdownTable(rows, { showReason = false } = {}) {
 }
 
 const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage";
+const actionRef = process.env.GITHUB_ACTION_REF || "v2";
 const isAudit = report.mode === "audit";
 
 // report.deniedTimeline is only present in explicit engine's report.js output
@@ -132,7 +133,7 @@ if (isAudit) {
   if (audited.length > 0) {
     markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n";
   }
-  markdown += buildRestrictExample(audited, actionRepo);
+  markdown += buildRestrictExample(audited, actionRepo, actionRef);
   const blocked = report.sections.blocked || [];
   if (blocked.length > 0) {
     if (audited.length > 0) markdown += "\n";


### PR DESCRIPTION
## Summary

The restrict-mode YAML example in the Job Summary (\`report\` action's "Switch to restrict mode" block) hardcoded \`setup@v2\` regardless of which ref actually invoked the action, so it drifted out of sync as soon as a newer version was released.

## Changes

- Read \`GITHUB_ACTION_REF\` in \`report/src/main.js\` and pass it through to \`buildRestrictExample\`
- \`buildRestrictExample\` now renders the invoking ref in the \`uses:\` line: a tag/branch (e.g. \`v2.1.0\`) is shown as-is, while a 40-char commit SHA is shown as a \`<sha>\` placeholder since the raw hash isn't meaningful to the reader