### PR TITLE
fix: skip blocked-connection annotations when not running as the report action

### DIFF
--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -276,8 +276,21 @@ markdown += `\n*Reported by [Buildcage](https://github.com/${actionRepo})*\n`;
 
 const summaryFile = process.env.GITHUB_STEP_SUMMARY;
 
-if (summaryFile ? node_fs.appendFileSync(summaryFile, markdown) : console.log(markdown), 
-report.blockedCount > 0) if (isAudit) console.log(`::notice::${report.blockedCount} blocked connection(s) detected by buildcage proxy`); else {
-  "true" === (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() ? (console.log(`::error::${report.blockedCount} blocked connection(s) detected by buildcage proxy`), 
-  process.exitCode = 1) : console.log(`::notice::${report.blockedCount} blocked connection(s) detected by buildcage proxy`);
+summaryFile ? node_fs.appendFileSync(summaryFile, markdown) : console.log(markdown);
+
+const outputForAction = Boolean(summaryFile), annotation = outputForAction ? {
+  notice(message) {
+    console.log(`::notice::${message}`);
+  },
+  error(message) {
+    console.log(`::error::${message}`);
+  }
+} : {
+  notice() {},
+  error() {}
+};
+
+if (report.blockedCount > 0) if (isAudit) annotation.notice(`${report.blockedCount} blocked connection(s) detected by buildcage proxy`); else {
+  "true" === (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() ? (annotation.error(`${report.blockedCount} blocked connection(s) detected by buildcage proxy`), 
+  process.exitCode = 1) : annotation.notice(`${report.blockedCount} blocked connection(s) detected by buildcage proxy`);
 }

--- a/report/src/lib/annotation.js
+++ b/report/src/lib/annotation.js
@@ -1,0 +1,21 @@
+/**
+ * Build a GitHub Actions annotation emitter. When `enabled` is false, every
+ * method is a no-op — used to suppress annotations when this script isn't
+ * running as the real report action (see main.js's `outputForAction`).
+ *
+ * @param {boolean} enabled
+ * @returns {{ notice(message: string): void, error(message: string): void }}
+ */
+export function createAnnotation(enabled) {
+  if (!enabled) {
+    return { notice() {}, error() {} };
+  }
+  return {
+    notice(message) {
+      console.log(`::notice::${message}`);
+    },
+    error(message) {
+      console.log(`::error::${message}`);
+    },
+  };
+}

--- a/report/src/lib/annotation.test.js
+++ b/report/src/lib/annotation.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createAnnotation } from "./annotation.js";
+
+describe("createAnnotation", () => {
+  describe("enabled", () => {
+    it("notice() logs a ::notice:: line", (t) => {
+      const log = t.mock.method(console, "log", () => {});
+      createAnnotation(true).notice("hello");
+      assert.equal(log.mock.calls.length, 1);
+      assert.equal(log.mock.calls[0].arguments[0], "::notice::hello");
+    });
+
+    it("error() logs a ::error:: line", (t) => {
+      const log = t.mock.method(console, "log", () => {});
+      createAnnotation(true).error("boom");
+      assert.equal(log.mock.calls.length, 1);
+      assert.equal(log.mock.calls[0].arguments[0], "::error::boom");
+    });
+  });
+
+  describe("disabled", () => {
+    it("notice() logs nothing", (t) => {
+      const log = t.mock.method(console, "log", () => {});
+      createAnnotation(false).notice("hello");
+      assert.equal(log.mock.calls.length, 0);
+    });
+
+    it("error() logs nothing", (t) => {
+      const log = t.mock.method(console, "log", () => {});
+      createAnnotation(false).error("boom");
+      assert.equal(log.mock.calls.length, 0);
+    });
+  });
+});

--- a/report/src/main.js
+++ b/report/src/main.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { buildRestrictExample } from "./lib/build-example.js";
 import { renderCommunicationDetails } from "./lib/command-log.js";
 import { selectAllRefs, parseVertexAllowedLog, aggregateAllowedHosts } from "./lib/vertex-log.js";
+import { createAnnotation } from "./lib/annotation.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -173,22 +174,24 @@ if (summaryFile) {
 }
 
 // 4. Error control for blocked connections
+const outputForAction = Boolean(summaryFile);
+const annotation = createAnnotation(outputForAction);
 if (report.blockedCount > 0) {
   if (isAudit) {
-    console.log(
-      `::notice::${report.blockedCount} blocked connection(s) detected by buildcage proxy`
+    annotation.notice(
+      `${report.blockedCount} blocked connection(s) detected by buildcage proxy`
     );
   } else {
     const failOnBlocked =
       (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
     if (failOnBlocked) {
-      console.log(
-        `::error::${report.blockedCount} blocked connection(s) detected by buildcage proxy`
+      annotation.error(
+        `${report.blockedCount} blocked connection(s) detected by buildcage proxy`
       );
       process.exitCode = 1;
     } else {
-      console.log(
-        `::notice::${report.blockedCount} blocked connection(s) detected by buildcage proxy`
+      annotation.notice(
+        `${report.blockedCount} blocked connection(s) detected by buildcage proxy`
       );
     }
   }

--- a/setup/src/main.js
+++ b/setup/src/main.js
@@ -50,7 +50,7 @@ async function main() {
     : null;
   if (localOverride) {
     console.log(
-      `::warning::BUILDCAGE_LOCAL_IMAGE_REF is set (${JSON.stringify(localOverride.imageRef)}) — ` +
+      `BUILDCAGE_LOCAL_IMAGE_REF is set (${JSON.stringify(localOverride.imageRef)}) — ` +
         `skipping image provenance verification and registry tag resolution entirely. ` +
         `This bypass exists only for buildcage's own CI self-tests and local development and is ` +
         `dead-code-eliminated from every published release build.`,


### PR DESCRIPTION
## Summary

`test.yml`'s matrix `test` job intentionally clears `GITHUB_STEP_SUMMARY` before invoking `report/src/main.js` directly, since that job tests proxy enforcement itself rather than the real `report` action. But `report/src/main.js`'s blocked-connection annotations (`::notice::`/`::error::`) were gated only on `report.blockedCount`, independent of `GITHUB_STEP_SUMMARY` — so those annotations leaked into a job that was never meant to produce them. This PR gates annotation output on the same condition as the Job Summary write, without touching the existing `fail_on_blocked` exit-code behavior.

## Changes

- **Add `report/src/lib/annotation.js`**: `createAnnotation(enabled)` returns a `{ notice, error }` object — a no-op when `enabled` is false, otherwise logs a `::notice::`/`::error::` line
- **Wire it into `report/src/main.js`**: `outputForAction` (`Boolean(GITHUB_STEP_SUMMARY)`) now gates the annotation calls the same way it already gates the Job Summary write; `process.exitCode` for `fail_on_blocked` is untouched
