### PR TITLE
ci: cross-compile buildkit-proxy to avoid QEMU emulation on arm64

### DIFF
--- a/docker/explicit/Dockerfile
+++ b/docker/explicit/Dockerfile
@@ -6,13 +6,22 @@
 # compose.test-explicit.yaml explicitly passes it, so integration-test-only code
 # (a self-signed-cert CA-trust escape hatch) is physically absent from the
 # published image's binary.
-FROM golang:1.25-alpine@sha256:523c3effe300580ed375e43f43b1c9b091b68e935a7c3a92bfcc4e7ed55b18c2 AS buildkit-proxy-build
+#
+# --platform=$BUILDPLATFORM pins this stage to the build host's own
+# architecture even when the overall image is being built for a different
+# target platform (e.g. linux/arm64 on an amd64 GitHub Actions runner), so
+# the Go toolchain always runs natively instead of under QEMU emulation.
+# GOOS/GOARCH below then cross-compile the actual output binary for the
+# target platform — CGO_ENABLED=0 makes this a plain, fast cross-compile.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:523c3effe300580ed375e43f43b1c9b091b68e935a7c3a92bfcc4e7ed55b18c2 AS buildkit-proxy-build
 ARG BUILDKIT_PROXY_BUILD_TAGS=""
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /src
 COPY explicit/buildkit-proxy/go.mod explicit/buildkit-proxy/go.sum ./
 RUN go mod download
 COPY explicit/buildkit-proxy/ ./
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -tags="${BUILDKIT_PROXY_BUILD_TAGS}" -o /out/buildkit-proxy .
+RUN CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build -trimpath -ldflags="-s -w" -tags="${BUILDKIT_PROXY_BUILD_TAGS}" -o /out/buildkit-proxy .
 
 # Final image
 FROM moby/buildkit:v0.31.1@sha256:6b59b7df63a8cb9902736f9ddf7fcff8261613d3e7449b8ea8b7537fc399c03a


### PR DESCRIPTION
## Summary

`buildkit-proxy`'s Go build was running under QEMU emulation for the `linux/arm64` leg of `docker-publish.yml`'s multi-platform build, even though it's only ~700 lines of Go with `CGO_ENABLED=0` — a case Go can cross-compile natively without any emulation at all. Pins the build stage to the host's own platform and lets the Go toolchain cross-compile instead, so the CPU-heavy compile step always runs at native speed regardless of which platform the overall image is being built for.

## Changes

- **Cross-compile `buildkit-proxy` instead of emulating the build stage**
  - `docker/explicit/Dockerfile`: added `--platform=$BUILDPLATFORM` to the `buildkit-proxy-build` stage, so it always runs on the build host's native architecture instead of an emulated one
  - Declared `TARGETOS`/`TARGETARCH` and passed them to `go build` via `GOOS`/`GOARCH`, so the stage still produces a binary for the actual target platform despite building natively
  - The final `moby/buildkit` stage is unchanged and still builds for the target platform as before — `apk add quickjs` there needs a real target-arch package, not a Go cross-compile
  - Verified locally with both a native build and a `--platform linux/amd64` cross-build on an arm64 host, confirming the emitted binary matches the target architecture (`file` reports the correct ELF machine type) and the compile step completes in a few seconds
