### PR TITLE
chore: restore 6 .trivyignore entries wrongly removed as version-fixed

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,10 +2,25 @@
 CVE-2025-22870
 CVE-2025-22872
 
+# QuickJS stack overflow via deeply nested JS input.
+# Only internal tool scripts (convert-rule.js, report.js) are executed;
+# no untrusted JavaScript is evaluated.
+CVE-2023-31922
+
 # Go stdlib html/template: XSS via escaping bugs in meta content URL and script type attribute.
 # No component in this product generates or serves HTML.
+CVE-2026-27142
 CVE-2026-39823
 CVE-2026-39826
+
+# Go stdlib net/url: incorrect parsing of IPv6 host literals.
+# CNI plugins do not parse user-supplied URLs.
+CVE-2026-25679
+
+# Go stdlib os: FileInfo can escape from a Root in ReadDir.
+# Same rationale as CVE-2026-32282/CVE-2026-39822 above — no component in
+# this product uses the os.Root sandboxed filesystem API.
+CVE-2026-27139
 
 # Go stdlib mime: excessive CPU on malformed MIME header decode.
 # buildkitd, buildkit-runc, and CNI plugins do not decode external MIME headers.
@@ -108,6 +123,8 @@ CVE-2026-56404
 CVE-2026-56403
 CVE-2026-56132
 CVE-2026-50219
+CVE-2026-41080
+CVE-2026-45186
 
 # c-ares: use-after-free / double-free in query-completion handling.
 # Only present as libcurl's transitive dependency, inherited from the moby/buildkit base image.


### PR DESCRIPTION
## Summary

Six of the entries removed in #143 as "version-fixed" reopened as live Trivy alerts (https://github.com/dash14/buildcage/security/code-scanning) on the very next scan. All six were boundary cases where the installed version exactly equaled the advisory's fixed version (`quickjs` and three `stdlib`/`libexpat` pairs); trivy's own comparator still treats those builds as vulnerable, so treating "installed == fixed" as safe was wrong. Cross-checked the current open alerts against `.trivyignore` and confirmed these are the only gaps — no genuinely new CVEs.

## Changes

- **Restore the 6 entries incorrectly dropped in #143, trusting the live scan over local version-string comparison**
  - `CVE-2023-31922` (quickjs): installed `0.20250426-r0` reads as newer by date, but apk/trivy's version comparator sorts its leading `0.` component below the fixed version's `2021-03-27-r5`, so it's still flagged
  - `CVE-2026-25679`, `CVE-2026-27139`, `CVE-2026-27142` (Go stdlib): CNI plugins build at exactly `go1.25.8`, matching the advisory's fixed version string, but the scan still treats that build as pre-fix
  - `CVE-2026-41080`, `CVE-2026-45186` (libexpat): same exact-match situation at `2.8.1-r0`
  - Restored each with its original rationale comment, merged back into the existing grouped blocks where one still exists (`html/template` XSS group, `libexpat` "additional XML parsing" group) rather than duplicating the comment
