### PR TITLE
Drop the -transparent Docker tag suffix and mark the explicit engine as experimental

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -82,12 +82,14 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
-          # latest=false: an unsuffixed "latest" would be ambiguous (and racy)
-          # across the two engine matrix legs, since each pushes its own image.
-          flavor: latest=false
+          # transparent (default) publishes the plain version tag, matching the
+          # pre-multi-engine tagging scheme; explicit (experimental) publishes
+          # under a -explicit suffix. Only transparent claims "latest", since it's
+          # the only engine with an unsuffixed tag namespace.
+          flavor: latest=${{ matrix.engine == 'transparent' }}
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }},suffix=-${{ matrix.engine }}
-            type=raw,value=sha-${{ steps.version.outputs.sha }}-${{ matrix.engine }},priority=100
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}${{ matrix.engine == 'explicit' && ',suffix=-explicit' || '' }}
+            type=raw,value=sha-${{ steps.version.outputs.sha }}${{ matrix.engine == 'explicit' && '-explicit' || '' }},priority=100
 
       - name: Login to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -171,8 +173,8 @@ jobs:
           BUNDLE_EXPLICIT: ${{ needs.build-and-push.outputs['bundle-content-explicit'] }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "$BUNDLE_TRANSPARENT" > buildcage-container-transparent.sigstore.json
+          echo "$BUNDLE_TRANSPARENT" > buildcage-container.sigstore.json
           echo "$BUNDLE_EXPLICIT" > buildcage-container-explicit.sigstore.json
           gh release upload --repo "$GITHUB_REPOSITORY" "$TAG" \
-            buildcage-container-transparent.sigstore.json \
+            buildcage-container.sigstore.json \
             buildcage-container-explicit.sigstore.json

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -67,14 +67,19 @@ jobs:
           LATEST_IN_MAJOR=$(echo "$TAGS" | grep -E "^v${MAJOR#v}\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
           LATEST_IN_MINOR=$(echo "$TAGS" | grep -E "^v${MINOR}\.[0-9]+$" | sort -V | tail -1)
 
-          # Each release publishes one image per proxy engine
-          # (e.g. ${VERSION}-transparent, ${VERSION}-explicit); update the
-          # floating major/minor tag for each engine independently.
+          # Each release publishes one image per proxy engine. transparent
+          # (default) uses the plain version tag (e.g. ${VERSION}); explicit
+          # (experimental) uses a -explicit suffix (e.g. ${VERSION}-explicit).
+          # Update the floating major/minor tag for each engine independently.
           for ENGINE in transparent explicit; do
+            SUFFIX=""
+            if [ "$ENGINE" = "explicit" ]; then
+              SUFFIX="-explicit"
+            fi
             if [ "$TAG" = "$LATEST_IN_MINOR" ]; then
-              docker buildx imagetools create --tag "${REPO}:${MINOR}-${ENGINE}" "${REPO}:${VERSION}-${ENGINE}"
+              docker buildx imagetools create --tag "${REPO}:${MINOR}${SUFFIX}" "${REPO}:${VERSION}${SUFFIX}"
             fi
             if [ "$TAG" = "$LATEST_IN_MAJOR" ]; then
-              docker buildx imagetools create --tag "${REPO}:${MAJOR#v}-${ENGINE}" "${REPO}:${VERSION}-${ENGINE}"
+              docker buildx imagetools create --tag "${REPO}:${MAJOR#v}${SUFFIX}" "${REPO}:${VERSION}${SUFFIX}"
             fi
           done

--- a/README.md
+++ b/README.md
@@ -199,10 +199,6 @@ Starts the Buildcage builder container.
 > External image overrides are not supported to preserve this guarantee. For best security, pin the
 > action to a commit SHA: `uses: dash14/buildcage/setup@<40-char-sha> # vX.Y.Z`
 >
-> Each release publishes one image per `proxy_engine` value, tagged with an engine suffix
-> (e.g. `v2.2.0-transparent`, `v2.2.0-explicit`). The `setup` action resolves the correct tag
-> automatically based on the `proxy_engine` parameter — you never need to reference these tags directly.
->
 > Self-hosting with a custom image requires forking the repository. See the [Self-Hosting Guide](./docs/self-hosting.md).
 > If the action package is private (self-hosted in a private repository), run
 > [`docker/login-action`](https://github.com/docker/login-action) with `packages: read` before this
@@ -275,7 +271,7 @@ syntax — switching engines never requires rewriting your allowlist.
 <td>Domain-level, for every connection regardless of whether the tool in the <code>RUN</code> step is proxy-aware</td>
 </tr>
 <tr>
-<td><code>explicit</code></td>
+<td><code>explicit</code> (experimental)</td>
 <td>BuildKit's native <code>--proxy-network</code>: injects <code>HTTP_PROXY</code>/<code>HTTPS_PROXY</code> and a generated CA into the <code>RUN</code> step, then MITMs the traffic</td>
 <td>Full URL/path-level, integrated into BuildKit's own build output and SLSA provenance — but only for tools that respect <code>HTTP_PROXY</code>. Non-proxy-aware tools are blocked with no visibility (see [Explicit Proxy Engine](./docs/security.md#explicit-proxy-engine))</td>
 </tr>
@@ -283,7 +279,11 @@ syntax — switching engines never requires rewriting your allowlist.
 </table>
 
 Use `transparent` (the default) unless you specifically need path-level provenance for cooperative
-tools and can accept reduced visibility into non-cooperative ones.
+tools and can accept reduced visibility into non-cooperative ones. `explicit` is experimental: its
+underlying BuildKit feature (`--proxy-network`) is still maturing, and some tools (e.g. npm) don't
+consult the injected CA even when they respect `HTTP_PROXY`, causing TLS errors. See
+[Explicit Proxy Engine](./docs/security.md#explicit-proxy-engine) for known limitations before
+relying on it.
 
 #### Usage notes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -106,6 +106,12 @@ Given these implementation costs versus the strict preconditions for the attack 
 
 ## Explicit Proxy Engine
 
+> [!WARNING]
+> `explicit` is an **experimental** engine. Its underlying BuildKit feature (`--proxy-network`) is
+> still maturing, and it has structural limitations not present in the `transparent` engine — see
+> [Coverage and known limitations](#coverage-and-known-limitations) below before relying on it.
+> `transparent` remains the default and recommended engine.
+
 `proxy_engine: explicit` uses BuildKit's native `--proxy-network` (available since moby/buildkit
 v0.31.0) instead of the CNI/DNS-redirect/HAProxy stack described above. This section covers how it
 works and what changes versus the `transparent` engine.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -37,7 +37,7 @@ To trigger the build:
 Once complete, the images will be available at:
 
 ```
-ghcr.io/<your_org>/buildcage:<version>-transparent
+ghcr.io/<your_org>/buildcage:<version>
 ghcr.io/<your_org>/buildcage:<version>-explicit
 ```
 

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: 'restrict'
   proxy_engine:
-    description: "Network enforcement engine: transparent (HAProxy/dnsmasq/iptables interception) or explicit (BuildKit's native --proxy-network)"
+    description: "Network enforcement engine: transparent (transparent proxy, default) or explicit (BuildKit's native --proxy-network; experimental, see docs/security.md)"
     required: false
     default: 'transparent'
   allowed_https_rules:

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -7092,7 +7092,7 @@ function imageTagFromRef(actionRef, proxyEngine = "transparent") {
   if (!actionRef) return "";
   let base;
   return base = /^[0-9a-f]{40}$/i.test(actionRef) ? `sha-${actionRef.toLowerCase()}` : actionRef.startsWith("v") ? actionRef.slice(1) : actionRef, 
-  `${base}-${proxyEngine}`;
+  "explicit" === proxyEngine ? `${base}-explicit` : base;
 }
 
 async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine = "transparent"}) {

--- a/setup/src/lib/verify-image.js
+++ b/setup/src/lib/verify-image.js
@@ -24,10 +24,13 @@ const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 /**
  * Convert an action ref into the base Docker image tag, then append the
- * proxy engine suffix. Each release publishes one image per engine
- * (e.g. `2.1.0-transparent` / `2.1.0-explicit`) sharing the same Sigstore
- * verification identity (same workflow, same git ref) — only the published
- * Docker tag differs, so this does not affect buildVerifyOptions below.
+ * proxy engine suffix for non-default engines. The `transparent` engine
+ * (default) publishes the plain version tag (e.g. `2.1.0`), matching the
+ * pre-multi-engine tagging scheme; the `explicit` engine, being experimental,
+ * publishes under a `-explicit` suffix (e.g. `2.1.0-explicit`). Both share the
+ * same Sigstore verification identity (same workflow, same git ref) — only
+ * the published Docker tag differs, so this does not affect
+ * buildVerifyOptions below.
  */
 export function imageTagFromRef(actionRef, proxyEngine = "transparent") {
   if (!actionRef) return "";
@@ -39,7 +42,7 @@ export function imageTagFromRef(actionRef, proxyEngine = "transparent") {
   } else {
     base = actionRef;
   }
-  return `${base}-${proxyEngine}`;
+  return proxyEngine === "explicit" ? `${base}-explicit` : base;
 }
 
 /**

--- a/setup/src/lib/verify-image.test.js
+++ b/setup/src/lib/verify-image.test.js
@@ -33,26 +33,26 @@ function makeSAN(ref) {
 // ── imageTagFromRef ───────────────────────────────────────────────────────────
 
 describe("imageTagFromRef", () => {
-  it("converts a 40-char hex SHA to sha-<sha>-transparent by default", () => {
+  it("converts a 40-char hex SHA to sha-<sha> by default (no suffix for transparent)", () => {
     const sha = "a".repeat(40);
-    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}-transparent`);
+    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}`);
   });
 
   it("lowercases the SHA", () => {
     const sha = "ABCDEF1234".padEnd(40, "0");
-    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}-transparent`);
+    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}`);
   });
 
   it("strips leading 'v' from a version tag", () => {
-    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0-transparent");
+    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0");
   });
 
   it("strips 'v' from a major-only tag", () => {
-    assert.equal(imageTagFromRef("v2"), "2-transparent");
+    assert.equal(imageTagFromRef("v2"), "2");
   });
 
-  it("returns a branch name as-is, with the engine suffix", () => {
-    assert.equal(imageTagFromRef("main"), "main-transparent");
+  it("returns a branch name as-is, with no suffix for the default engine", () => {
+    assert.equal(imageTagFromRef("main"), "main");
   });
 
   it("returns empty string for empty input", () => {

--- a/setup/src/main.property.test.js
+++ b/setup/src/main.property.test.js
@@ -14,50 +14,54 @@ import { buildACLRules, resolveBuildcageImageRef, resolveProxyEngine } from "./m
 // imageTagFromRef
 // ---------------------------------------------------------------------------
 
+// Only the `explicit` engine appends a suffix; `transparent` (the default)
+// publishes the plain tag, matching the pre-multi-engine tagging scheme.
+const suffixFor = (engine) => (engine === "explicit" ? "-explicit" : "");
+
 describe("imageTagFromRef – properties", () => {
-  it("40-char hex SHA always produces sha-<lowercase sha>-<engine>", () => {
+  it("40-char hex SHA always produces sha-<lowercase sha>, suffixed only for explicit", () => {
     fc.assert(
       fc.property(
         fc.stringMatching(/^[0-9a-fA-F]{40}$/),
         fc.constantFrom("transparent", "explicit"),
         (sha, engine) => {
-          assert.equal(imageTagFromRef(sha, engine), `sha-${sha.toLowerCase()}-${engine}`);
+          assert.equal(imageTagFromRef(sha, engine), `sha-${sha.toLowerCase()}${suffixFor(engine)}`);
         },
       ),
     );
   });
 
-  it("v-prefixed ref always strips the leading v and appends the engine suffix", () => {
+  it("v-prefixed ref always strips the leading v, suffixed only for explicit", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 1 }).map((s) => `v${s}`),
         fc.constantFrom("transparent", "explicit"),
         (ref, engine) => {
-          assert.equal(imageTagFromRef(ref, engine), `${ref.slice(1)}-${engine}`);
+          assert.equal(imageTagFromRef(ref, engine), `${ref.slice(1)}${suffixFor(engine)}`);
         },
       ),
     );
   });
 
   // Leading 'g' is not a hex char and not 'v', so this always hits the passthrough branch.
-  it("non-SHA non-v-prefixed ref always passes through unchanged plus the engine suffix", () => {
+  it("non-SHA non-v-prefixed ref always passes through unchanged, suffixed only for explicit", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 0, maxLength: 50 }).map((s) => `g${s}`),
         fc.constantFrom("transparent", "explicit"),
         (ref, engine) => {
-          assert.equal(imageTagFromRef(ref, engine), `${ref}-${engine}`);
+          assert.equal(imageTagFromRef(ref, engine), `${ref}${suffixFor(engine)}`);
         },
       ),
     );
   });
 
-  it("defaults to the transparent engine suffix when no engine is given", () => {
+  it("defaults to no suffix (transparent) when no engine is given", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 0, maxLength: 50 }).map((s) => `g${s}`),
         (ref) => {
-          assert.equal(imageTagFromRef(ref), `${ref}-transparent`);
+          assert.equal(imageTagFromRef(ref), ref);
         },
       ),
     );

--- a/setup/src/main.test.js
+++ b/setup/src/main.test.js
@@ -23,25 +23,25 @@ const execFail = () => { throw new Error("manifest not found"); };
 // ---------------------------------------------------------------------------
 
 describe("resolveImageTag", () => {
-  it("converts a 40-char hex SHA to sha-<sha>-transparent by default", () => {
+  it("converts a 40-char hex SHA to sha-<sha> by default (no suffix for transparent)", () => {
     const sha = "a".repeat(40);
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: sha }, execOk);
-    assert.equal(result, `sha-${"a".repeat(40)}-transparent`);
+    assert.equal(result, `sha-${"a".repeat(40)}`);
   });
 
   it("strips leading 'v' from a version tag", () => {
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "v2.1.0" }, execOk);
-    assert.equal(result, "2.1.0-transparent");
+    assert.equal(result, "2.1.0");
   });
 
   it("strips leading 'v' from a major-only tag", () => {
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "v3" }, execOk);
-    assert.equal(result, "3-transparent");
+    assert.equal(result, "3");
   });
 
   it("uses branch name as-is when image exists", () => {
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: "main" }, execOk);
-    assert.equal(result, "main-transparent");
+    assert.equal(result, "main");
   });
 
   it("uses the explicit engine suffix when requested", () => {
@@ -73,7 +73,7 @@ describe("resolveImageTag", () => {
   it("lowercases a SHA-derived tag", () => {
     const sha = "ABCDEF1234".padEnd(40, "0");
     const result = resolveImageTag("ghcr.io/owner/repo", { actionRef: sha }, execOk);
-    assert.equal(result, `sha-${sha.toLowerCase()}-transparent`);
+    assert.equal(result, `sha-${sha.toLowerCase()}`);
   });
 });
 
@@ -105,7 +105,7 @@ describe("resolveBuildcageImageRef", () => {
       { imageDigest: "", actionRepository: "owner/repo", actionRef: "v2.1.0" },
       execOk
     );
-    assert.equal(result, "ghcr.io/owner/repo:2.1.0-transparent");
+    assert.equal(result, "ghcr.io/owner/repo:2.1.0");
   });
 
   it("falls back to tag reference when imageDigest is undefined", () => {
@@ -113,7 +113,7 @@ describe("resolveBuildcageImageRef", () => {
       { imageDigest: undefined, actionRepository: "owner/repo", actionRef: "v2.1.0" },
       execOk
     );
-    assert.equal(result, "ghcr.io/owner/repo:2.1.0-transparent");
+    assert.equal(result, "ghcr.io/owner/repo:2.1.0");
   });
 
   it("uses the explicit engine's tag suffix when requested", () => {


### PR DESCRIPTION
## Summary

Drops the `-transparent` suffix from published Docker tags and marks `explicit` as an experimental engine. `transparent` (default) now publishes under the plain version tag again (e.g. `v2.2.0`), matching the pre-multi-engine scheme; only `explicit` keeps an engine suffix (`v2.2.0-explicit`).

## Why

When `explicit` was added (#121), tagging was designed symmetrically — both engines got an engine suffix, treating them as two equally-supported options. In practice, `explicit` turned out to carry real constraints: its underlying BuildKit feature (`--proxy-network`) is still maturing, and some tools (e.g. npm) don't consult the injected CA even when they respect `HTTP_PROXY`, causing TLS errors. This PR undoes the symmetric-tagging design so `transparent` behaves exactly as it did pre-`explicit`, and `explicit` is clearly positioned as the opt-in, experimental option.

## Changes

- `imageTagFromRef` (`setup/src/lib/verify-image.js`, rebuilt into `setup/dist/main.cjs`) only appends `-explicit` for the `explicit` engine; `transparent` returns the plain tag. Tests updated to match.
- `docker-publish.yml` / `update-major-tag.yml`: tag/`latest`/release-asset-filename generation now follows the same asymmetric rule, so `transparent` publishes and floats plain tags again while `explicit` keeps its suffix.
- `setup/action.yml`, README, and docs: mark `explicit` as experimental and update tag examples to the new scheme.

## Not changed

- `docker/transparent/`, `docker/explicit/`, `docker/tools/shared/` directory layout — reverting this to a flat, pre-`explicit` structure would break `explicit`'s use of the shared tooling and require new special-casing in `compose.yaml`/`Makefile`/CI, so it stays as-is.
- CI still builds, tests, and publishes both engines on every release.
