### PR TITLE
feat: make explicit the default proxy engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,34 +17,8 @@ clean: ## Clean up all resources
 
 # ---------------------------------------------------------------------------
 # run_{engine}_{mode}_mode — start the builder only (no build/verify/cleanup).
-# One target per (transparent, explicit) x (audit, restrict) combination.
+# One target per (explicit, transparent) x (audit, restrict) combination.
 # ---------------------------------------------------------------------------
-
-.PHONY: run_transparent_audit_mode
-run_transparent_audit_mode: ## Start transparent engine in audit mode
-	@echo "Starting buildcage (transparent engine) in AUDIT mode..."
-	@COMPOSE_FILE=$(COMPOSE_FILE) \
-	  PROXY_MODE=audit \
-	  docker compose up -d --wait --build
-	@docker buildx rm buildcage 2>/dev/null || true
-	@echo "Creating buildx builder..."
-	@docker buildx create --bootstrap \
-		--name buildcage \
-		--driver remote docker-container://buildcage
-
-.PHONY: run_transparent_restrict_mode
-run_transparent_restrict_mode: ## Start transparent engine in restrict mode
-	@echo "Starting buildcage (transparent engine) in RESTRICT mode..."
-	@COMPOSE_FILE=$(COMPOSE_FILE) \
-	  PROXY_MODE=restrict \
-	  ALLOWED_HTTP_RULES="$${ALLOWED_HTTP_RULES:-}" \
-	  ALLOWED_HTTPS_RULES="$${ALLOWED_HTTPS_RULES:-github.com:443 registry.npmjs.org:443 api.github.com:443 objects.githubusercontent.com:443 httpbin.org:443 deb.debian.org:80 *.githubusercontent.com:443}" \
-	  docker compose up -d --wait --build
-	@docker buildx rm buildcage 2>/dev/null || true
-	@echo "Creating buildx builder..."
-	@docker buildx create --bootstrap \
-		--name buildcage \
-		--driver remote docker-container://buildcage
 
 .PHONY: run_explicit_audit_mode
 run_explicit_audit_mode: ## Start explicit proxy engine in audit mode
@@ -74,38 +48,36 @@ run_explicit_restrict_mode: ## Start explicit proxy engine in restrict mode
 		--name buildcage \
 		--driver remote docker-container://buildcage
 
+.PHONY: run_transparent_audit_mode
+run_transparent_audit_mode: ## Start transparent engine in audit mode
+	@echo "Starting buildcage (transparent engine) in AUDIT mode..."
+	@COMPOSE_FILE=$(COMPOSE_FILE) \
+	  PROXY_MODE=audit \
+	  docker compose up -d --wait --build
+	@docker buildx rm buildcage 2>/dev/null || true
+	@echo "Creating buildx builder..."
+	@docker buildx create --bootstrap \
+		--name buildcage \
+		--driver remote docker-container://buildcage
+
+.PHONY: run_transparent_restrict_mode
+run_transparent_restrict_mode: ## Start transparent engine in restrict mode
+	@echo "Starting buildcage (transparent engine) in RESTRICT mode..."
+	@COMPOSE_FILE=$(COMPOSE_FILE) \
+	  PROXY_MODE=restrict \
+	  ALLOWED_HTTP_RULES="$${ALLOWED_HTTP_RULES:-}" \
+	  ALLOWED_HTTPS_RULES="$${ALLOWED_HTTPS_RULES:-github.com:443 registry.npmjs.org:443 api.github.com:443 objects.githubusercontent.com:443 httpbin.org:443 deb.debian.org:80 *.githubusercontent.com:443}" \
+	  docker compose up -d --wait --build
+	@docker buildx rm buildcage 2>/dev/null || true
+	@echo "Creating buildx builder..."
+	@docker buildx create --bootstrap \
+		--name buildcage \
+		--driver remote docker-container://buildcage
+
 # ---------------------------------------------------------------------------
 # test_{engine}_{mode}_mode — run_{engine}_{mode}_mode + build the matching
 # test/Dockerfile.* + verify + clean up. One target per combination.
 # ---------------------------------------------------------------------------
-
-.PHONY: test_transparent_audit_mode
-test_transparent_audit_mode: ## Run transparent-engine audit mode tests
-	@echo "Running transparent-engine audit mode tests..."
-	@COMPOSE_FILE=compose.yaml:compose.test-transparent.yaml \
-	  $(MAKE) run_transparent_audit_mode
-	@docker buildx build --no-cache \
-	  --builder buildcage \
-	  --platform linux/arm64 \
-	  --progress=plain -f test/Dockerfile.transparent-audit test/ \
-	  --load -t buildcage-test
-	@node report/src/main.js ./compose.yaml
-	@./test/assert-transparent-audit.sh
-	@$(MAKE) clean
-
-.PHONY: test_transparent_restrict_mode
-test_transparent_restrict_mode: ## Run transparent-engine restrict mode tests
-	@echo "Running transparent-engine restrict mode tests..."
-	@COMPOSE_FILE=compose.yaml:compose.test-transparent.yaml \
-	  $(MAKE) run_transparent_restrict_mode
-	@docker buildx build --no-cache \
-	  --builder buildcage \
-	  --platform linux/arm64 \
-	  --progress=plain -f test/Dockerfile.transparent-restrict test/ \
-	  --load -t buildcage-test
-	@node report/src/main.js ./compose.yaml || true
-	@./test/assert-transparent-restrict.sh
-	@$(MAKE) clean
 
 .PHONY: test_explicit_audit_mode
 test_explicit_audit_mode: ## Run explicit-engine audit mode tests
@@ -134,6 +106,34 @@ test_explicit_restrict_mode: ## Run explicit-engine restrict mode tests
 	@PROXY_ENGINE=explicit node report/src/main.js ./compose.yaml || true
 	@./test/assert-explicit-restrict.sh
 	@TEST_COMPOSE_FILE=compose.test-explicit.yaml $(MAKE) clean
+
+.PHONY: test_transparent_audit_mode
+test_transparent_audit_mode: ## Run transparent-engine audit mode tests
+	@echo "Running transparent-engine audit mode tests..."
+	@COMPOSE_FILE=compose.yaml:compose.test-transparent.yaml \
+	  $(MAKE) run_transparent_audit_mode
+	@docker buildx build --no-cache \
+	  --builder buildcage \
+	  --platform linux/arm64 \
+	  --progress=plain -f test/Dockerfile.transparent-audit test/ \
+	  --load -t buildcage-test
+	@node report/src/main.js ./compose.yaml
+	@./test/assert-transparent-audit.sh
+	@$(MAKE) clean
+
+.PHONY: test_transparent_restrict_mode
+test_transparent_restrict_mode: ## Run transparent-engine restrict mode tests
+	@echo "Running transparent-engine restrict mode tests..."
+	@COMPOSE_FILE=compose.yaml:compose.test-transparent.yaml \
+	  $(MAKE) run_transparent_restrict_mode
+	@docker buildx build --no-cache \
+	  --builder buildcage \
+	  --platform linux/arm64 \
+	  --progress=plain -f test/Dockerfile.transparent-restrict test/ \
+	  --load -t buildcage-test
+	@node report/src/main.js ./compose.yaml || true
+	@./test/assert-transparent-restrict.sh
+	@$(MAKE) clean
 
 .PHONY: test_unit
 test_unit: test_setup test_report test_qjs ## Run unit tests

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ services:
     container_name: ${BUILDER_NAME:-buildcage}
     build:
       context: docker
-      dockerfile: ${PROXY_ENGINE:-transparent}/Dockerfile
+      dockerfile: ${PROXY_ENGINE:-explicit}/Dockerfile
     # Instead of privileged: true, grant only the minimum privileges required
     # to run BuildKit and iptables. This avoids granting full device access
     # and unrestricted /sys write permissions that privileged mode includes.
@@ -34,5 +34,5 @@ services:
       - ALLOWED_HTTP_RULES=${ALLOWED_HTTP_RULES:-}
       - ALLOWED_IP_RULES=${ALLOWED_IP_RULES:-}
       - EXTERNAL_RESOLVER=${EXTERNAL_RESOLVER:-}
-      - PROXY_ENGINE=${PROXY_ENGINE:-transparent}
+      - PROXY_ENGINE=${PROXY_ENGINE:-explicit}
     restart: unless-stopped

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -11,9 +11,9 @@ inputs:
     required: false
     default: 'restrict'
   proxy_engine:
-    description: "Network enforcement engine: transparent (HAProxy/dnsmasq/iptables interception) or explicit (BuildKit's native --proxy-network)"
+    description: "Network enforcement engine: explicit (BuildKit's native --proxy-network) or transparent (HAProxy/dnsmasq/iptables interception)"
     required: false
-    default: 'transparent'
+    default: 'explicit'
   allowed_https_rules:
     description: "HTTPS allow rules (wildcard or ~regex), separated by whitespace. Port required. e.g., '*.example.com:443 ~^custom\\.pattern:443$'"
     required: false

--- a/setup/compose.yaml
+++ b/setup/compose.yaml
@@ -30,5 +30,5 @@ services:
       - ALLOWED_HTTP_RULES=${ALLOWED_HTTP_RULES:-}
       - ALLOWED_IP_RULES=${ALLOWED_IP_RULES:-}
       - EXTERNAL_RESOLVER=${EXTERNAL_RESOLVER:-}
-      - PROXY_ENGINE=${PROXY_ENGINE:-transparent}
+      - PROXY_ENGINE=${PROXY_ENGINE:-explicit}
     restart: unless-stopped

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -7088,14 +7088,14 @@ async function verifyBundle(bundleJson, options, expectedDigest) {
 
 const OID_SOURCE_REPO_DIGEST = "1.3.6.1.4.1.57264.1.13", escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-function imageTagFromRef(actionRef, proxyEngine = "transparent") {
+function imageTagFromRef(actionRef, proxyEngine = "explicit") {
   if (!actionRef) return "";
   let base;
   return base = /^[0-9a-f]{40}$/i.test(actionRef) ? `sha-${actionRef.toLowerCase()}` : actionRef.startsWith("v") ? actionRef.slice(1) : actionRef, 
   `${base}-${proxyEngine}`;
 }
 
-async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine = "transparent"}) {
+async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine = "explicit"}) {
   const repoPath = actionRepo.toLowerCase(), verifyOptions = function({actionRef: actionRef, actionRepo: actionRepo}) {
     const sanPrefix = `^${escapeRegex(`https://github.com/${actionRepo}/.github/workflows/docker-publish.yml@refs/tags/`)}`, base = {
       certificateIssuer: "https://token.actions.githubusercontent.com",
@@ -7232,7 +7232,7 @@ async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo, 
 
 const __dirname$1 = path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = path.join(__dirname$1, "../compose.yaml");
 
-function resolveBuildcageImageRef({imageDigest: imageDigest, actionRepository: actionRepository, actionRef: actionRef, proxyEngine: proxyEngine = "transparent"}, _exec = node_child_process.execFileSync) {
+function resolveBuildcageImageRef({imageDigest: imageDigest, actionRepository: actionRepository, actionRef: actionRef, proxyEngine: proxyEngine = "explicit"}, _exec = node_child_process.execFileSync) {
   const repository = `ghcr.io/${actionRepository}`.toLowerCase();
   if (imageDigest) return `${repository}@${imageDigest}`;
   return `${repository}:${resolveImageTag(repository, {
@@ -7241,7 +7241,7 @@ function resolveBuildcageImageRef({imageDigest: imageDigest, actionRepository: a
   }, _exec)}`;
 }
 
-function resolveImageTag(repository, {actionRef: actionRef, proxyEngine: proxyEngine = "transparent"}, _exec = node_child_process.execFileSync) {
+function resolveImageTag(repository, {actionRef: actionRef, proxyEngine: proxyEngine = "explicit"}, _exec = node_child_process.execFileSync) {
   const attemptedTag = actionRef ? imageTagFromRef(actionRef, proxyEngine) : void 0;
   if (actionRef) try {
     return _exec("docker", [ "manifest", "inspect", `${repository}:${attemptedTag}` ], {
@@ -7252,7 +7252,7 @@ function resolveImageTag(repository, {actionRef: actionRef, proxyEngine: proxyEn
 }
 
 function resolveProxyEngine(input) {
-  const engine = input?.trim() || "transparent";
+  const engine = input?.trim() || "explicit";
   if ("transparent" !== engine && "explicit" !== engine) throw new SetupError(`Invalid proxy_engine: ${JSON.stringify(input)}. Must be "transparent" or "explicit".`, "INVALID_PROXY_ENGINE");
   return engine;
 }

--- a/setup/src/lib/verify-image.js
+++ b/setup/src/lib/verify-image.js
@@ -25,11 +25,11 @@ const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 /**
  * Convert an action ref into the base Docker image tag, then append the
  * proxy engine suffix. Each release publishes one image per engine
- * (e.g. `2.1.0-transparent` / `2.1.0-explicit`) sharing the same Sigstore
+ * (e.g. `2.1.0-explicit` / `2.1.0-transparent`) sharing the same Sigstore
  * verification identity (same workflow, same git ref) — only the published
  * Docker tag differs, so this does not affect buildVerifyOptions below.
  */
-export function imageTagFromRef(actionRef, proxyEngine = "transparent") {
+export function imageTagFromRef(actionRef, proxyEngine = "explicit") {
   if (!actionRef) return "";
   let base;
   if (/^[0-9a-f]{40}$/i.test(actionRef)) {
@@ -94,7 +94,7 @@ export function buildVerifyOptions({ actionRef, actionRepo }) {
  *
  * @param {{ actionRef: string, actionRepo: string, proxyEngine?: string }} opts
  */
-export async function verifyImageDigest({ actionRef, actionRepo, proxyEngine = "transparent" }) {
+export async function verifyImageDigest({ actionRef, actionRepo, proxyEngine = "explicit" }) {
   const repoPath = actionRepo.toLowerCase();
 
   const verifyOptions = buildVerifyOptions({ actionRef, actionRepo });

--- a/setup/src/lib/verify-image.test.js
+++ b/setup/src/lib/verify-image.test.js
@@ -33,26 +33,26 @@ function makeSAN(ref) {
 // ── imageTagFromRef ───────────────────────────────────────────────────────────
 
 describe("imageTagFromRef", () => {
-  it("converts a 40-char hex SHA to sha-<sha>-transparent by default", () => {
+  it("converts a 40-char hex SHA to sha-<sha>-explicit by default", () => {
     const sha = "a".repeat(40);
-    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}-transparent`);
+    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}-explicit`);
   });
 
   it("lowercases the SHA", () => {
     const sha = "ABCDEF1234".padEnd(40, "0");
-    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}-transparent`);
+    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}-explicit`);
   });
 
   it("strips leading 'v' from a version tag", () => {
-    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0-transparent");
+    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0-explicit");
   });
 
   it("strips 'v' from a major-only tag", () => {
-    assert.equal(imageTagFromRef("v2"), "2-transparent");
+    assert.equal(imageTagFromRef("v2"), "2-explicit");
   });
 
   it("returns a branch name as-is, with the engine suffix", () => {
-    assert.equal(imageTagFromRef("main"), "main-transparent");
+    assert.equal(imageTagFromRef("main"), "main-explicit");
   });
 
   it("returns empty string for empty input", () => {
@@ -63,9 +63,9 @@ describe("imageTagFromRef", () => {
     assert.equal(imageTagFromRef(undefined), "");
   });
 
-  it("appends the explicit engine suffix instead when requested", () => {
-    assert.equal(imageTagFromRef("v2.1.0", "explicit"), "2.1.0-explicit");
-    assert.equal(imageTagFromRef("a".repeat(40), "explicit"), `sha-${"a".repeat(40)}-explicit`);
+  it("appends the transparent engine suffix instead when requested", () => {
+    assert.equal(imageTagFromRef("v2.1.0", "transparent"), "2.1.0-transparent");
+    assert.equal(imageTagFromRef("a".repeat(40), "transparent"), `sha-${"a".repeat(40)}-transparent`);
   });
 });
 

--- a/setup/src/main.js
+++ b/setup/src/main.js
@@ -100,7 +100,7 @@ async function main() {
  * The repository is always derived from the action repository — external image
  * overrides are intentionally not supported to preserve Sigstore verification integrity.
  */
-export function resolveBuildcageImageRef({ imageDigest, actionRepository, actionRef, proxyEngine = "transparent" }, _exec = execFileSync) {
+export function resolveBuildcageImageRef({ imageDigest, actionRepository, actionRef, proxyEngine = "explicit" }, _exec = execFileSync) {
   const repository = `ghcr.io/${actionRepository}`.toLowerCase();
   if (imageDigest) {
     // Pull by verified digest to close the TOCTOU window between verification and docker pull.
@@ -115,7 +115,7 @@ export function resolveBuildcageImageRef({ imageDigest, actionRepository, action
  * Throws if the ref cannot be resolved to an existing image tag.
  * Used only when no verified digest is available (branch/local references).
  */
-export function resolveImageTag(repository, { actionRef, proxyEngine = "transparent" }, _exec = execFileSync) {
+export function resolveImageTag(repository, { actionRef, proxyEngine = "explicit" }, _exec = execFileSync) {
   const attemptedTag = actionRef ? imageTagFromRef(actionRef, proxyEngine) : undefined;
   if (actionRef) {
     try {
@@ -141,11 +141,11 @@ export function resolveImageTag(repository, { actionRef, proxyEngine = "transpar
 
 /**
  * Resolve and validate the proxy_engine input.
- * Only "transparent" (default) and "explicit" are accepted — each maps to a
+ * Only "explicit" (default) and "transparent" are accepted — each maps to a
  * separately published, separately tagged Docker image (see resolveImageTag).
  */
 export function resolveProxyEngine(input) {
-  const engine = input?.trim() || "transparent";
+  const engine = input?.trim() || "explicit";
   if (engine !== "transparent" && engine !== "explicit") {
     throw new SetupError(
       `Invalid proxy_engine: ${JSON.stringify(input)}. Must be "transparent" or "explicit".`,

--- a/setup/src/main.property.test.js
+++ b/setup/src/main.property.test.js
@@ -52,12 +52,12 @@ describe("imageTagFromRef – properties", () => {
     );
   });
 
-  it("defaults to the transparent engine suffix when no engine is given", () => {
+  it("defaults to the explicit engine suffix when no engine is given", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 0, maxLength: 50 }).map((s) => `g${s}`),
         (ref) => {
-          assert.equal(imageTagFromRef(ref), `${ref}-transparent`);
+          assert.equal(imageTagFromRef(ref), `${ref}-explicit`);
         },
       ),
     );

--- a/setup/src/main.test.js
+++ b/setup/src/main.test.js
@@ -23,30 +23,30 @@ const execFail = () => { throw new Error("manifest not found"); };
 // ---------------------------------------------------------------------------
 
 describe("resolveImageTag", () => {
-  it("converts a 40-char hex SHA to sha-<sha>-transparent by default", () => {
+  it("converts a 40-char hex SHA to sha-<sha>-explicit by default", () => {
     const sha = "a".repeat(40);
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: sha }, execOk);
-    assert.equal(result, `sha-${"a".repeat(40)}-transparent`);
+    assert.equal(result, `sha-${"a".repeat(40)}-explicit`);
   });
 
   it("strips leading 'v' from a version tag", () => {
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "v2.1.0" }, execOk);
-    assert.equal(result, "2.1.0-transparent");
+    assert.equal(result, "2.1.0-explicit");
   });
 
   it("strips leading 'v' from a major-only tag", () => {
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "v3" }, execOk);
-    assert.equal(result, "3-transparent");
+    assert.equal(result, "3-explicit");
   });
 
   it("uses branch name as-is when image exists", () => {
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "main" }, execOk);
-    assert.equal(result, "main-transparent");
+    assert.equal(result, "main-explicit");
   });
 
-  it("uses the explicit engine suffix when requested", () => {
-    const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "v2.1.0", proxyEngine: "explicit" }, execOk);
-    assert.equal(result, "2.1.0-explicit");
+  it("uses the transparent engine suffix when requested", () => {
+    const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "v2.1.0", proxyEngine: "transparent" }, execOk);
+    assert.equal(result, "2.1.0-transparent");
   });
 
   it("throws when docker manifest inspect fails (tag not found)", () => {
@@ -73,7 +73,7 @@ describe("resolveImageTag", () => {
   it("lowercases a SHA-derived tag", () => {
     const sha = "ABCDEF1234".padEnd(40, "0");
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: sha }, execOk);
-    assert.equal(result, `sha-${sha.toLowerCase()}-transparent`);
+    assert.equal(result, `sha-${sha.toLowerCase()}-explicit`);
   });
 });
 
@@ -105,7 +105,7 @@ describe("resolveBuildcageImageRef", () => {
       { imageDigest: "", actionRepository: "owner/repo", actionRef: "v2.1.0" },
       execOk
     );
-    assert.equal(result, "ghcr.io/owner/repo:2.1.0-transparent");
+    assert.equal(result, "ghcr.io/owner/repo:2.1.0-explicit");
   });
 
   it("falls back to tag reference when imageDigest is undefined", () => {
@@ -113,15 +113,15 @@ describe("resolveBuildcageImageRef", () => {
       { imageDigest: undefined, actionRepository: "owner/repo", actionRef: "v2.1.0" },
       execOk
     );
-    assert.equal(result, "ghcr.io/owner/repo:2.1.0-transparent");
+    assert.equal(result, "ghcr.io/owner/repo:2.1.0-explicit");
   });
 
-  it("uses the explicit engine's tag suffix when requested", () => {
+  it("uses the transparent engine's tag suffix when requested", () => {
     const result = resolveBuildcageImageRef(
-      { imageDigest: undefined, actionRepository: "owner/repo", actionRef: "v2.1.0", proxyEngine: "explicit" },
+      { imageDigest: undefined, actionRepository: "owner/repo", actionRef: "v2.1.0", proxyEngine: "transparent" },
       execOk
     );
-    assert.equal(result, "ghcr.io/owner/repo:2.1.0-explicit");
+    assert.equal(result, "ghcr.io/owner/repo:2.1.0-transparent");
   });
 
   it("always derives repository from actionRepository (no external override)", () => {
@@ -148,12 +148,12 @@ describe("resolveBuildcageImageRef", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveProxyEngine", () => {
-  it("defaults to transparent for undefined", () => {
-    assert.equal(resolveProxyEngine(undefined), "transparent");
+  it("defaults to explicit for undefined", () => {
+    assert.equal(resolveProxyEngine(undefined), "explicit");
   });
 
-  it("defaults to transparent for empty string", () => {
-    assert.equal(resolveProxyEngine(""), "transparent");
+  it("defaults to explicit for empty string", () => {
+    assert.equal(resolveProxyEngine(""), "explicit");
   });
 
   it("accepts transparent explicitly", () => {


### PR DESCRIPTION
## Summary

`proxy_engine` defaulted to `transparent`, but `explicit` (BuildKit's native `--proxy-network`) is now the recommended engine going forward — it gives finer-grained, BuildKit-integrated visibility for cooperative build tools without buildcage's own CNI/DNS-redirect/HAProxy stack. This PR flips the default so new users get `explicit` unless they opt into `transparent`.

## Changes

- `setup/action.yml`: `proxy_engine` input now defaults to `explicit`
- `compose.yaml`, `setup/compose.yaml`: `PROXY_ENGINE` fallback changed from `transparent` to `explicit`
- `setup/src/main.js`, `setup/src/lib/verify-image.js`: default `proxyEngine` parameter values changed from `"transparent"` to `"explicit"` (`resolveProxyEngine`, `resolveBuildcageImageRef`, `resolveImageTag`, `imageTagFromRef`, `verifyImageDigest`)
- `setup/dist/main.cjs`: rebuilt from source
- `setup/src/main.test.js`, `setup/src/main.property.test.js`, `setup/src/lib/verify-image.test.js`: updated default-value assertions to `explicit`, and re-pointed the "requested engine" test cases at `transparent`
- `Makefile`: reordered the `run_{engine}_{mode}_mode` / `test_{engine}_{mode}_mode` targets so `explicit` comes first, matching `make help`'s output order to the new default