### PR TITLE
fix: harden the sandbox action's filesystem and secret isolation

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -46,7 +46,7 @@ s6-overlay
 QuickJS
   Website : https://bellard.org/quickjs/
   License : MIT License
-  Source  : https://github.com/nicedoc/nicedoc.io or https://bellard.org/quickjs/
+  Source  : https://bellard.org/quickjs/ or via Alpine Linux source packages
 
 ------------------------------------------------------------------------------
 

--- a/docker/explicit/files/THIRD_PARTY_LICENSES
+++ b/docker/explicit/files/THIRD_PARTY_LICENSES
@@ -18,7 +18,7 @@ BuildKit (base image: moby/buildkit)
 QuickJS
   Website : https://bellard.org/quickjs/
   License : MIT License
-  Source  : https://github.com/nicedoc/nicedoc.io or https://bellard.org/quickjs/
+  Source  : https://bellard.org/quickjs/ or via Alpine Linux source packages
 
 ------------------------------------------------------------------------------
 

--- a/docker/sandbox/files/THIRD_PARTY_LICENSES
+++ b/docker/sandbox/files/THIRD_PARTY_LICENSES
@@ -32,7 +32,7 @@ s6-overlay
 QuickJS
   Website : https://bellard.org/quickjs/
   License : MIT License
-  Source  : https://github.com/nicedoc/nicedoc.io or https://bellard.org/quickjs/
+  Source  : https://bellard.org/quickjs/ or via Alpine Linux source packages
 
 ------------------------------------------------------------------------------
 

--- a/docker/transparent/files/THIRD_PARTY_LICENSES
+++ b/docker/transparent/files/THIRD_PARTY_LICENSES
@@ -46,7 +46,7 @@ s6-overlay
 QuickJS
   Website : https://bellard.org/quickjs/
   License : MIT License
-  Source  : https://github.com/nicedoc/nicedoc.io or https://bellard.org/quickjs/
+  Source  : https://bellard.org/quickjs/ or via Alpine Linux source packages
 
 ------------------------------------------------------------------------------
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -243,9 +243,13 @@ socket, or reading another process's memory).
   are bind-mounted onto themselves and kept writable; every other existing mount is remounted
   read-only inside the isolated mount namespace. This closes off tampering with anything outside
   those three paths — e.g. rewriting a binary earlier on `$PATH` to plant a payload for a later,
-  non-sandboxed step in the same job. The `writable` input adds further paths to the writable set
-  for tools that need to write elsewhere (e.g. a cache directory); setting it to `/` disables this
-  restriction entirely — see [Filesystem Access](./reference.md#filesystem-access) in Reference.
+  non-sandboxed step in the same job. The read-only remount is enforced, not best-effort: a
+  pseudo-filesystem that legitimately rejects a read-only remount (`proc`, `sysfs`, `cgroup2`,
+  etc.) is tolerated, but if any *real* filesystem cannot be made read-only the step fails closed
+  rather than running with it silently left writable. The `writable` input adds further paths to
+  the writable set for tools that need to write elsewhere (e.g. a cache directory); setting it to
+  `/` disables this restriction entirely — see
+  [Filesystem Access](./reference.md#filesystem-access) in Reference.
 
 ### Known Limitations
 
@@ -266,6 +270,11 @@ socket, or reading another process's memory).
 - **Linux only**: requires a Linux runner with passwordless `sudo` for the isolation setup itself
   (network namespace, veth, iptables) — the default on GitHub-hosted `ubuntu-*` runners. Not
   supported on Windows or macOS runners.
+- **Rootful Docker assumed**: the isolation joins the proxy container's network namespace via its
+  host-visible PID (`docker inspect .State.Pid`, entered as `/proc/<pid>/ns/net`). This assumes
+  containers share the host PID namespace, as they do on the default GitHub-hosted runner setup.
+  Under rootless Docker or `userns-remap`, that PID may not be directly reachable, so the sandbox
+  is not currently supported on those setups.
 - **Per-step overhead**: each `sandbox` step starts and stops its own proxy container, rather than
   sharing one across steps in the same job — this keeps allowlists independently configurable per
   step and keeps the traffic report's step-to-container mapping unambiguous, at the cost of

--- a/sandbox/dist/main.cjs
+++ b/sandbox/dist/main.cjs
@@ -7279,7 +7279,9 @@ const __dirname$2 = path.dirname(node_url.fileURLToPath("undefined" == typeof do
 function runIsolated({scriptPath: scriptPath, proxyPid: proxyPid, workdir: workdir, home: home, writablePaths: writablePaths = [], env: env, runScriptDir: runScriptDir}) {
   const runIsolatedShPath = path.join(__dirname$2, "..", "scripts", "run-isolated.sh"), envFilePath = function(env, dir) {
     const envFilePath = path.join(dir, "env-dump.bin"), buf = Buffer.concat(Object.entries(env).filter(([, v]) => void 0 !== v).map(([k, v]) => Buffer.from(`${k}=${v}\0`, "utf8")));
-    return node_fs.writeFileSync(envFilePath, buf), envFilePath;
+    return node_fs.writeFileSync(envFilePath, buf, {
+      mode: 384
+    }), envFilePath;
   }(env, runScriptDir), args = [ "-n", "--", runIsolatedShPath, "--proxy-pid", String(proxyPid), "--uid", String(process.getuid()), "--gid", String(process.getgid()), "--env-file", envFilePath ];
   workdir && args.push("--workdir", workdir), home && args.push("--home", home);
   for (const p of writablePaths) args.push("--writable", p);

--- a/sandbox/scripts/run-isolated.sh
+++ b/sandbox/scripts/run-isolated.sh
@@ -181,15 +181,34 @@ else
     # "remount,ro" changes the underlying superblock, which is shared with
     # the mount this was cloned from (i.e. the real host mount namespace)
     # even after make-rprivate -- only "remount,bind,ro" scopes the
-    # read-only flag to this one mount entry. Best-effort per mount (some
-    # pseudo-filesystems do not support remount) rather than fatal.
-    tac /proc/self/mountinfo | while read -r _ _ _ _ mnt_point _; do
+    # read-only flag to this one mount entry.
+    #
+    # A failed remount is NOT silently ignored: pseudo-filesystems that
+    # legitimately reject a read-only remount are tolerated (their
+    # writability is not a payload-planting surface for a later step), but
+    # any *real* filesystem left writable fails the run closed, so a silent
+    # remount failure can never quietly weaken the read-only guarantee
+    # documented in docs/security.md. In each mountinfo line the field
+    # immediately after the " - " separator is the filesystem type.
+    tac /proc/self/mountinfo | while read -r _ _ _ _ mnt_point rest; do
       skip=0
       for p in "$@"; do
         [ "$mnt_point" = "$p" ] && skip=1 && break
       done
       [ "$skip" = 1 ] && continue
-      mount -o remount,bind,ro "$mnt_point" 2>/dev/null || true
+      mount -o remount,bind,ro "$mnt_point" 2>/dev/null && continue
+      fstype=${rest#* - }
+      fstype=${fstype%% *}
+      case "$fstype" in
+        proc|procfs|sysfs|cgroup|cgroup2|devpts|mqueue|debugfs|tracefs|securityfs|\
+pstore|bpf|configfs|fusectl|hugetlbfs|binfmt_misc|autofs|efivarfs|nsfs|rpc_pipefs)
+          echo "run-isolated: note: pseudo-fs ${mnt_point} (${fstype}) rejected read-only remount; tolerated" >&2
+          ;;
+        *)
+          echo "ERROR: failed to remount ${mnt_point} (${fstype:-unknown}) read-only; refusing to run with it left writable" >&2
+          exit 1
+          ;;
+      esac
     done
   ' sh "${PROTECTED_PATHS[@]}"
 fi

--- a/sandbox/src/lib/isolated-exec.js
+++ b/sandbox/src/lib/isolated-exec.js
@@ -27,6 +27,12 @@ export function writeRunScript(runInput, dir) {
  * deliberately don't use `sudo -E` (its availability depends on a sudoers
  * SETENV tag, which isn't portable) — this file is the explicit channel
  * instead.
+ *
+ * Written 0600: this dump contains the whole process environment, including
+ * any secrets passed to the step via `env:`. The scratch dir is already
+ * 0700 (see withScratchDir), but restricting the file itself keeps the
+ * secrets unreadable to other local users even if the dir's mode is ever
+ * loosened, matching writeRunScript's own explicit mode.
  */
 export function writeEnvDump(env, dir) {
   const envFilePath = join(dir, "env-dump.bin");
@@ -35,7 +41,7 @@ export function writeEnvDump(env, dir) {
       .filter(([, v]) => v !== undefined)
       .map(([k, v]) => Buffer.from(`${k}=${v}\0`, "utf8")),
   );
-  writeFileSync(envFilePath, buf);
+  writeFileSync(envFilePath, buf, { mode: 0o600 });
   return envFilePath;
 }
 

--- a/sandbox/src/lib/isolated-exec.test.js
+++ b/sandbox/src/lib/isolated-exec.test.js
@@ -46,6 +46,14 @@ describe("writeEnvDump", () => {
       assert.equal(readFileSync(path, "utf8"), "FOO=bar\0");
     });
   });
+
+  it("writes the env dump 0600 (it can hold secrets from the step's env:)", () => {
+    withScratchDir((dir) => {
+      const path = writeEnvDump({ SECRET: "s3cr3t" }, dir);
+      const mode = statSync(path).mode & 0o777;
+      assert.equal(mode, 0o600);
+    });
+  });
 });
 
 describe("withScratchDir", () => {


### PR DESCRIPTION
## Summary

Follow-up hardening for the `sandbox` action (added in #155), from a security review of its isolation mechanism. The review found no exploitable network-isolation bypass; these changes instead tighten two defense-in-depth layers that were weaker than the docs implied, plus a couple of documentation/licensing corrections.

Two gaps stood out. The read-only filesystem restriction — which stops an isolated command from planting a payload for a later, non-sandboxed step — was best-effort: a failed `mount -o remount,bind,ro` was silently ignored, so a real filesystem could quietly stay writable while `docs/security.md` claimed "every other existing mount is remounted read-only". Separately, the environment dump that carries the step's env (including any secrets passed via `env:`) into the isolated namespace was written with the default mode rather than `0600`.

## Changes

- **Fail closed when a real filesystem can't be made read-only**: `run-isolated.sh` now tolerates only pseudo-filesystems (`proc`, `sysfs`, `cgroup2`, …) rejecting the read-only remount; any real filesystem left writable aborts the run instead of proceeding silently. `docs/security.md` is updated to describe this as enforced rather than best-effort.
- **Write the env dump `0600`**: the NUL-separated env dump (which can hold secrets from the step's `env:`) is now created `0600`, matching `writeRunScript`'s explicit mode, so it stays unreadable to other local users even if the `0700` scratch dir's mode is ever loosened. Adds a unit test asserting the mode.
- **Document the rootless-Docker limitation**: the isolation joins the proxy container's netns via its host-visible PID (`docker inspect .State.Pid`), which assumes rootful Docker sharing the host PID namespace; `docs/security.md` now notes rootless / `userns-remap` setups aren't supported.

## Testing

- Sandbox unit tests pass (`node --test 'sandbox/src/**/*.test.js'`), including the new `0600` mode assertion.
- The `run-isolated.sh` fail-close path uses Linux-only primitives and can't run natively on macOS; its `mountinfo` parsing and exit-code propagation through the pipe subshell were verified locally against sample data, but the `test_sandbox` job (real `ubuntu-latest` runner) remains the final word — it should stay green before merge.
