### PR TITLE
fix: handle read-only remount rejections on Docker-masked /proc mounts

### DIFF
--- a/run/scripts/run-isolated.sh
+++ b/run/scripts/run-isolated.sh
@@ -188,16 +188,27 @@ else
     # writability is not a payload-planting surface for a later step), but
     # any *real* filesystem left writable fails the run closed, so a silent
     # remount failure can never quietly weaken the read-only guarantee
-    # documented in docs/security.md. In each mountinfo line the field
-    # immediately after the " - " separator is the filesystem type.
-    tac /proc/self/mountinfo | while read -r _ _ _ _ mnt_point rest; do
+    # documented in docs/security.md. In each mountinfo line the 6th field
+    # holds the per-mount options, and the field immediately after the
+    # " - " separator is the filesystem type.
+    tac /proc/self/mountinfo | while read -r _ _ _ _ mnt_point mnt_opts rest; do
       skip=0
       for p in "$@"; do
         [ "$mnt_point" = "$p" ] && skip=1 && break
       done
       [ "$skip" = 1 ] && continue
+      # Already read-only per mountinfo -- no remount needed.
+      case ",${mnt_opts}," in
+        *,ro,*) continue ;;
+      esac
       mount -o remount,bind,ro "$mnt_point" 2>/dev/null && continue
-      fstype=${rest#* - }
+      # Retry once, re-bound onto itself: a mount that predates this
+      # namespace (e.g. a Docker maskedPath tmpfs re-parented under
+      # --mount-proc, seen on /proc/scsi and /proc/interrupts) can reject an
+      # otherwise-safe remount until re-bound gives it a fresh mount entry.
+      mount --bind "$mnt_point" "$mnt_point" 2>/dev/null &&
+        mount -o remount,bind,ro "$mnt_point" 2>/dev/null && continue
+      fstype=${rest#*- }
       fstype=${fstype%% *}
       case "$fstype" in
         proc|procfs|sysfs|cgroup|cgroup2|devpts|mqueue|debugfs|tracefs|securityfs|\


### PR DESCRIPTION
## Summary

`run-isolated.sh`'s read-only pass walks every mount under `/proc/self/mountinfo` and remounts each one read-only, failing the run closed if a *real* filesystem rejects the remount (see #156). Under Docker Desktop, this fails closed on paths that are actually already safe: `/proc/scsi` and `/proc/interrupts` are masked by Docker before `unshare`'s `--mount-proc` re-parents them under the fresh procfs it creates for the new PID namespace, and the kernel then rejects an otherwise-harmless remount on them — even though `/proc/scsi` is already `ro` per `mountinfo`, and `/proc/interrupts` is a `/dev/null` bind that cannot hold a payload either way. This breaks the mac dev loop (`make test_sandbox_mode`) without indicating any actual isolation gap.

Production CI's `test_sandbox` job runs `run-isolated.sh` directly on the runner host rather than nested inside a container, so it never hits Docker's `maskedPaths` mechanism and doesn't reproduce this.

## Changes

- **Skip mounts already reported read-only by `mountinfo`** — no remount needed, and this alone covers `/proc/scsi`
- **Retry once, re-bound onto itself, for mounts still rejecting the remount** — re-binding gives the kernel a fresh mount-table entry it will allow to remount, covering `/proc/interrupts` and any other mount that predates the namespace in the same way
