### PR TITLE
fix: eliminate flaky SIGPIPE/pipefail race in test assert scripts

### DIFF
--- a/test/assert-explicit-audit.sh
+++ b/test/assert-explicit-audit.sh
@@ -60,9 +60,9 @@ REPORT_MARKDOWN=$(GITHUB_STEP_SUMMARY= PROXY_ENGINE=explicit node report/src/mai
 # report.js) from buildctl's build-history vertex log, aggregated by
 # aggregateAllowedHosts — see report/src/lib/vertex-log.js.
 echo "[report action] Audited Hosts table (rendered markdown, from buildctl aggregation):"
-if echo "$REPORT_MARKDOWN" | grep -qF "### 📋 Audited Hosts" \
-  && echo "$REPORT_MARKDOWN" | grep -qF "| blocked.example.com:443 | HTTPS | 1 |" \
-  && echo "$REPORT_MARKDOWN" | grep -qF "| 10.200.0.100:80 | HTTP | 1 |"; then
+if grep -qF "### 📋 Audited Hosts" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "| blocked.example.com:443 | HTTPS | 1 |" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "| 10.200.0.100:80 | HTTP | 1 |" <<< "$REPORT_MARKDOWN"; then
   echo "  PASS  rendered markdown has an Audited Hosts table incl. blocked.example.com and 10.200.0.100"
 else
   echo "  FAIL  rendered markdown missing expected Audited Hosts table content"
@@ -75,10 +75,10 @@ echo ""
 # report/src/lib/vertex-log.js. Step-counter brackets are escaped in the
 # rendered markdown (see command-log.js's escapeMarkdown) — "**\[3/8\] RUN ...".
 echo "[report action] per-command communication detail (rendered markdown):"
-if echo "$REPORT_MARKDOWN" | grep -qF "Communication details" \
-  && echo "$REPORT_MARKDOWN" | grep -qE '^\*\*\\\[ *[0-9]+/[0-9]+\\\] RUN ' \
-  && echo "$REPORT_MARKDOWN" | grep -qE -- '- GET https://blocked\.example\.com/ -> 200' \
-  && ! echo "$REPORT_MARKDOWN" | grep -qF "**DENIED**"; then
+if grep -qF "Communication details" <<< "$REPORT_MARKDOWN" \
+  && grep -qE '^\*\*\\\[ *[0-9]+/[0-9]+\\\] RUN ' <<< "$REPORT_MARKDOWN" \
+  && grep -qE -- '- GET https://blocked\.example\.com/ -> 200' <<< "$REPORT_MARKDOWN" \
+  && ! grep -qF "**DENIED**" <<< "$REPORT_MARKDOWN"; then
   echo "  PASS  rendered markdown has per-command breakdown with no DENIED section"
 else
   echo "  FAIL  rendered markdown missing expected Communication details content"

--- a/test/assert-explicit-restrict.sh
+++ b/test/assert-explicit-restrict.sh
@@ -10,7 +10,7 @@ LOGS=$(docker compose exec builder cat /var/log/buildkitd/current 2>/dev/null)
 # when it's non-default.
 assert_denied() {
   local target="$1"
-  if echo "$LOGS" | grep -qF "ref=\"${target}\""; then
+  if grep -qF "ref=\"${target}\"" <<< "$LOGS"; then
     echo "  PASS  [BLOCKED] $target"
   else
     echo "  FAIL  [BLOCKED] $target -- not found in logs"
@@ -101,9 +101,9 @@ REPORT_MARKDOWN=$(GITHUB_STEP_SUMMARY= PROXY_ENGINE=explicit node report/src/mai
 # report.js) from buildctl's build-history vertex log, aggregated by
 # aggregateAllowedHosts — see report/src/lib/vertex-log.js.
 echo "[report action] Allowed Hosts table (rendered markdown, from buildctl aggregation):"
-if echo "$REPORT_MARKDOWN" | grep -qF "### ✅ Allowed Hosts" \
-  && echo "$REPORT_MARKDOWN" | grep -qF "| allowed.example.com:443 | HTTPS | 1 |" \
-  && echo "$REPORT_MARKDOWN" | grep -qF "| sub.wildcard.example.com:443 | HTTPS | 1 |"; then
+if grep -qF "### ✅ Allowed Hosts" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "| allowed.example.com:443 | HTTPS | 1 |" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "| sub.wildcard.example.com:443 | HTTPS | 1 |" <<< "$REPORT_MARKDOWN"; then
   echo "  PASS  rendered markdown has an Allowed Hosts table incl. allowed.example.com and sub.wildcard.example.com"
 else
   echo "  FAIL  rendered markdown missing expected Allowed Hosts table content"
@@ -116,12 +116,12 @@ echo ""
 # report/src/lib/vertex-log.js. Step-counter brackets are escaped in the
 # rendered markdown (see command-log.js's escapeMarkdown) — "**\[ 3/15\] RUN ...".
 echo "[report action] per-command communication detail (rendered markdown):"
-if echo "$REPORT_MARKDOWN" | grep -qF "Communication details" \
-  && echo "$REPORT_MARKDOWN" | grep -qE '^\*\*\\\[ *[0-9]+/[0-9]+\\\] RUN ' \
-  && echo "$REPORT_MARKDOWN" | grep -qF "(no communication)" \
-  && echo "$REPORT_MARKDOWN" | grep -qE -- '- GET https://allowed\.example\.com/ -> 200' \
-  && echo "$REPORT_MARKDOWN" | grep -qF "**DENIED**" \
-  && echo "$REPORT_MARKDOWN" | grep -qF "https://blocked.example.com/"; then
+if grep -qF "Communication details" <<< "$REPORT_MARKDOWN" \
+  && grep -qE '^\*\*\\\[ *[0-9]+/[0-9]+\\\] RUN ' <<< "$REPORT_MARKDOWN" \
+  && grep -qF "(no communication)" <<< "$REPORT_MARKDOWN" \
+  && grep -qE -- '- GET https://allowed\.example\.com/ -> 200' <<< "$REPORT_MARKDOWN" \
+  && grep -qF "**DENIED**" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "https://blocked.example.com/" <<< "$REPORT_MARKDOWN"; then
   echo "  PASS  rendered markdown has per-command breakdown, (no communication), and a DENIED list"
 else
   echo "  FAIL  rendered markdown missing expected Communication details content"

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -14,7 +14,9 @@ assert_log_contains() {
     pattern="$pattern $reason"
     label="$label $reason"
   fi
-  if echo "$LOGS" | grep buildcage | grep -q "$pattern"; then
+  local buildcage_logs
+  buildcage_logs=$(grep buildcage <<< "$LOGS" || true)
+  if grep -q "$pattern" <<< "$buildcage_logs"; then
     echo "  PASS  $label"
   else
     echo "  FAIL  $label  -- not found in logs"


### PR DESCRIPTION
## Summary

`test (explicit-restrict)` failed intermittently on an assertion that was actually true — `report/src/main.js`'s rendered markdown did contain the expected content, but the check still reported FAIL with a `Broken pipe` message. The assert scripts run under `set -euo pipefail` and chain multiple `echo "$VAR" | grep -q PATTERN` checks; `grep -q` exits as soon as it finds a match, and if `$VAR` is large enough that `echo` hasn't finished writing to the pipe yet, `echo` gets killed by SIGPIPE. With `pipefail` enabled, that non-zero `echo` exit status (not `grep`'s, which succeeded) fails the whole pipeline, so the assertion spuriously reports FAIL even though the pattern was found. This PR removes the race everywhere it exists in the test suite.

## Changes

- **Replace `echo "$VAR" | grep -q ...` with `grep -q ... <<< "$VAR"` wherever grep can exit early**
  - `test/assert-explicit-restrict.sh`, `test/assert-explicit-audit.sh`: all `-q` (and negated `! ... -q`) checks, including the multi-condition `&&` chains against `$REPORT_MARKDOWN`
  - A here-string has no separate writer process to receive SIGPIPE, so an early-exiting `grep -q` can no longer race a still-writing upstream process
  - Left the `-c`/`-o` (count/print-all) pipelines alone — they always read their input to EOF, so they were never subject to this race

- **Fix the same race in `test/helpers.sh`'s two-stage `grep buildcage | grep -q` pipeline**
  - Converting only the trailing `grep -q` to a here-string isn't enough here, since the middle `grep buildcage` stage can itself still be SIGPIPE'd by the final `grep -q` exiting early
  - Materializes the first grep's output into a variable via command substitution before the second `grep -q` reads it, so neither stage is a live pipe anymore
