### PR TITLE
feat: reorder and reformat the Communication details section

### DIFF
--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -8,6 +8,16 @@ const ruleTypeToParam = {
   IP: "allowed_ip_rules"
 };
 
+function renderVertexItem({command: command, started: started, completed: completed, entries: entries}, indent) {
+  const inner = indent + "   ";
+  let s = `${indent}* ${escapeMarkdown(command)}\n\n`;
+  if (s += `${inner}(${formatSeconds(started)} · duration ${function(started, completed) {
+    const seconds = (Date.parse(completed) - Date.parse(started)) / 1e3;
+    return `${seconds.toFixed(3)}s`;
+  }(started, completed)})\n\n`, s += `${inner}\`\`\`\n`, 0 === entries.length) s += `${inner}(no communication)\n`; else for (const entry of entries) s += `${inner}${renderRequestLine(entry)}\n`;
+  return s += `${inner}\`\`\`\n\n`, s;
+}
+
 function renderRequestLine({method: method, url: url, status: status}) {
   const line = `- ${escapeMarkdown(method)} ${escapeMarkdown(url)}`;
   return void 0 === status ? line : `${line} -> ${status}`;
@@ -17,16 +27,8 @@ function escapeMarkdown(text) {
   return text.replace(/([\\`*_[\]<>])/g, "\\$1");
 }
 
-function formatMillis(iso) {
-  return new Date(iso).toISOString().slice(11, 23) + "Z";
-}
-
 function formatSeconds(iso) {
   return new Date(iso).toISOString().slice(11, 19) + "Z";
-}
-
-function formatDuration(started, completed) {
-  return `${((Date.parse(completed) - Date.parse(started)) / 1e3).toFixed(3)}s`;
 }
 
 const requestLineDetailPattern = /^-\s+(\S+)\s+(\S+?)(?:\s+->\s+(\d+))?$/;
@@ -253,25 +255,23 @@ if (isAudit) {
 isExplicit && (markdown += function(builds, deniedTimeline) {
   const nonEmptyBuilds = (builds || []).filter(b => b && b.length > 0), hasVertexLog = nonEmptyBuilds.length > 0, hasDenied = deniedTimeline && deniedTimeline.length > 0;
   if (!hasVertexLog && !hasDenied) return "";
-  let md = "\n<details>\n<summary>Communication details</summary>\n\n";
+  let md = "\n<details>\n<summary>💬 Communication details</summary>\n\n";
   if (hasVertexLog) {
+    md += "* **✅ Allowed Urls**\n\n";
     const showBuildHeadings = nonEmptyBuilds.length > 1;
     nonEmptyBuilds.forEach((vertices, i) => {
-      showBuildHeadings && (md += `### Build ${i + 1}\n\n`);
-      for (const {command: command, started: started, completed: completed, entries: entries} of vertices) {
-        if (md += `**${escapeMarkdown(command)}**\n`, md += `_started ${formatMillis(started)} · duration ${formatDuration(started, completed)}_\n`, 
-        0 === entries.length) md += "(no communication)\n"; else for (const entry of entries) md += `${renderRequestLine(entry)}\n`;
-        md += "\n";
-      }
+      const indent = showBuildHeadings ? "      " : "   ";
+      showBuildHeadings && (md += `   * Build ${i + 1}\n\n`);
+      for (const vertex of vertices) md += renderVertexItem(vertex, indent);
     });
   }
   if (hasDenied) {
-    md += "**DENIED**\n";
-    for (const {url: url, timestamp: timestamp} of deniedTimeline) md += `- ${formatSeconds(timestamp)} ${escapeMarkdown(url)}\n`;
+    md += "* **🚫 Blocked Urls**\n\n";
+    for (const {url: url, timestamp: timestamp} of deniedTimeline) md += `   - (${formatSeconds(timestamp)}) ${escapeMarkdown(url)}\n`;
     md += "\n";
   }
   return md += "</details>\n", md;
-}(builds, report.deniedTimeline)), markdown += "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n", 
+}(builds, report.deniedTimeline)), isExplicit || (markdown += "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n"), 
 markdown += `\n*Reported by [Buildcage](https://github.com/${actionRepo})*\n`;
 
 const summaryFile = process.env.GITHUB_STEP_SUMMARY;

--- a/report/src/lib/command-log.js
+++ b/report/src/lib/command-log.js
@@ -1,32 +1,15 @@
 /**
  * Render the explicit engine's communication detail as a collapsed markdown
- * section. Returns "" if there is nothing to show (including when both
- * inputs are absent/empty, as in transparent mode, which has neither).
+ * section, or "" if there's nothing to show. Allowed Urls is listed before
+ * Blocked Urls, matching the Allowed Hosts / Blocked Hosts tables above.
  *
- * `builds` (one entry per build found via `buildctl debug histories` — see
- * report/src/lib/vertex-log.js's parseVertexAllowedLog(), called once per
- * ref — oldest build first) is rendered as one block per RUN step, including
- * steps with no communication at all, shown as "(no communication)"; each
- * build's own steps are already grouped by build stage and ordered for human
- * debugging by vertex-log.js, so this function just renders them in the
- * order given. A "### Build N" heading separates builds only when there is
- * more than one — a workflow that runs several builds against the same
- * container before calling the report action once would otherwise repeat
- * step labels like "[2/15] RUN ..." with no indication they're from
- * different builds.
+ * Blocked entries aren't attributed to a specific RUN step — buildkitd's
+ * denial log carries no vertex/span identifier to attribute it with. A
+ * "Build N" item separates builds only when there's more than one, since
+ * step labels like "[2/15] RUN ..." repeat across builds.
  *
- * `deniedTimeline` (from docker/tools/explicit/report.js's
- * parseDenialTimeline(), which already covers every build since it reads
- * buildkitd's own append-only debug log) is rendered separately, as a flat
- * "DENIED" list with each entry's own timestamp, rather than attributed to a
- * specific RUN step — BuildKit's own denial log carries no vertex/span
- * identifier to attribute it with, so a human has to eyeball the timestamps
- * against the per-step started/duration above to guess which step (and
- * which build) it belongs to.
- *
- * Command/URL text originates in the Dockerfile (or the request itself) and
- * is escaped before being embedded in markdown, so it can't break out of the
- * bold/list formatting it's rendered into.
+ * Command text is escaped since it's embedded directly in markdown; request
+ * lines go inside a fenced code block instead, where escaping isn't needed.
  *
  * @param {Array<Array<{ command: string, started: string, completed: string, entries: Array<{ method: string, url: string, status?: number }> }>>} builds
  * @param {Array<{ url: string, timestamp: string }>} deniedTimeline
@@ -38,35 +21,42 @@ export function renderCommunicationDetails(builds, deniedTimeline) {
   const hasDenied = deniedTimeline && deniedTimeline.length > 0;
   if (!hasVertexLog && !hasDenied) return "";
 
-  let md = "\n<details>\n<summary>Communication details</summary>\n\n";
+  let md = "\n<details>\n<summary>💬 Communication details</summary>\n\n";
 
   if (hasVertexLog) {
+    md += "* **✅ Allowed Urls**\n\n";
     const showBuildHeadings = nonEmptyBuilds.length > 1;
     nonEmptyBuilds.forEach((vertices, i) => {
-      if (showBuildHeadings) md += `### Build ${i + 1}\n\n`;
-      for (const { command, started, completed, entries } of vertices) {
-        md += `**${escapeMarkdown(command)}**\n`;
-        md += `_started ${formatMillis(started)} · duration ${formatDuration(started, completed)}_\n`;
-        if (entries.length === 0) {
-          md += "(no communication)\n";
-        } else {
-          for (const entry of entries) md += `${renderRequestLine(entry)}\n`;
-        }
-        md += "\n";
-      }
+      const indent = showBuildHeadings ? "      " : "   ";
+      if (showBuildHeadings) md += `   * Build ${i + 1}\n\n`;
+      for (const vertex of vertices) md += renderVertexItem(vertex, indent);
     });
   }
 
   if (hasDenied) {
-    md += "**DENIED**\n";
+    md += "* **🚫 Blocked Urls**\n\n";
     for (const { url, timestamp } of deniedTimeline) {
-      md += `- ${formatSeconds(timestamp)} ${escapeMarkdown(url)}\n`;
+      md += `   - (${formatSeconds(timestamp)}) ${escapeMarkdown(url)}\n`;
     }
     md += "\n";
   }
 
   md += "</details>\n";
   return md;
+}
+
+function renderVertexItem({ command, started, completed, entries }, indent) {
+  const inner = indent + "   ";
+  let s = `${indent}* ${escapeMarkdown(command)}\n\n`;
+  s += `${inner}(${formatSeconds(started)} · duration ${formatDuration(started, completed)})\n\n`;
+  s += `${inner}\`\`\`\n`;
+  if (entries.length === 0) {
+    s += `${inner}(no communication)\n`;
+  } else {
+    for (const entry of entries) s += `${inner}${renderRequestLine(entry)}\n`;
+  }
+  s += `${inner}\`\`\`\n\n`;
+  return s;
 }
 
 function renderRequestLine({ method, url, status }) {
@@ -87,15 +77,8 @@ function escapeMarkdown(text) {
   return text.replace(/([\\`*_[\]<>])/g, "\\$1");
 }
 
-// "HH:MM:SS.mmmZ" — millisecond precision, available for vertex started/
-// completed times (from buildctl's rawjson output).
-function formatMillis(iso) {
-  return new Date(iso).toISOString().slice(11, 23) + "Z";
-}
-
-// "HH:MM:SSZ" — whole-second precision only, matching what buildkitd's own
-// denial log actually records (no fractional seconds at all); formatting
-// this the same way as formatMillis would imply false precision.
+// Whole-second precision, matching what buildkitd's own denial log records
+// (no fractional seconds) — used for vertex started times too, for consistency.
 function formatSeconds(iso) {
   return new Date(iso).toISOString().slice(11, 19) + "Z";
 }

--- a/report/src/lib/command-log.test.js
+++ b/report/src/lib/command-log.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { renderCommunicationDetails } from "./command-log.js";
 
 function wrap(body) {
-  return "\n<details>\n<summary>Communication details</summary>\n\n" + body + "</details>\n";
+  return "\n<details>\n<summary>💬 Communication details</summary>\n\n" + body + "</details>\n";
 }
 
 // No brackets in these two fixtures on purpose, so the non-escaping tests
@@ -23,6 +23,22 @@ const VERTEX_B = {
   entries: [{ method: "GET", url: "https://allowed.example.com/", status: 200 }],
 };
 
+const ALLOWED_A =
+  "* **✅ Allowed Urls**\n\n" +
+  "   * RUN echo no-network-here && mkdir -p /tmp/work\n\n" +
+  "      (22:08:41Z · duration 0.143s)\n\n" +
+  "      ```\n" +
+  "      (no communication)\n" +
+  "      ```\n\n";
+
+const ALLOWED_B =
+  "* **✅ Allowed Urls**\n\n" +
+  "   * RUN echo step-A && wget -q -O /dev/null --timeout=5 https://allowed.example.com/ && echo A-done\n\n" +
+  "      (22:08:41Z · duration 0.081s)\n\n" +
+  "      ```\n" +
+  "      - GET https://allowed.example.com/ -> 200\n" +
+  "      ```\n\n";
+
 describe("renderCommunicationDetails", () => {
   it("empty arrays → empty string", () => {
     assert.equal(renderCommunicationDetails([], []), "");
@@ -38,20 +54,11 @@ describe("renderCommunicationDetails", () => {
   });
 
   it("a vertex with no entries renders '(no communication)'", () => {
-    assert.equal(
-      renderCommunicationDetails([[VERTEX_A]], []),
-      wrap("**RUN echo no-network-here && mkdir -p /tmp/work**\n_started 22:08:41.527Z · duration 0.143s_\n(no communication)\n\n")
-    );
+    assert.equal(renderCommunicationDetails([[VERTEX_A]], []), wrap(ALLOWED_A));
   });
 
-  it("a vertex with an allowed entry renders the request line", () => {
-    assert.equal(
-      renderCommunicationDetails([[VERTEX_B]], []),
-      wrap(
-        "**RUN echo step-A && wget -q -O /dev/null --timeout=5 https://allowed.example.com/ && echo A-done**\n" +
-          "_started 22:08:41.670Z · duration 0.081s_\n- GET https://allowed.example.com/ -> 200\n\n"
-      )
-    );
+  it("a vertex with an allowed entry renders the request line in a code block", () => {
+    assert.equal(renderCommunicationDetails([[VERTEX_B]], []), wrap(ALLOWED_B));
   });
 
   it("an entry with no status omits the arrow", () => {
@@ -59,87 +66,90 @@ describe("renderCommunicationDetails", () => {
     assert.match(renderCommunicationDetails([[vertex]], []), /- GET https:\/\/allowed\.example\.com\/\n/);
   });
 
-  it("renders multiple vertices within one build as separate blocks, no build heading", () => {
+  it("renders multiple vertices within one build under one 'Allowed Urls' item, no build item", () => {
     const md = renderCommunicationDetails([[VERTEX_A, VERTEX_B]], []);
-    assert.equal(md.includes("### Build"), false);
+    assert.equal(md.includes("Build"), false);
     assert.equal(
       md,
       wrap(
-        "**RUN echo no-network-here && mkdir -p /tmp/work**\n_started 22:08:41.527Z · duration 0.143s_\n(no communication)\n\n" +
-          "**RUN echo step-A && wget -q -O /dev/null --timeout=5 https://allowed.example.com/ && echo A-done**\n" +
-          "_started 22:08:41.670Z · duration 0.081s_\n- GET https://allowed.example.com/ -> 200\n\n"
+        "* **✅ Allowed Urls**\n\n" +
+          "   * RUN echo no-network-here && mkdir -p /tmp/work\n\n" +
+          "      (22:08:41Z · duration 0.143s)\n\n" +
+          "      ```\n" +
+          "      (no communication)\n" +
+          "      ```\n\n" +
+          "   * RUN echo step-A && wget -q -O /dev/null --timeout=5 https://allowed.example.com/ && echo A-done\n\n" +
+          "      (22:08:41Z · duration 0.081s)\n\n" +
+          "      ```\n" +
+          "      - GET https://allowed.example.com/ -> 200\n" +
+          "      ```\n\n"
       )
     );
   });
 
-  it("adds a '### Build N' heading per build only when there is more than one build", () => {
+  it("adds a 'Build N' item per build, one level deeper, only when there is more than one build", () => {
     const md = renderCommunicationDetails([[VERTEX_A], [VERTEX_B]], []);
-    assert.equal(md.includes("### Build 1\n\n**RUN echo no-network-here"), true);
-    assert.equal(md.includes("### Build 2\n\n**RUN echo step-A"), true);
+    assert.equal(md.includes("   * Build 1\n\n      * RUN echo no-network-here"), true);
+    assert.equal(md.includes("   * Build 2\n\n      * RUN echo step-A"), true);
   });
 
-  it("skips empty builds when deciding whether to show build headings (only 1 non-empty build)", () => {
+  it("skips empty builds when deciding whether to show build items (only 1 non-empty build)", () => {
     const md = renderCommunicationDetails([[], [VERTEX_A], []], []);
-    assert.equal(md.includes("### Build"), false);
+    assert.equal(md.includes("Build"), false);
   });
 
-  it("renders the DENIED section with whole-second timestamps, no vertex attribution", () => {
+  it("renders the Blocked Urls section with whole-second timestamps, no vertex attribution", () => {
     const deniedTimeline = [{ url: "https://blocked.example.com/", timestamp: "2026-07-05T22:08:41Z" }];
     assert.equal(
       renderCommunicationDetails([], deniedTimeline),
-      wrap("**DENIED**\n- 22:08:41Z https://blocked.example.com/\n\n")
+      wrap("* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/\n\n")
     );
   });
 
-  it("renders multiple DENIED entries in the order given", () => {
+  it("renders multiple Blocked Urls entries in the order given", () => {
     const deniedTimeline = [
       { url: "https://blocked.example.com/a", timestamp: "2026-07-05T22:08:41Z" },
       { url: "https://blocked.example.com/b", timestamp: "2026-07-05T22:08:42Z" },
     ];
     assert.equal(
       renderCommunicationDetails([], deniedTimeline),
-      wrap("**DENIED**\n- 22:08:41Z https://blocked.example.com/a\n- 22:08:42Z https://blocked.example.com/b\n\n")
+      wrap(
+        "* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/a\n   - (22:08:42Z) https://blocked.example.com/b\n\n"
+      )
     );
   });
 
-  it("renders both the vertex breakdown and the DENIED list together", () => {
+  it("renders Allowed Urls before Blocked Urls", () => {
     const deniedTimeline = [{ url: "https://blocked.example.com/", timestamp: "2026-07-05T22:08:41Z" }];
     assert.equal(
       renderCommunicationDetails([[VERTEX_B]], deniedTimeline),
-      wrap(
-        "**RUN echo step-A && wget -q -O /dev/null --timeout=5 https://allowed.example.com/ && echo A-done**\n" +
-          "_started 22:08:41.670Z · duration 0.081s_\n- GET https://allowed.example.com/ -> 200\n\n" +
-          "**DENIED**\n- 22:08:41Z https://blocked.example.com/\n\n"
-      )
+      wrap(ALLOWED_B + "* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/\n\n")
     );
   });
 
-  it("renders only the DENIED list when builds is empty but deniedTimeline is not", () => {
+  it("renders only Blocked Urls when builds is empty but deniedTimeline is not", () => {
     const deniedTimeline = [{ url: "https://blocked.example.com/", timestamp: "2026-07-05T22:08:41Z" }];
-    assert.equal(renderCommunicationDetails([], deniedTimeline), wrap("**DENIED**\n- 22:08:41Z https://blocked.example.com/\n\n"));
+    assert.equal(
+      renderCommunicationDetails([], deniedTimeline),
+      wrap("* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/\n\n")
+    );
   });
 
-  it("renders only the vertex breakdown when deniedTimeline is empty but builds is not", () => {
-    assert.equal(
-      renderCommunicationDetails([[VERTEX_B]], []),
-      wrap(
-        "**RUN echo step-A && wget -q -O /dev/null --timeout=5 https://allowed.example.com/ && echo A-done**\n" +
-          "_started 22:08:41.670Z · duration 0.081s_\n- GET https://allowed.example.com/ -> 200\n\n"
-      )
-    );
+  it("renders only Allowed Urls when deniedTimeline is empty but builds is not", () => {
+    assert.equal(renderCommunicationDetails([[VERTEX_B]], []), wrap(ALLOWED_B));
   });
 
   describe("markdown escaping", () => {
     it("escapes '[' ']' in a command, including a '[N/M]' step-counter prefix, so it can't be misread as link syntax", () => {
       const vertex = { ...VERTEX_A, command: '[2/2] RUN echo "=== [HTTPS - allowed] ==="', entries: [] };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /\*\*\\\[2\/2\\\] RUN echo "=== \\\[HTTPS - allowed\\\] ==="\*\*/);
+      assert.match(md, /\* \\\[2\/2\\\] RUN echo "=== \\\[HTTPS - allowed\\\] ==="\n/);
     });
 
-    it("escapes '*' and '_' in a command so they can't break out of the bold header", () => {
+    it("escapes '*' and '_' in a command so they can't be misread as emphasis", () => {
       const vertex = { ...VERTEX_A, command: "RUN echo *hi* && echo _bye_", entries: [] };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /\*\*RUN echo \\\*hi\\\* && echo \\_bye\\_\*\*/);
+      assert.match(md, /\* RUN echo \\\*hi\\\* && echo \\_bye\\_\n/);
     });
 
     it("escapes backticks and backslashes in a command", () => {
@@ -148,7 +158,7 @@ describe("renderCommunicationDetails", () => {
       assert.match(md, /echo \\`whoami\\` && echo C:\\\\\\\\path/);
     });
 
-    it("escapes special characters in an allowed request's URL", () => {
+    it("escapes special characters in an allowed request's URL inside the code block", () => {
       const vertex = { ...VERTEX_A, entries: [{ method: "GET", url: "https://allowed.example.com/[id]", status: 200 }] };
       const md = renderCommunicationDetails([[vertex]], []);
       assert.match(md, /- GET https:\/\/allowed\.example\.com\/\\\[id\\\] -> 200/);
@@ -157,13 +167,13 @@ describe("renderCommunicationDetails", () => {
     it("escapes special characters in a denied URL", () => {
       const deniedTimeline = [{ url: "https://blocked.example.com/[id]", timestamp: "2026-07-05T22:08:41Z" }];
       const md = renderCommunicationDetails([], deniedTimeline);
-      assert.match(md, /- 22:08:41Z https:\/\/blocked\.example\.com\/\\\[id\\\]/);
+      assert.match(md, /- \(22:08:41Z\) https:\/\/blocked\.example\.com\/\\\[id\\\]/);
     });
 
     it("does not escape '.' or '-', which are common and harmless in URLs/commands", () => {
       const vertex = { ...VERTEX_A, command: "RUN echo hello-world.txt", entries: [] };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /\*\*RUN echo hello-world\.txt\*\*/);
+      assert.match(md, /\* RUN echo hello-world\.txt\n/);
     });
   });
 });

--- a/report/src/main.js
+++ b/report/src/main.js
@@ -160,7 +160,11 @@ if (isExplicit) {
   markdown += renderCommunicationDetails(builds, report.deniedTimeline);
 }
 
-markdown += "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n";
+// SNI-based sniffing only applies to the transparent engine — the explicit
+// engine terminates TLS itself, so this caveat doesn't apply to it.
+if (!isExplicit) {
+  markdown += "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n";
+}
 
 markdown += `\n*Reported by [Buildcage](https://github.com/${actionRepo})*\n`;
 

--- a/test/assert-explicit-audit.sh
+++ b/test/assert-explicit-audit.sh
@@ -73,13 +73,14 @@ echo ""
 # The per-command "Communication details" section is built by report/src/main.js
 # itself (not report.js) via buildctl debug histories/logs — see
 # report/src/lib/vertex-log.js. Step-counter brackets are escaped in the
-# rendered markdown (see command-log.js's escapeMarkdown) — "**\[3/8\] RUN ...".
+# rendered markdown (see command-log.js's escapeMarkdown) — "* \[3/8\] RUN ...".
 echo "[report action] per-command communication detail (rendered markdown):"
 if grep -qF "Communication details" <<< "$REPORT_MARKDOWN" \
-  && grep -qE '^\*\*\\\[ *[0-9]+/[0-9]+\\\] RUN ' <<< "$REPORT_MARKDOWN" \
+  && grep -qF "Allowed Urls" <<< "$REPORT_MARKDOWN" \
+  && grep -qE '^ *\* \\\[ *[0-9]+/[0-9]+\\\] RUN ' <<< "$REPORT_MARKDOWN" \
   && grep -qE -- '- GET https://blocked\.example\.com/ -> 200' <<< "$REPORT_MARKDOWN" \
-  && ! grep -qF "**DENIED**" <<< "$REPORT_MARKDOWN"; then
-  echo "  PASS  rendered markdown has per-command breakdown with no DENIED section"
+  && ! grep -qF "Blocked Urls" <<< "$REPORT_MARKDOWN"; then
+  echo "  PASS  rendered markdown has per-command breakdown with no Blocked Urls section"
 else
   echo "  FAIL  rendered markdown missing expected Communication details content"
   FAILURES=$((FAILURES + 1))

--- a/test/assert-explicit-restrict.sh
+++ b/test/assert-explicit-restrict.sh
@@ -114,15 +114,16 @@ echo ""
 # The per-command "Communication details" section is built by report/src/main.js
 # itself (not report.js) via buildctl debug histories/logs — see
 # report/src/lib/vertex-log.js. Step-counter brackets are escaped in the
-# rendered markdown (see command-log.js's escapeMarkdown) — "**\[ 3/15\] RUN ...".
+# rendered markdown (see command-log.js's escapeMarkdown) — "* \[ 3/15\] RUN ...".
 echo "[report action] per-command communication detail (rendered markdown):"
 if grep -qF "Communication details" <<< "$REPORT_MARKDOWN" \
-  && grep -qE '^\*\*\\\[ *[0-9]+/[0-9]+\\\] RUN ' <<< "$REPORT_MARKDOWN" \
+  && grep -qF "Allowed Urls" <<< "$REPORT_MARKDOWN" \
+  && grep -qE '^ *\* \\\[ *[0-9]+/[0-9]+\\\] RUN ' <<< "$REPORT_MARKDOWN" \
   && grep -qF "(no communication)" <<< "$REPORT_MARKDOWN" \
   && grep -qE -- '- GET https://allowed\.example\.com/ -> 200' <<< "$REPORT_MARKDOWN" \
-  && grep -qF "**DENIED**" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "Blocked Urls" <<< "$REPORT_MARKDOWN" \
   && grep -qF "https://blocked.example.com/" <<< "$REPORT_MARKDOWN"; then
-  echo "  PASS  rendered markdown has per-command breakdown, (no communication), and a DENIED list"
+  echo "  PASS  rendered markdown has per-command breakdown, (no communication), and a Blocked Urls list"
 else
   echo "  FAIL  rendered markdown missing expected Communication details content"
   FAILURES=$((FAILURES + 1))


### PR DESCRIPTION
## Summary

The explicit engine's "Communication details" section had drifted from the rest of the report's conventions: no emoji in its heading (unlike `✅ Allowed Hosts` / `📋 Audited Hosts` / `🚫 Blocked Hosts`), its `DENIED` list shown after the per-step breakdown instead of before, and mismatched wording (`DENIED` vs. `BLOCKED` everywhere else). The per-step request log was also a flat bold-header + bullet list that didn't visually separate the command from its communication log. This PR realigns the section with the rest of the report and reformats the successful-request log as a list item with a code block.

## Changes

- **Add `💬` to the section heading**, matching the emoji-prefixed headings used elsewhere in the report
- **Move the blocked-connection list ahead of the per-step breakdown and rename it to `🚫 BLOCKED`**, matching `docker/tools/explicit/lib/buildkitd-log-parser.js`'s own `"BLOCKED"` decision label
- **Reformat each RUN step as `* command` followed by a `<sub>time · duration</sub>` line and a fenced code block of its requests**, replacing the bold-header-plus-bullets layout; the "started" label is dropped and the timestamp is rounded to whole seconds (matching `BLOCKED`'s precision, which is all buildkitd's own log records)
