### PR TITLE
fix: apply the "latest" docker tag on release publish, not draft creation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,10 +91,9 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # transparent (default) publishes the plain version tag, matching the
           # pre-multi-engine tagging scheme; every other engine (explicit,
-          # proxy) publishes under a -<engine> suffix. Only transparent
-          # claims "latest", since it's the only engine with an unsuffixed tag
-          # namespace.
-          flavor: latest=${{ matrix.engine == 'transparent' }}
+          # proxy) publishes under a -<engine> suffix.
+          # "latest" is applied later, by update-major-tag.yml on release publish.
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.tag }}${{ matrix.engine != 'transparent' && format(',suffix=-{0}', matrix.engine) || '' }}
             type=raw,value=sha-${{ steps.version.outputs.sha }}${{ matrix.engine != 'transparent' && format('-{0}', matrix.engine) || '' }},priority=100

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,4 +1,4 @@
-name: Update major version tag
+name: Update major/minor/latest tags
 
 on:
   release:
@@ -52,7 +52,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Docker major/minor tags
+      - name: Update Docker major/minor/latest tags
         env:
           MAJOR: ${{ steps.version.outputs.major }}
           REPO: ghcr.io/${{ github.repository }}
@@ -66,12 +66,8 @@ jobs:
 
           LATEST_IN_MAJOR=$(echo "$TAGS" | grep -E "^v${MAJOR#v}\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
           LATEST_IN_MINOR=$(echo "$TAGS" | grep -E "^v${MINOR}\.[0-9]+$" | sort -V | tail -1)
+          LATEST_OVERALL=$(echo "$TAGS" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
 
-          # Each release publishes one image per proxy engine. transparent
-          # (default) uses the plain version tag (e.g. ${VERSION}); every
-          # other engine uses a -<engine> suffix (e.g. ${VERSION}-explicit,
-          # ${VERSION}-proxy). Update the floating major/minor tag for each
-          # engine independently.
           for ENGINE in transparent explicit proxy; do
             SUFFIX=""
             if [ "$ENGINE" != "transparent" ]; then
@@ -82,5 +78,8 @@ jobs:
             fi
             if [ "$TAG" = "$LATEST_IN_MAJOR" ]; then
               docker buildx imagetools create --tag "${REPO}:${MAJOR#v}${SUFFIX}" "${REPO}:${VERSION}${SUFFIX}"
+            fi
+            if [ "$ENGINE" = "transparent" ] && [ "$TAG" = "$LATEST_OVERALL" ]; then
+              docker buildx imagetools create --tag "${REPO}:latest" "${REPO}:${VERSION}"
             fi
           done


### PR DESCRIPTION
## Summary

`docker-publish.yml` tags the `transparent` engine's image `latest` unconditionally via `flavor: latest=${{ matrix.engine == 'transparent' }}`, and that workflow runs on tag push — which happens as part of creating the *draft* release in `release.yml`, before anyone has reviewed or published it. So `latest` moves onto the new version while the release is still a draft, not when it's actually published. `update-major-tag.yml` already gets this right for the major/minor floating tags, since it's triggered by `release: published`; this PR moves `latest` onto the same trigger.

## Changes

- **Stop tagging `latest` in `docker-publish.yml`** — `flavor: latest=false` disables it at build/push time.
- **Move `latest` to `update-major-tag.yml`, gated on `release: published`** — adds a `LATEST_OVERALL` check (highest semver tag across all releases) alongside the existing `LATEST_IN_MAJOR`/`LATEST_IN_MINOR`, and retags `${REPO}:latest` for the `transparent` engine only, matching `latest`'s previous scope (no `-explicit`/`-proxy` variant existed before either).
