### PR TITLE
test: add npm CA-trust coverage to both proxy engines

### DIFF
--- a/compose.test-explicit.yaml
+++ b/compose.test-explicit.yaml
@@ -16,7 +16,7 @@ services:
         BUILDKIT_PROXY_BUILD_TAGS: testhooks
     environment:
       - EXTERNAL_RESOLVER=10.200.0.53
-      - ALLOWED_HTTPS_RULES=allowed.example.com:443 allowed.example.com:8443 *.wildcard.example.com:443 *.wildcard.example.com:8443
+      - ALLOWED_HTTPS_RULES=allowed.example.com:443 allowed.example.com:8443 *.wildcard.example.com:443 *.wildcard.example.com:8443 registry.npmjs.org:443
       - ALLOWED_HTTP_RULES=allowed.example.com:80 allowed.example.com:8080 *.wildcard.example.com:80 *.wildcard.example.com:8080
       - BUILDKIT_PROXY_EXTRA_CA_FILE=/test-fixtures/test-server-cert.pem
     volumes:

--- a/compose.test-transparent.yaml
+++ b/compose.test-transparent.yaml
@@ -3,7 +3,7 @@ services:
   builder:
     environment:
       - EXTERNAL_RESOLVER=10.200.0.53
-      - ALLOWED_HTTPS_RULES=allowed.example.com:443 allowed.example.com:8443 *.wildcard.example.com:443 *.wildcard.example.com:8443
+      - ALLOWED_HTTPS_RULES=allowed.example.com:443 allowed.example.com:8443 *.wildcard.example.com:443 *.wildcard.example.com:8443 registry.npmjs.org:443
       - ALLOWED_HTTP_RULES=allowed.example.com:80 allowed.example.com:8080 *.wildcard.example.com:80 *.wildcard.example.com:8080
     networks:
       default:

--- a/test/Dockerfile.explicit-audit
+++ b/test/Dockerfile.explicit-audit
@@ -1,4 +1,4 @@
-FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # DNS check — buildkit-proxy writes /etc/resolv.conf from EXTERNAL_RESOLVER at
 # container startup (no dnsmasq in this image).
@@ -39,6 +39,13 @@ RUN echo "=== [Direct IP - audit mode] ===" && \
 # no dns-failed / missing-sni / missing-host-header probes. Those exercise
 # buildcage's transparent-mode network-layer interception; explicit mode has
 # no equivalent (see docs/security.md's "Coverage and known limitations").
+
+# [npm install - NODE_USE_SYSTEM_CA=1 trusts BuildKit's injected MITM CA]
+RUN echo "=== [npm install - system CA trust] ===" && \
+    mkdir -p /app && cd /app && \
+    (npm init -y >/dev/null 2>&1 && \
+     NODE_USE_SYSTEM_CA=1 npm install --ignore-scripts --fetch-retries=0 express >/dev/null 2>&1 && \
+     echo "✓ npm install express: OK") || (echo "✗ npm install express: FAILED" && exit 1)
 
 # Network configuration check
 RUN echo "=== Network Configuration ===" && \

--- a/test/Dockerfile.explicit-restrict
+++ b/test/Dockerfile.explicit-restrict
@@ -1,4 +1,4 @@
-FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # The FROM pull above already exercises the "base image pulls are unaffected
 # by the explicit-mode source policy" guarantee: registry-1.docker.io is never
@@ -74,6 +74,13 @@ RUN echo "=== [Port 8080 - blocked] ===" && \
 RUN echo "=== [Direct IP - blocked] ===" && \
     echo "Testing direct IP access to 10.200.0.100 (should be blocked by source policy)..." && \
     (wget -q -O /dev/null --timeout=5 http://10.200.0.100/ && echo "✗ 10.200.0.100: ALLOWED (unexpected)" && exit 1) || echo "✓ 10.200.0.100: BLOCKED by source policy (expected)"
+
+# [npm install - allowed - NODE_USE_SYSTEM_CA=1 trusts BuildKit's injected MITM CA]
+RUN echo "=== [npm install - system CA trust, allowed registry] ===" && \
+    mkdir -p /app && cd /app && \
+    (npm init -y >/dev/null 2>&1 && \
+     NODE_USE_SYSTEM_CA=1 npm install --ignore-scripts --fetch-retries=0 express >/dev/null 2>&1 && \
+     echo "✓ npm install express: OK") || (echo "✗ npm install express: FAILED" && exit 1)
 
 # Note: unlike test/Dockerfile.transparent-restrict, this Dockerfile has no missing-sni /
 # missing-host-header / dns-failed probes. Those exercise buildcage's

--- a/test/Dockerfile.transparent-audit
+++ b/test/Dockerfile.transparent-audit
@@ -1,4 +1,4 @@
-FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \
@@ -50,6 +50,13 @@ RUN echo "=== [HTTP - missing-host-header] ===" && \
     echo "Testing HTTP request without Host header (should be blocked)..." && \
     ((printf 'GET / HTTP/1.0\r\n\r\n'; sleep 1) | nc -w 5 allowed.example.com 80 > /dev/null 2>&1 || true) && \
     echo "✓ missing-host-header: request sent (blocked expected in logs)"
+
+# [npm install - no CA workaround needed, unlike the explicit engine]
+RUN echo "=== [npm install - non-cooperative CA store] ===" && \
+    mkdir -p /app && cd /app && \
+    (npm init -y >/dev/null 2>&1 && \
+     npm install --ignore-scripts express >/dev/null 2>&1 && \
+     echo "✓ npm install express: OK") || (echo "✗ npm install express: FAILED" && exit 1)
 
 # Network configuration check
 RUN echo "=== Network Configuration ===" && \

--- a/test/Dockerfile.transparent-restrict
+++ b/test/Dockerfile.transparent-restrict
@@ -1,4 +1,4 @@
-FROM alpine:3.24.0@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \
@@ -85,6 +85,14 @@ RUN echo "=== [HTTP - missing-host-header] ===" && \
     echo "Testing HTTP request without Host header (should be blocked)..." && \
     ((printf 'GET / HTTP/1.0\r\n\r\n'; sleep 1) | nc -w 5 allowed.example.com 80 > /dev/null 2>&1 || true) && \
     echo "✓ missing-host-header: request sent (blocked expected in logs)"
+
+# [npm install - allowed - registry.npmjs.org is in ALLOWED_HTTPS_RULES; no CA
+# workaround needed, unlike the explicit engine]
+RUN echo "=== [npm install - allowed registry] ===" && \
+    mkdir -p /app && cd /app && \
+    (npm init -y >/dev/null 2>&1 && \
+     npm install --ignore-scripts express >/dev/null 2>&1 && \
+     echo "✓ npm install express: OK") || (echo "✗ npm install express: FAILED" && exit 1)
 
 # Network configuration check
 RUN echo "=== Network Configuration ===" && \

--- a/test/test-dns/dnsmasq.conf
+++ b/test/test-dns/dnsmasq.conf
@@ -1,4 +1,12 @@
-# Resolve all domains to test-server IP
-address=/#/10.200.0.100
-# Return NXDOMAIN for this domain (no IP = NXDOMAIN in dnsmasq 2.86+)
+# Resolve the fake test domains (and all subdomains, e.g. sub.wildcard.example.com)
+# to the test-server IP.
+address=/allowed.example.com/10.200.0.100
+address=/blocked.example.com/10.200.0.100
+address=/wildcard.example.com/10.200.0.100
+# Return NXDOMAIN for this domain (no IP = NXDOMAIN in dnsmasq 2.86+). More
+# specific than the wildcard.example.com rule above, so it takes precedence.
 address=/nxdomain.wildcard.example.com/
+# Forward everything else to a real upstream resolver, needed for the npm
+# install test's registry.npmjs.org lookup.
+server=1.1.1.1
+server=8.8.8.8


### PR DESCRIPTION
## Summary

Local `test_explicit_*` runs never caught the CA error real users hit running npm under the explicit engine, because the tests only exercised `wget` — a tool that already trusts the system CA store BuildKit's `--proxy-network` injects. This PR adds npm as a second, non-cooperative-CA-store client to both engines' test suites, so the CA-handling difference between the two engines (and any regression in it) is actually exercised locally instead of only being documented in prose.

While building this out, the first attempt at the coverage turned out to test the wrong thing: it relied on Alpine's own apk-packaged Node build, which already defers to the system trust store and silently masked the very failure it was meant to catch. Switched to the official upstream Node binary instead, matching what real users (and `example-audit.yml`) actually run.
