### PR TITLE
feat: add known_blocked_rules to mark expected blocked connections

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -332,6 +332,61 @@ jobs:
 
       # No cleanup step: run stops its own proxy container in its finally block.
 
+  # A blocked connection matching known_blocked_rules must not fail the step
+  # even though fail_on_blocked defaults to true (per-row matching logic
+  # itself is already unit-tested; this proves the INPUT_KNOWN_BLOCKED_RULES
+  # -> container report -> pass/fail wiring works end-to-end).
+  test_sandbox_known_blocked_rules:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.test_sandbox == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: "e2e: test (sandbox, known_blocked_rules)"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Build local sandbox proxy image
+        run: docker compose build proxy
+
+      - name: Resolve local image ref
+        id: local_image
+        run: echo "ref=$(docker compose config --images proxy)" >> "$GITHUB_OUTPUT"
+
+      - name: Rebuild run action with the local-image test hook enabled
+        env:
+          BUILDCAGE_BUILD_TEST_HOOKS: "1"
+        run: pnpm build
+
+      - name: Run an isolated command whose only blocked connection is known_blocked_rules-listed
+        id: known_blocked_connection
+        uses: ./run
+        env:
+          BUILDCAGE_LOCAL_IMAGE_REF: ${{ steps.local_image.outputs.ref }}
+        with:
+          allowed_https_rules: example.com:443
+          allowed_http_rules: example.com:80
+          known_blocked_rules: neverssl.com:80
+          # fail_on_blocked intentionally left at its default (true).
+          run: wget -q -T 5 -O /dev/null http://neverssl.com/ || true
+
+      - name: Verify known_blocked_rules kept the step from failing
+        if: always()
+        run: |
+          if [ "${{ steps.known_blocked_connection.outcome }}" != "success" ]; then
+            echo "::error::Expected the step to succeed (the only blocked connection matches known_blocked_rules), but it reported '${{ steps.known_blocked_connection.outcome }}'"
+            exit 1
+          fi
+          echo "OK: known_blocked_rules correctly kept the step from failing"
+
+      # No cleanup step: run stops its own proxy container in its finally block.
+
   # Proves container/network/Compose-project namespacing holds under
   # Actions' own `parallel:` keyword; the direct-script counterpart is
   # in test-integration.yml.
@@ -425,6 +480,7 @@ jobs:
         test_sandbox_audit_mode,
         test_sandbox_enforcement,
         test_sandbox_fail_on_blocked,
+        test_sandbox_known_blocked_rules,
         test_sandbox_concurrency,
       ]
     if: always()

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -279,15 +279,17 @@ jobs:
 
       # No cleanup step: run stops its own proxy container in its finally block.
 
-  # fail_on_blocked defaults to true; verify a blocked connection actually
-  # fails the step (exit-code logic itself is already unit-tested).
+  # fail_on_blocked defaults to true and should fail on a blocked
+  # connection; known_blocked_rules should exempt a matching one. Both are
+  # unit-tested at the logic level — this proves the wiring end-to-end,
+  # reusing the same built image for both cases.
   test_sandbox_fail_on_blocked:
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.test_sandbox == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    name: "e2e: test (sandbox, fail_on_blocked)"
+    name: "e2e: test (sandbox, fail_on_blocked & known_blocked_rules)"
 
     steps:
       - name: Checkout
@@ -329,40 +331,6 @@ jobs:
             exit 1
           fi
           echo "OK: fail_on_blocked correctly failed the step"
-
-      # No cleanup step: run stops its own proxy container in its finally block.
-
-  # A blocked connection matching known_blocked_rules must not fail the step
-  # even though fail_on_blocked defaults to true (per-row matching logic
-  # itself is already unit-tested; this proves the INPUT_KNOWN_BLOCKED_RULES
-  # -> container report -> pass/fail wiring works end-to-end).
-  test_sandbox_known_blocked_rules:
-    needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.test_sandbox == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    name: "e2e: test (sandbox, known_blocked_rules)"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: ./.github/actions/setup-pnpm
-
-      - name: Build local sandbox proxy image
-        run: docker compose build proxy
-
-      - name: Resolve local image ref
-        id: local_image
-        run: echo "ref=$(docker compose config --images proxy)" >> "$GITHUB_OUTPUT"
-
-      - name: Rebuild run action with the local-image test hook enabled
-        env:
-          BUILDCAGE_BUILD_TEST_HOOKS: "1"
-        run: pnpm build
 
       - name: Run an isolated command whose only blocked connection is known_blocked_rules-listed
         id: known_blocked_connection
@@ -480,7 +448,6 @@ jobs:
         test_sandbox_audit_mode,
         test_sandbox_enforcement,
         test_sandbox_fail_on_blocked,
-        test_sandbox_known_blocked_rules,
         test_sandbox_concurrency,
       ]
     if: always()

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -157,7 +157,7 @@ jobs:
         # This job tests proxy enforcement directly, not the report action
         # itself — only test_action's real `uses: ./report` should produce a
         # Job Summary, so print to stdout here instead.
-        run: GITHUB_STEP_SUMMARY= node report/src/main.js ./compose.yaml || true
+        run: GITHUB_STEP_SUMMARY='' node report/src/main.js ./compose.yaml || true
 
       - name: Run assertions
         env:

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ test_sandbox_integration: ## Run the run action's integration tests (needs BUILD
 	@./run/test/integration-test-nested-mount-readonly.sh
 	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
 	@./run/test/integration-test-concurrent.sh
+	@./run/test/integration-test-known-blocked-rules.sh
 
 .PHONY: test_unit
 test_unit: test_setup test_report test_sandbox_unit test_qjs ## Run unit tests

--- a/core/lib/known-blocked.js
+++ b/core/lib/known-blocked.js
@@ -1,33 +1,17 @@
 /**
- * Shared logic for the `known_blocked_rules` input (run/report actions):
- * domains expected to be blocked intentionally, so a blocked connection
- * matching one of these rules doesn't fail the step even when
- * fail_on_blocked is true. Rules use the same wildcard/~regex syntax as
- * allowed_*_rules (see core/shared/lib/rules.js) but are never sent to the
- * container's ACL — they only affect this action's own pass/fail decision
- * and Job Summary rendering.
+ * Shared logic for `known_blocked_rules`: domains expected to be blocked,
+ * so a matching blocked connection doesn't fail the step even when
+ * fail_on_blocked is true. Never sent to the container's ACL — only
+ * affects this action's pass/fail decision and Job Summary rendering.
  */
 import { convertRule } from "../shared/lib/rules.js";
-
-/**
- * Parse+validate `known_blocked_rules` input into raw rule strings.
- *
- * @param {string|undefined} rulesInput
- * @returns {string[]}
- * @throws {Error} if any rule has invalid wildcard/regex syntax
- */
-export function parseKnownBlockedRules(rulesInput) {
-  const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  rules.forEach(convertRule); // validate eagerly; throws on bad wildcard/regex syntax
-  return rules;
-}
 
 /**
  * Tag each aggregated blocked-hosts row with `expected: boolean` — true iff
  * its `host:port` matches at least one known_blocked_rules pattern.
  *
  * @param {{host:string, port:string, ruleType:string, reason:string, count:number}[]} blockedRows
- * @param {string[]} knownBlockedRules - as returned by parseKnownBlockedRules
+ * @param {string[]} knownBlockedRules - as returned by parseAndValidateRules
  * @returns {({host:string, port:string, ruleType:string, reason:string, count:number, expected:boolean})[]}
  */
 export function annotateKnownBlocked(blockedRows, knownBlockedRules) {
@@ -63,15 +47,40 @@ export function determineBlockedOutcome({ isAudit, failOnBlocked, blockedCount, 
 /**
  * Build the annotation message text for a blocked-connections check.
  *
- * @param {{blockedCount: number, blockedRows: object[], knownBlockedRulesUsed: boolean, engineLabel: "sandbox"|"proxy"}} params
+ * In audit mode the text always stays the fixed-format base string,
+ * regardless of known_blocked_rules matching — audit mode's pass/fail
+ * outcome is unaffected by matching (see determineBlockedOutcome), so
+ * varying the notice text there would be misleading and would silently
+ * break any tooling that matches the old fixed-format notice.
+ *
+ * @param {{blockedCount: number, blockedRows: object[], engineLabel: "sandbox"|"proxy", isAudit: boolean}} params
  * @returns {string}
  */
-export function buildBlockedMessage({ blockedCount, blockedRows, knownBlockedRulesUsed, engineLabel }) {
+export function buildBlockedMessage({ blockedCount, blockedRows, engineLabel, isAudit }) {
   const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
-  if (!knownBlockedRulesUsed) return base;
+  if (isAudit) return base;
   const unexpected = blockedRows.filter((row) => !row.expected).length;
-  const expected = blockedRows.length - unexpected;
-  if (expected === 0) return base;
+  if (unexpected === blockedRows.length) return base; // nothing matched (incl. known_blocked_rules unset)
   if (unexpected === 0) return `${base}, all matched known_blocked_rules (expected)`;
   return `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
+}
+
+/**
+ * Single entry point composing the three functions above. Both
+ * run/src/lib/report.js and report/src/main.js call this once and thread
+ * the result through their table rendering and annotation code, rather
+ * than each recomputing annotateKnownBlocked independently.
+ *
+ * @param {{mode: string|null, blockedCount?: number, sections?: {blocked?: object[]}}} report
+ * @param {{knownBlockedRules: string[], failOnBlocked: boolean, engineLabel: "sandbox"|"proxy"}} options
+ * @returns {{blockedRows: object[], showExpected: boolean, outcome: {level: string, shouldFail: boolean}, message: string|null}}
+ */
+export function evaluateBlockedReport(report, { knownBlockedRules, failOnBlocked, engineLabel }) {
+  const isAudit = report.mode === "audit";
+  const blockedRows = annotateKnownBlocked(report.sections?.blocked ?? [], knownBlockedRules);
+  const outcome = determineBlockedOutcome({ isAudit, failOnBlocked, blockedCount: report.blockedCount ?? 0, blockedRows });
+  const message = outcome.level === "none"
+    ? null
+    : buildBlockedMessage({ blockedCount: report.blockedCount ?? 0, blockedRows, engineLabel, isAudit });
+  return { blockedRows, showExpected: knownBlockedRules.length > 0, outcome, message };
 }

--- a/core/lib/known-blocked.js
+++ b/core/lib/known-blocked.js
@@ -1,0 +1,77 @@
+/**
+ * Shared logic for the `known_blocked_rules` input (run/report actions):
+ * domains expected to be blocked intentionally, so a blocked connection
+ * matching one of these rules doesn't fail the step even when
+ * fail_on_blocked is true. Rules use the same wildcard/~regex syntax as
+ * allowed_*_rules (see core/shared/lib/rules.js) but are never sent to the
+ * container's ACL — they only affect this action's own pass/fail decision
+ * and Job Summary rendering.
+ */
+import { convertRule } from "../shared/lib/rules.js";
+
+/**
+ * Parse+validate `known_blocked_rules` input into raw rule strings.
+ *
+ * @param {string|undefined} rulesInput
+ * @returns {string[]}
+ * @throws {Error} if any rule has invalid wildcard/regex syntax
+ */
+export function parseKnownBlockedRules(rulesInput) {
+  const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+  rules.forEach(convertRule); // validate eagerly; throws on bad wildcard/regex syntax
+  return rules;
+}
+
+/**
+ * Tag each aggregated blocked-hosts row with `expected: boolean` — true iff
+ * its `host:port` matches at least one known_blocked_rules pattern.
+ *
+ * @param {{host:string, port:string, ruleType:string, reason:string, count:number}[]} blockedRows
+ * @param {string[]} knownBlockedRules - as returned by parseKnownBlockedRules
+ * @returns {({host:string, port:string, ruleType:string, reason:string, count:number, expected:boolean})[]}
+ */
+export function annotateKnownBlocked(blockedRows, knownBlockedRules) {
+  const matchers = knownBlockedRules.map((rule) => new RegExp(convertRule(rule)));
+  return blockedRows.map((row) => ({
+    ...row,
+    expected: matchers.some((re) => re.test(`${row.host}:${row.port}`)),
+  }));
+}
+
+/**
+ * Decide whether blocked connections should fail the step.
+ *
+ * `blockedRows` must already be annotated via annotateKnownBlocked. Uses
+ * per-row matching rather than count arithmetic because `blockedCount`'s
+ * meaning differs by proxy engine (transparent: total blocked events;
+ * explicit: aggregated row count — see setup/docker/explicit/scripts/report.js),
+ * so subtracting summed row counts from it isn't reliable. An empty
+ * `blockedRows` with a nonzero `blockedCount` (malformed/incomplete report
+ * data) is treated as unexpected too (fail closed).
+ *
+ * @param {{isAudit: boolean, failOnBlocked: boolean, blockedCount: number, blockedRows: object[]}} params
+ * @returns {{level: "none"|"notice"|"error", shouldFail: boolean}}
+ */
+export function determineBlockedOutcome({ isAudit, failOnBlocked, blockedCount, blockedRows }) {
+  if (!blockedCount) return { level: "none", shouldFail: false };
+  if (isAudit) return { level: "notice", shouldFail: false };
+  const hasUnexpected = blockedRows.length === 0 || blockedRows.some((row) => !row.expected);
+  if (failOnBlocked && hasUnexpected) return { level: "error", shouldFail: true };
+  return { level: "notice", shouldFail: false };
+}
+
+/**
+ * Build the annotation message text for a blocked-connections check.
+ *
+ * @param {{blockedCount: number, blockedRows: object[], knownBlockedRulesUsed: boolean, engineLabel: "sandbox"|"proxy"}} params
+ * @returns {string}
+ */
+export function buildBlockedMessage({ blockedCount, blockedRows, knownBlockedRulesUsed, engineLabel }) {
+  const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
+  if (!knownBlockedRulesUsed) return base;
+  const unexpected = blockedRows.filter((row) => !row.expected).length;
+  const expected = blockedRows.length - unexpected;
+  if (expected === 0) return base;
+  if (unexpected === 0) return `${base}, all matched known_blocked_rules (expected)`;
+  return `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
+}

--- a/core/lib/known-blocked.test.js
+++ b/core/lib/known-blocked.test.js
@@ -1,43 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
-  parseKnownBlockedRules,
   annotateKnownBlocked,
   determineBlockedOutcome,
   buildBlockedMessage,
+  evaluateBlockedReport,
 } from "./known-blocked.js";
-
-describe("parseKnownBlockedRules", () => {
-  it("parses whitespace-separated rules", () => {
-    assert.deepEqual(
-      parseKnownBlockedRules("a.example.com:443 b.example.com:80"),
-      ["a.example.com:443", "b.example.com:80"],
-    );
-  });
-
-  it("returns an empty array for undefined input", () => {
-    assert.deepEqual(parseKnownBlockedRules(undefined), []);
-  });
-
-  it("returns an empty array for empty/whitespace-only input", () => {
-    assert.deepEqual(parseKnownBlockedRules("   "), []);
-  });
-
-  it("throws on invalid wildcard syntax", () => {
-    assert.throws(() => parseKnownBlockedRules("w*x.example.com:443"), /Invalid wildcard/);
-  });
-
-  it("throws on invalid regex syntax", () => {
-    assert.throws(() => parseKnownBlockedRules("~^(unclosed"), /Invalid regex/);
-  });
-
-  it("accepts a mix of wildcard and ~regex rules", () => {
-    assert.deepEqual(
-      parseKnownBlockedRules("*.example.com:443 ~^api\\.example\\.com:443$"),
-      ["*.example.com:443", "~^api\\.example\\.com:443$"],
-    );
-  });
-});
 
 describe("annotateKnownBlocked", () => {
   const row = (overrides = {}) => ({
@@ -150,10 +118,10 @@ describe("determineBlockedOutcome", () => {
 });
 
 describe("buildBlockedMessage", () => {
-  it("matches the legacy wording when known_blocked_rules is unused", () => {
+  it("matches the legacy wording when no rows matched known_blocked_rules", () => {
     const message = buildBlockedMessage({
       blockedCount: 2, blockedRows: [{ expected: false }, { expected: false }],
-      knownBlockedRulesUsed: false, engineLabel: "sandbox",
+      engineLabel: "sandbox", isAudit: false,
     });
     assert.equal(message, "2 blocked connection(s) detected by buildcage sandbox");
   });
@@ -161,7 +129,7 @@ describe("buildBlockedMessage", () => {
   it("notes that all rows matched when every row is expected", () => {
     const message = buildBlockedMessage({
       blockedCount: 3, blockedRows: [{ expected: true }, { expected: true }],
-      knownBlockedRulesUsed: true, engineLabel: "proxy",
+      engineLabel: "proxy", isAudit: false,
     });
     assert.match(message, /all matched known_blocked_rules \(expected\)/);
   });
@@ -169,16 +137,102 @@ describe("buildBlockedMessage", () => {
   it("reports the unmatched count when some rows are unexpected", () => {
     const message = buildBlockedMessage({
       blockedCount: 3, blockedRows: [{ expected: true }, { expected: false }],
-      knownBlockedRulesUsed: true, engineLabel: "sandbox",
+      engineLabel: "sandbox", isAudit: false,
     });
     assert.match(message, /1 of 2 distinct blocked host\(s\) unmatched by known_blocked_rules/);
   });
 
-  it("matches the legacy wording when known_blocked_rules is set but nothing matched", () => {
-    const message = buildBlockedMessage({
-      blockedCount: 2, blockedRows: [{ expected: false }, { expected: false }],
-      knownBlockedRulesUsed: true, engineLabel: "sandbox",
+  // Audit's outcome never depends on matching (see determineBlockedOutcome),
+  // so the message shouldn't either.
+  describe("audit mode — text must never vary with known_blocked_rules matching", () => {
+    const fixedText = "5 blocked connection(s) detected by buildcage sandbox";
+
+    it("stays fixed when every row matched", () => {
+      const message = buildBlockedMessage({
+        blockedCount: 5, blockedRows: [{ expected: true }, { expected: true }],
+        engineLabel: "sandbox", isAudit: true,
+      });
+      assert.equal(message, fixedText);
     });
-    assert.equal(message, "2 blocked connection(s) detected by buildcage sandbox");
+
+    it("stays fixed when some rows are unmatched", () => {
+      const message = buildBlockedMessage({
+        blockedCount: 5, blockedRows: [{ expected: true }, { expected: false }],
+        engineLabel: "sandbox", isAudit: true,
+      });
+      assert.equal(message, fixedText);
+    });
+
+    it("stays fixed when no rows matched", () => {
+      const message = buildBlockedMessage({
+        blockedCount: 5, blockedRows: [{ expected: false }, { expected: false }],
+        engineLabel: "sandbox", isAudit: true,
+      });
+      assert.equal(message, fixedText);
+    });
+  });
+});
+
+describe("evaluateBlockedReport", () => {
+  it("returns level 'none' and a null message when there are no blocked connections", () => {
+    const result = evaluateBlockedReport(
+      { mode: "restrict", blockedCount: 0, sections: {} },
+      { knownBlockedRules: [], failOnBlocked: true, engineLabel: "sandbox" },
+    );
+    assert.deepEqual(result.outcome, { level: "none", shouldFail: false });
+    assert.equal(result.message, null);
+  });
+
+  it("does not crash when report.sections is undefined", () => {
+    const result = evaluateBlockedReport(
+      { mode: "restrict", blockedCount: 0 },
+      { knownBlockedRules: [], failOnBlocked: true, engineLabel: "sandbox" },
+    );
+    assert.deepEqual(result.blockedRows, []);
+    assert.deepEqual(result.outcome, { level: "none", shouldFail: false });
+  });
+
+  it("in audit mode, the message stays fixed even when known_blocked_rules matches", () => {
+    const report = {
+      mode: "audit",
+      blockedCount: 1,
+      sections: { blocked: [{ host: "known.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 1 }] },
+    };
+    const result = evaluateBlockedReport(report, {
+      knownBlockedRules: ["known.example.com:443"], failOnBlocked: true, engineLabel: "sandbox",
+    });
+    assert.equal(result.outcome.level, "notice");
+    assert.equal(result.message, "1 blocked connection(s) detected by buildcage sandbox");
+  });
+
+  it("in restrict mode, returns notice (not error) when every blocked row matches", () => {
+    const report = {
+      mode: "restrict",
+      blockedCount: 1,
+      sections: { blocked: [{ host: "known.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 1 }] },
+    };
+    const result = evaluateBlockedReport(report, {
+      knownBlockedRules: ["known.example.com:443"], failOnBlocked: true, engineLabel: "sandbox",
+    });
+    assert.deepEqual(result.outcome, { level: "notice", shouldFail: false });
+    assert.equal(result.showExpected, true);
+  });
+
+  it("in restrict mode, returns error when a blocked row is unexpected", () => {
+    const report = {
+      mode: "restrict",
+      blockedCount: 1,
+      sections: { blocked: [{ host: "unknown.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 1 }] },
+    };
+    const result = evaluateBlockedReport(report, {
+      knownBlockedRules: ["known.example.com:443"], failOnBlocked: true, engineLabel: "sandbox",
+    });
+    assert.deepEqual(result.outcome, { level: "error", shouldFail: true });
+  });
+
+  it("showExpected is false when known_blocked_rules is empty", () => {
+    const report = { mode: "restrict", blockedCount: 1, sections: { blocked: [{ host: "a.com", port: "443", ruleType: "HTTPS", reason: "-", count: 1 }] } };
+    const result = evaluateBlockedReport(report, { knownBlockedRules: [], failOnBlocked: true, engineLabel: "sandbox" });
+    assert.equal(result.showExpected, false);
   });
 });

--- a/core/lib/known-blocked.test.js
+++ b/core/lib/known-blocked.test.js
@@ -1,0 +1,184 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseKnownBlockedRules,
+  annotateKnownBlocked,
+  determineBlockedOutcome,
+  buildBlockedMessage,
+} from "./known-blocked.js";
+
+describe("parseKnownBlockedRules", () => {
+  it("parses whitespace-separated rules", () => {
+    assert.deepEqual(
+      parseKnownBlockedRules("a.example.com:443 b.example.com:80"),
+      ["a.example.com:443", "b.example.com:80"],
+    );
+  });
+
+  it("returns an empty array for undefined input", () => {
+    assert.deepEqual(parseKnownBlockedRules(undefined), []);
+  });
+
+  it("returns an empty array for empty/whitespace-only input", () => {
+    assert.deepEqual(parseKnownBlockedRules("   "), []);
+  });
+
+  it("throws on invalid wildcard syntax", () => {
+    assert.throws(() => parseKnownBlockedRules("w*x.example.com:443"), /Invalid wildcard/);
+  });
+
+  it("throws on invalid regex syntax", () => {
+    assert.throws(() => parseKnownBlockedRules("~^(unclosed"), /Invalid regex/);
+  });
+
+  it("accepts a mix of wildcard and ~regex rules", () => {
+    assert.deepEqual(
+      parseKnownBlockedRules("*.example.com:443 ~^api\\.example\\.com:443$"),
+      ["*.example.com:443", "~^api\\.example\\.com:443$"],
+    );
+  });
+});
+
+describe("annotateKnownBlocked", () => {
+  const row = (overrides = {}) => ({
+    host: "evil.example.com",
+    port: "443",
+    ruleType: "HTTPS",
+    reason: "not in allowlist",
+    count: 3,
+    ...overrides,
+  });
+
+  it("marks all rows as not expected when no rules are given", () => {
+    const result = annotateKnownBlocked([row()], []);
+    assert.equal(result[0].expected, false);
+  });
+
+  it("marks a row as expected on an exact host:port match", () => {
+    const result = annotateKnownBlocked([row()], ["evil.example.com:443"]);
+    assert.equal(result[0].expected, true);
+  });
+
+  it("marks a row as expected on a wildcard match", () => {
+    const result = annotateKnownBlocked([row()], ["*.example.com:443"]);
+    assert.equal(result[0].expected, true);
+  });
+
+  it("marks a row as expected on a ~regex match", () => {
+    const result = annotateKnownBlocked([row()], ["~^evil\\.example\\.com:443$"]);
+    assert.equal(result[0].expected, true);
+  });
+
+  it("does not match when the port differs", () => {
+    const result = annotateKnownBlocked([row({ port: "80" })], ["evil.example.com:443"]);
+    assert.equal(result[0].expected, false);
+  });
+
+  it("preserves the original row fields", () => {
+    const result = annotateKnownBlocked([row()], []);
+    assert.equal(result[0].host, "evil.example.com");
+    assert.equal(result[0].port, "443");
+    assert.equal(result[0].ruleType, "HTTPS");
+    assert.equal(result[0].reason, "not in allowlist");
+    assert.equal(result[0].count, 3);
+  });
+
+  it("annotates each row independently across a mixed list", () => {
+    const result = annotateKnownBlocked(
+      [row({ host: "known.example.com" }), row({ host: "unknown.example.com" })],
+      ["known.example.com:443"],
+    );
+    assert.equal(result[0].expected, true);
+    assert.equal(result[1].expected, false);
+  });
+});
+
+describe("determineBlockedOutcome", () => {
+  it("returns none when there are no blocked connections", () => {
+    assert.deepEqual(
+      determineBlockedOutcome({ isAudit: false, failOnBlocked: true, blockedCount: 0, blockedRows: [] }),
+      { level: "none", shouldFail: false },
+    );
+  });
+
+  it("always returns notice in audit mode, even with unmatched rows", () => {
+    assert.deepEqual(
+      determineBlockedOutcome({
+        isAudit: true, failOnBlocked: true, blockedCount: 2,
+        blockedRows: [{ expected: false }],
+      }),
+      { level: "notice", shouldFail: false },
+    );
+  });
+
+  it("returns notice (not error) when every blocked row matched known_blocked_rules", () => {
+    assert.deepEqual(
+      determineBlockedOutcome({
+        isAudit: false, failOnBlocked: true, blockedCount: 3,
+        blockedRows: [{ expected: true }, { expected: true }],
+      }),
+      { level: "notice", shouldFail: false },
+    );
+  });
+
+  it("returns error when at least one blocked row is unexpected", () => {
+    assert.deepEqual(
+      determineBlockedOutcome({
+        isAudit: false, failOnBlocked: true, blockedCount: 3,
+        blockedRows: [{ expected: true }, { expected: false }],
+      }),
+      { level: "error", shouldFail: true },
+    );
+  });
+
+  it("returns notice when failOnBlocked is false, even with unexpected rows", () => {
+    assert.deepEqual(
+      determineBlockedOutcome({
+        isAudit: false, failOnBlocked: false, blockedCount: 2,
+        blockedRows: [{ expected: false }],
+      }),
+      { level: "notice", shouldFail: false },
+    );
+  });
+
+  it("fails closed when blockedRows is empty but blockedCount is nonzero", () => {
+    assert.deepEqual(
+      determineBlockedOutcome({ isAudit: false, failOnBlocked: true, blockedCount: 2, blockedRows: [] }),
+      { level: "error", shouldFail: true },
+    );
+  });
+});
+
+describe("buildBlockedMessage", () => {
+  it("matches the legacy wording when known_blocked_rules is unused", () => {
+    const message = buildBlockedMessage({
+      blockedCount: 2, blockedRows: [{ expected: false }, { expected: false }],
+      knownBlockedRulesUsed: false, engineLabel: "sandbox",
+    });
+    assert.equal(message, "2 blocked connection(s) detected by buildcage sandbox");
+  });
+
+  it("notes that all rows matched when every row is expected", () => {
+    const message = buildBlockedMessage({
+      blockedCount: 3, blockedRows: [{ expected: true }, { expected: true }],
+      knownBlockedRulesUsed: true, engineLabel: "proxy",
+    });
+    assert.match(message, /all matched known_blocked_rules \(expected\)/);
+  });
+
+  it("reports the unmatched count when some rows are unexpected", () => {
+    const message = buildBlockedMessage({
+      blockedCount: 3, blockedRows: [{ expected: true }, { expected: false }],
+      knownBlockedRulesUsed: true, engineLabel: "sandbox",
+    });
+    assert.match(message, /1 of 2 distinct blocked host\(s\) unmatched by known_blocked_rules/);
+  });
+
+  it("matches the legacy wording when known_blocked_rules is set but nothing matched", () => {
+    const message = buildBlockedMessage({
+      blockedCount: 2, blockedRows: [{ expected: false }, { expected: false }],
+      knownBlockedRulesUsed: true, engineLabel: "sandbox",
+    });
+    assert.equal(message, "2 blocked connection(s) detected by buildcage sandbox");
+  });
+});

--- a/core/lib/markdown-table.js
+++ b/core/lib/markdown-table.js
@@ -1,0 +1,26 @@
+/**
+ * Render aggregated host rows as a GitHub-flavored markdown table. Shared by
+ * run/src/lib/report.js and report/src/main.js so both actions' Job Summary
+ * tables render identically.
+ *
+ * @param {{host:string, port:string, ruleType:string, reason?:string, count:number, expected?:boolean}[]} rows
+ * @param {{showReason?: boolean, showExpected?: boolean}} [options]
+ * @returns {string}
+ */
+export function markdownTable(rows, { showReason = false, showExpected = false } = {}) {
+  const headers = ["Host", "Rule"];
+  const aligns = ["---", "---"];
+  if (showReason) { headers.push("Reason"); aligns.push("---"); }
+  headers.push("Count"); aligns.push("---:");
+  if (showExpected) { headers.push("Expected"); aligns.push(":---:"); }
+
+  const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
+  for (const r of rows) {
+    const cells = [`${r.host}:${r.port}`, r.ruleType];
+    if (showReason) cells.push(r.reason);
+    cells.push(r.count);
+    if (showExpected) cells.push(r.expected ? "✅" : "");
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+  return lines.join("\n");
+}

--- a/core/lib/markdown-table.test.js
+++ b/core/lib/markdown-table.test.js
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { markdownTable } from "./markdown-table.js";
+
+describe("markdownTable", () => {
+  const row = (overrides = {}) => ({
+    host: "example.com",
+    port: "443",
+    ruleType: "HTTPS",
+    reason: "not in allowlist",
+    count: 2,
+    ...overrides,
+  });
+
+  it("renders a default 3-column table (Host, Rule, Count)", () => {
+    const table = markdownTable([row()]);
+    assert.equal(
+      table,
+      "| Host | Rule | Count |\n| --- | --- | ---: |\n| example.com:443 | HTTPS | 2 |",
+    );
+  });
+
+  it("adds a Reason column when showReason is true", () => {
+    const table = markdownTable([row()], { showReason: true });
+    assert.match(table, /^\| Host \| Rule \| Reason \| Count \|/);
+    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \|/);
+  });
+
+  it("adds an Expected column with a checkmark when showExpected is true and the row matched", () => {
+    const table = markdownTable([row({ expected: true })], { showExpected: true });
+    assert.match(table, /^\| Host \| Rule \| Count \| Expected \|/);
+    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| ✅ \|/);
+  });
+
+  it("leaves the Expected cell blank when the row did not match", () => {
+    const table = markdownTable([row({ expected: false })], { showExpected: true });
+    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| {2}\|/);
+  });
+
+  it("renders all 5 columns when both showReason and showExpected are true", () => {
+    const table = markdownTable([row({ expected: true })], { showReason: true, showExpected: true });
+    assert.match(table, /^\| Host \| Rule \| Reason \| Count \| Expected \|/);
+    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \| ✅ \|/);
+  });
+
+  it("renders only the header rows for an empty list", () => {
+    const table = markdownTable([]);
+    assert.equal(table, "| Host | Rule | Count |\n| --- | --- | ---: |");
+  });
+});

--- a/core/shared/lib/rules.js
+++ b/core/shared/lib/rules.js
@@ -4,14 +4,38 @@
  */
 
 /**
+ * Split a whitespace-separated rules string into individual rule tokens.
+ *
+ * @param {string|undefined} rulesInput
+ * @returns {string[]}
+ */
+export function splitRuleTokens(rulesInput) {
+  return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+}
+
+/**
  * Build regex rules from a space-separated input string.
  *
  * @param {string} rulesInput
  * @returns {string[]}
  */
 export function buildRules(rulesInput) {
-  const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  return rules.map(convertRule);
+  return splitRuleTokens(rulesInput).map(convertRule);
+}
+
+/**
+ * Split+validate a space-separated rules string, returning the raw
+ * (unconverted) rule tokens — for callers that need the original
+ * wildcard/~regex syntax preserved, such as known_blocked_rules.
+ *
+ * @param {string|undefined} rulesInput
+ * @returns {string[]}
+ * @throws {Error} if any rule has invalid wildcard/regex syntax
+ */
+export function parseAndValidateRules(rulesInput) {
+  const rules = splitRuleTokens(rulesInput);
+  rules.forEach(convertRule); // validate eagerly; throws on bad syntax
+  return rules;
 }
 
 /**

--- a/core/shared/lib/rules.property.test.js
+++ b/core/shared/lib/rules.property.test.js
@@ -7,7 +7,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 
-import { convertRule, buildRules } from "./rules.js";
+import { convertRule, buildRules, parseAndValidateRules } from "./rules.js";
 
 // ---------------------------------------------------------------------------
 // convertRule / wildcardToRegex
@@ -99,5 +99,38 @@ describe("buildRules – properties", () => {
         },
       ),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAndValidateRules
+// ---------------------------------------------------------------------------
+
+describe("parseAndValidateRules – properties", () => {
+  it("returns the same tokens buildRules derives its length from, unconverted", () => {
+    const validRule = fc
+      .tuple(
+        fc.stringMatching(/^[a-z][a-z0-9]{0,8}\.[a-z]{2,4}$/),
+        fc.integer({ min: 1, max: 65535 }),
+      )
+      .map(([domain, port]) => `${domain}:${port}`);
+
+    fc.assert(
+      fc.property(fc.array(validRule, { minLength: 0, maxLength: 5 }), (rules) => {
+        const input = rules.join(" ");
+        assert.deepEqual(parseAndValidateRules(input), rules);
+        assert.equal(parseAndValidateRules(input).length, buildRules(input).length);
+      }),
+    );
+  });
+
+  it("returns an empty array for empty/undefined input", () => {
+    assert.deepEqual(parseAndValidateRules(undefined), []);
+    assert.deepEqual(parseAndValidateRules(""), []);
+  });
+
+  it("throws on invalid syntax, matching buildRules' own validation", () => {
+    assert.throws(() => parseAndValidateRules("no-port-specified"));
+    assert.throws(() => buildRules("no-port-specified"));
   });
 });

--- a/core/shared/lib/rules.test.js
+++ b/core/shared/lib/rules.test.js
@@ -3,6 +3,7 @@ import {
   wildcardToRegex,
   convertRule,
   buildRules,
+  parseAndValidateRules,
 } from "./rules.js";
 
 // ---------------------------------------------------------------------------
@@ -159,6 +160,30 @@ describe("buildRules", () => {
       buildRules("~^custom\\.regex:(443|8080)$ example.com:443"),
       ["^custom\\.regex:(443|8080)$", "^example\\.com:443$"],
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAndValidateRules
+// ---------------------------------------------------------------------------
+describe("parseAndValidateRules", () => {
+  it("returns raw (unconverted) rule tokens", () => {
+    assert.deepEqual(
+      parseAndValidateRules("example.com:443 *.foo.com:8443"),
+      ["example.com:443", "*.foo.com:8443"],
+    );
+  });
+
+  it("empty input → empty array", () => {
+    assert.deepEqual(parseAndValidateRules(""), []);
+  });
+
+  it("validates syntax eagerly, throwing on invalid wildcard rules", () => {
+    assert.throws(() => parseAndValidateRules("w*.example.com:443"), /Invalid wildcard/);
+  });
+
+  it("validates syntax eagerly, throwing on invalid regex rules", () => {
+    assert.throws(() => parseAndValidateRules("~^(unclosed"), /Invalid regex/);
   });
 });
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -186,12 +186,21 @@ Use the domain names shown in the report to create your allowlist for restrict m
 
 In restrict mode, the report step fails if blocked connections are detected, causing the workflow to fail. You can disable this by setting `fail_on_blocked: false`. In audit mode, blocked connections (e.g., protocol errors) are reported but never cause the step to fail.
 
+If some blocked connections are expected — a known-noisy dependency, a domain you're deliberately
+keeping off the allowlist to confirm it stays blocked — list them in `known_blocked_rules` (same
+syntax as `allowed_https_rules`, see [Rule Syntax](./rules.md)). When every blocked connection
+matches `known_blocked_rules`, the step no longer fails even with `fail_on_blocked: true`, and a
+`::notice::` is emitted instead of `::error::`; any other, unmatched blocked connection still fails
+the step as before. Once `known_blocked_rules` is set, the Job Summary's Blocked Hosts table gains
+an extra **Expected** column (✅) marking the matched rows.
+
 ### Parameters
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `builder_name` | No | `buildcage` | Name of the builder container |
 | `fail_on_blocked` | No | `true` | Fail the step if blocked connections are detected (restrict mode only; ignored in audit mode) |
+| `known_blocked_rules` | No | empty | Domains expected to be blocked intentionally (wildcard or regex, port required); blocked connections matching these don't fail the step even when `fail_on_blocked` is `true` |
 
 ---
 
@@ -244,10 +253,13 @@ See the [restrict mode](../.github/workflows/example-run-restrict.yml) and
 | `allowed_http_rules` | No | empty | HTTP allow rules (wildcard or regex, port required) |
 | `allowed_ip_rules` | No | empty | IP address allow rules (wildcard or regex, port required) |
 | `fail_on_blocked` | No | `true` | Fail the step if blocked connections are detected (restrict mode only; ignored in audit mode) |
+| `known_blocked_rules` | No | empty | Domains expected to be blocked intentionally (wildcard or regex, port required); blocked connections matching these don't fail the step even when `fail_on_blocked` is `true` |
 | `writable` | No | empty | Additional writable directories (newline-separated), on top of `$GITHUB_WORKSPACE`, `$HOME`, `/tmp`, and `$RUNNER_TEMP` — see [Filesystem Access](#filesystem-access) below |
 | `label` | No | empty | Label appended to this step's Job Summary heading, e.g. `npm install` — useful to tell steps apart when `run` is used more than once in the same job |
 
-Rule syntax is identical to `setup`'s — see [Rule Syntax](#rule-syntax) above.
+Rule syntax is identical to `setup`'s — see [Rule Syntax](#rule-syntax) above. `known_blocked_rules`
+uses this same syntax; see the [Report Action](#report-action-dash14buildcagereport) section above
+for its exact semantics, which applies here too.
 
 ### Passing Values to `run`
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,6 @@
 # Rule Syntax
 
-Buildcage uses `allowed_https_rules`, `allowed_http_rules`, and `allowed_ip_rules` to control which destinations are accessible during Docker builds.
+Buildcage uses `allowed_https_rules`, `allowed_http_rules`, and `allowed_ip_rules` to control which destinations are accessible during Docker builds, and `known_blocked_rules` to mark destinations that are expected to be blocked rather than allowlisting them — see [Reference](./reference.md) for its exact semantics. All four share the syntax below.
 
 ## Delimiters
 

--- a/report/action.yml
+++ b/report/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Fail the step if blocked connections are detected"
     required: false
     default: 'true'
+  known_blocked_rules:
+    description: "Domains expected to be blocked intentionally (wildcard or ~regex), separated by whitespace. Port required. Blocked connections matching these rules don't fail the step even when fail_on_blocked is true — only unmatched (unexpected) blocked connections do. e.g., 'known-noisy.example.com:443'"
+    required: false
+    default: ''
 
 runs:
   using: node24

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -109,12 +109,46 @@ function aggregateAllowedHosts(builds, decision) {
   }(entries);
 }
 
+function convertRule(rule) {
+  if (rule.startsWith("~")) {
+    const regex = rule.slice(1);
+    try {
+      new RegExp(regex);
+    } catch (e) {
+      throw new Error(`Invalid regex in rule "${rule}": ${e.message}`);
+    }
+    return regex;
+  }
+  return `^${function(pattern) {
+    if (!/^[^:]+:(?:\d+|\*)$/.test(pattern)) throw new Error(`Invalid pattern "${pattern}"`);
+    const [domain, port] = pattern.split(":"), portRegex = "*" === port ? "\\d+" : port;
+    return `${function(domain) {
+      const regexParts = domain.split(".").map(part => {
+        if ("**" === part) return ".+";
+        if ("*" === part) return "[^.]+";
+        if (part.includes("*")) throw new Error(`Invalid wildcard in "${domain}": part "${part}" mixes "*" with other characters`);
+        return part.replace(/[.+^$()[\]{}|\\]/g, "\\$&").replace(/\?/g, "[^.]");
+      });
+      return regexParts.join("\\.");
+    }(domain)}:${portRegex}`;
+  }(rule)}$`;
+}
+
 const __dirname$1 = node_path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = process.argv[2] || node_path.join(__dirname$1, "../..", "setup", "compose.yaml"), composeEnv = {
   ...process.env,
   BUILDER_NAME: process.env.INPUT_BUILDER_NAME || "buildcage"
 };
 
-let jsonOutput;
+let knownBlockedRules, jsonOutput;
+
+try {
+  knownBlockedRules = function(rulesInput) {
+    const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+    return rules.forEach(convertRule), rules;
+  }(process.env.INPUT_KNOWN_BLOCKED_RULES);
+} catch (e) {
+  console.log(`::error::${e.message}`), process.exit(1);
+}
 
 try {
   jsonOutput = node_child_process.execFileSync("docker", [ "compose", "-f", composeFile, "exec", "builder", "sh", "-c", "qjs -m /opt/buildcage/scripts/report.js" ], {
@@ -147,14 +181,16 @@ if (console.log("::endgroup::"), console.log(), null === report.mode) {
   process.exit(0);
 }
 
-function markdownTable(rows, {showReason: showReason = !1} = {}) {
-  if (showReason) {
-    const lines = [ "| Host | Rule | Reason | Count |", "| --- | --- | --- | ---: |" ];
-    for (const r of rows) lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.reason} | ${r.count} |`);
-    return lines.join("\n");
+function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
+  const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
+  showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
+  aligns.push("---:"), showExpected && (headers.push("Expected"), aligns.push(":---:"));
+  const lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
+  for (const r of rows) {
+    const cells = [ `${r.host}:${r.port}`, r.ruleType ];
+    showReason && cells.push(r.reason), cells.push(r.count), showExpected && cells.push(r.expected ? "✅" : ""), 
+    lines.push(`| ${cells.join(" | ")} |`);
   }
-  const lines = [ "| Host | Rule | Count |", "| --- | --- | ---: |" ];
-  for (const r of rows) lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.count} |`);
   return lines.join("\n");
 }
 
@@ -229,6 +265,14 @@ if (isExplicit) try {
 
 let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
 
+const blocked = report.sections.blocked || [], annotatedBlocked = function(blockedRows, knownBlockedRules) {
+  const matchers = knownBlockedRules.map(rule => new RegExp(convertRule(rule)));
+  return blockedRows.map(row => ({
+    ...row,
+    expected: matchers.some(re => re.test(`${row.host}:${row.port}`))
+  }));
+}(blocked, knownBlockedRules), showExpected = knownBlockedRules.length > 0;
+
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
   audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n"), 
@@ -254,16 +298,17 @@ if (isAudit) {
     let md = "\n<details>\n";
     return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", 
     md += yaml, md += "```\n\n", md += "</details>\n", md;
-  }(audited, actionRepo, actionRef);
-  const blocked = report.sections.blocked || [];
-  blocked.length > 0 && (audited.length > 0 && (markdown += "\n"), markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, {
-    showReason: !0
+  }(audited, actionRepo, actionRef), blocked.length > 0 && (audited.length > 0 && (markdown += "\n"), 
+  markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+    showReason: !0,
+    showExpected: showExpected
   }) + "\n");
 } else {
-  const allowed = isExplicit ? aggregateAllowedHosts(builds, "ALLOWED") : report.sections.allowed || [], blocked = report.sections.blocked || [];
+  const allowed = isExplicit ? aggregateAllowedHosts(builds, "ALLOWED") : report.sections.allowed || [];
   allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n"), 
-  allowed.length > 0 && blocked.length > 0 && (markdown += "\n"), blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, {
-    showReason: !0
+  allowed.length > 0 && blocked.length > 0 && (markdown += "\n"), blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+    showReason: !0,
+    showExpected: showExpected
   }) + "\n");
 }
 
@@ -305,7 +350,41 @@ const outputForAction = Boolean(summaryFile), annotation = outputForAction ? {
   error() {}
 };
 
-if (report.blockedCount > 0) if (isAudit) annotation.notice(`${report.blockedCount} blocked connection(s) detected by buildcage proxy`); else {
-  "true" === (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() ? (annotation.error(`${report.blockedCount} blocked connection(s) detected by buildcage proxy`), 
-  process.exitCode = 1) : annotation.notice(`${report.blockedCount} blocked connection(s) detected by buildcage proxy`);
+const outcome = function({isAudit: isAudit, failOnBlocked: failOnBlocked, blockedCount: blockedCount, blockedRows: blockedRows}) {
+  if (!blockedCount) return {
+    level: "none",
+    shouldFail: !1
+  };
+  if (isAudit) return {
+    level: "notice",
+    shouldFail: !1
+  };
+  const hasUnexpected = 0 === blockedRows.length || blockedRows.some(row => !row.expected);
+  return failOnBlocked && hasUnexpected ? {
+    level: "error",
+    shouldFail: !0
+  } : {
+    level: "notice",
+    shouldFail: !1
+  };
+}({
+  isAudit: isAudit,
+  failOnBlocked: "true" === (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase(),
+  blockedCount: report.blockedCount,
+  blockedRows: annotatedBlocked
+});
+
+if ("none" !== outcome.level) {
+  const message = function({blockedCount: blockedCount, blockedRows: blockedRows, knownBlockedRulesUsed: knownBlockedRulesUsed, engineLabel: engineLabel}) {
+    const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
+    if (!knownBlockedRulesUsed) return base;
+    const unexpected = blockedRows.filter(row => !row.expected).length;
+    return 0 === blockedRows.length - unexpected ? base : 0 === unexpected ? `${base}, all matched known_blocked_rules (expected)` : `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
+  }({
+    blockedCount: report.blockedCount,
+    blockedRows: annotatedBlocked,
+    knownBlockedRulesUsed: knownBlockedRules.length > 0,
+    engineLabel: "proxy"
+  });
+  "error" === outcome.level ? (annotation.error(message), process.exitCode = 1) : annotation.notice(message);
 }

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -134,6 +134,19 @@ function convertRule(rule) {
   }(rule)}$`;
 }
 
+function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
+  const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
+  showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
+  aligns.push("---:"), showExpected && (headers.push("Expected"), aligns.push(":---:"));
+  const lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
+  for (const r of rows) {
+    const cells = [ `${r.host}:${r.port}`, r.ruleType ];
+    showReason && cells.push(r.reason), cells.push(r.count), showExpected && cells.push(r.expected ? "✅" : ""), 
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+  return lines.join("\n");
+}
+
 const __dirname$1 = node_path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = process.argv[2] || node_path.join(__dirname$1, "../..", "setup", "compose.yaml"), composeEnv = {
   ...process.env,
   BUILDER_NAME: process.env.INPUT_BUILDER_NAME || "buildcage"
@@ -143,7 +156,9 @@ let knownBlockedRules, jsonOutput;
 
 try {
   knownBlockedRules = function(rulesInput) {
-    const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+    const rules = function(rulesInput) {
+      return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+    }(rulesInput);
     return rules.forEach(convertRule), rules;
   }(process.env.INPUT_KNOWN_BLOCKED_RULES);
 } catch (e) {
@@ -179,19 +194,6 @@ if (console.log("::endgroup::"), console.log(), null === report.mode) {
   const summaryFile = process.env.GITHUB_STEP_SUMMARY;
   summaryFile && node_fs.appendFileSync(summaryFile, "No proxy logs found.\n"), console.log("No proxy logs found."), 
   process.exit(0);
-}
-
-function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
-  const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
-  showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
-  aligns.push("---:"), showExpected && (headers.push("Expected"), aligns.push(":---:"));
-  const lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
-  for (const r of rows) {
-    const cells = [ `${r.host}:${r.port}`, r.ruleType ];
-    showReason && cells.push(r.reason), cells.push(r.count), showExpected && cells.push(r.expected ? "✅" : ""), 
-    lines.push(`| ${cells.join(" | ")} |`);
-  }
-  return lines.join("\n");
 }
 
 const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", actionRef = process.env.GITHUB_ACTION_REF || "v2", isAudit = "audit" === report.mode, isExplicit = void 0 !== report.deniedTimeline;
@@ -263,15 +265,59 @@ if (isExplicit) try {
   console.log("(failed to fetch allowed/audited traffic detail via buildctl:", e.message, ")");
 }
 
-let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
+const failOnBlocked = "true" === (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase(), {blockedRows: annotatedBlocked, showExpected: showExpected, outcome: outcome, message: message} = function(report, {knownBlockedRules: knownBlockedRules, failOnBlocked: failOnBlocked, engineLabel: engineLabel}) {
+  const isAudit = "audit" === report.mode, blockedRows = function(blockedRows, knownBlockedRules) {
+    const matchers = knownBlockedRules.map(rule => new RegExp(convertRule(rule)));
+    return blockedRows.map(row => ({
+      ...row,
+      expected: matchers.some(re => re.test(`${row.host}:${row.port}`))
+    }));
+  }(report.sections?.blocked ?? [], knownBlockedRules), outcome = function({isAudit: isAudit, failOnBlocked: failOnBlocked, blockedCount: blockedCount, blockedRows: blockedRows}) {
+    if (!blockedCount) return {
+      level: "none",
+      shouldFail: !1
+    };
+    if (isAudit) return {
+      level: "notice",
+      shouldFail: !1
+    };
+    const hasUnexpected = 0 === blockedRows.length || blockedRows.some(row => !row.expected);
+    return failOnBlocked && hasUnexpected ? {
+      level: "error",
+      shouldFail: !0
+    } : {
+      level: "notice",
+      shouldFail: !1
+    };
+  }({
+    isAudit: isAudit,
+    failOnBlocked: failOnBlocked,
+    blockedCount: report.blockedCount ?? 0,
+    blockedRows: blockedRows
+  }), message = "none" === outcome.level ? null : function({blockedCount: blockedCount, blockedRows: blockedRows, engineLabel: engineLabel, isAudit: isAudit}) {
+    const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
+    if (isAudit) return base;
+    const unexpected = blockedRows.filter(row => !row.expected).length;
+    return unexpected === blockedRows.length ? base : 0 === unexpected ? `${base}, all matched known_blocked_rules (expected)` : `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
+  }({
+    blockedCount: report.blockedCount ?? 0,
+    blockedRows: blockedRows,
+    engineLabel: engineLabel,
+    isAudit: isAudit
+  });
+  return {
+    blockedRows: blockedRows,
+    showExpected: knownBlockedRules.length > 0,
+    outcome: outcome,
+    message: message
+  };
+}(report, {
+  knownBlockedRules: knownBlockedRules,
+  failOnBlocked: failOnBlocked,
+  engineLabel: "proxy"
+});
 
-const blocked = report.sections.blocked || [], annotatedBlocked = function(blockedRows, knownBlockedRules) {
-  const matchers = knownBlockedRules.map(rule => new RegExp(convertRule(rule)));
-  return blockedRows.map(row => ({
-    ...row,
-    expected: matchers.some(re => re.test(`${row.host}:${row.port}`))
-  }));
-}(blocked, knownBlockedRules), showExpected = knownBlockedRules.length > 0;
+let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
 
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
@@ -298,7 +344,7 @@ if (isAudit) {
     let md = "\n<details>\n";
     return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", 
     md += yaml, md += "```\n\n", md += "</details>\n", md;
-  }(audited, actionRepo, actionRef), blocked.length > 0 && (audited.length > 0 && (markdown += "\n"), 
+  }(audited, actionRepo, actionRef), annotatedBlocked.length > 0 && (audited.length > 0 && (markdown += "\n"), 
   markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
     showReason: !0,
     showExpected: showExpected
@@ -306,7 +352,7 @@ if (isAudit) {
 } else {
   const allowed = isExplicit ? aggregateAllowedHosts(builds, "ALLOWED") : report.sections.allowed || [];
   allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n"), 
-  allowed.length > 0 && blocked.length > 0 && (markdown += "\n"), blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+  allowed.length > 0 && annotatedBlocked.length > 0 && (markdown += "\n"), annotatedBlocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
     showReason: !0,
     showExpected: showExpected
   }) + "\n");
@@ -350,41 +396,4 @@ const outputForAction = Boolean(summaryFile), annotation = outputForAction ? {
   error() {}
 };
 
-const outcome = function({isAudit: isAudit, failOnBlocked: failOnBlocked, blockedCount: blockedCount, blockedRows: blockedRows}) {
-  if (!blockedCount) return {
-    level: "none",
-    shouldFail: !1
-  };
-  if (isAudit) return {
-    level: "notice",
-    shouldFail: !1
-  };
-  const hasUnexpected = 0 === blockedRows.length || blockedRows.some(row => !row.expected);
-  return failOnBlocked && hasUnexpected ? {
-    level: "error",
-    shouldFail: !0
-  } : {
-    level: "notice",
-    shouldFail: !1
-  };
-}({
-  isAudit: isAudit,
-  failOnBlocked: "true" === (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase(),
-  blockedCount: report.blockedCount,
-  blockedRows: annotatedBlocked
-});
-
-if ("none" !== outcome.level) {
-  const message = function({blockedCount: blockedCount, blockedRows: blockedRows, knownBlockedRulesUsed: knownBlockedRulesUsed, engineLabel: engineLabel}) {
-    const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
-    if (!knownBlockedRulesUsed) return base;
-    const unexpected = blockedRows.filter(row => !row.expected).length;
-    return 0 === blockedRows.length - unexpected ? base : 0 === unexpected ? `${base}, all matched known_blocked_rules (expected)` : `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
-  }({
-    blockedCount: report.blockedCount,
-    blockedRows: annotatedBlocked,
-    knownBlockedRulesUsed: knownBlockedRules.length > 0,
-    engineLabel: "proxy"
-  });
-  "error" === outcome.level ? (annotation.error(message), process.exitCode = 1) : annotation.notice(message);
-}
+"error" === outcome.level ? (annotation.error(message), process.exitCode = 1) : "notice" === outcome.level && annotation.notice(message);

--- a/report/src/main.js
+++ b/report/src/main.js
@@ -6,6 +6,7 @@ import { buildRestrictExample } from "../../core/lib/build-example.js";
 import { renderCommunicationDetails } from "./lib/command-log.js";
 import { selectAllRefs, parseVertexAllowedLog, aggregateAllowedHosts } from "./lib/vertex-log.js";
 import { createAnnotation } from "../../core/lib/annotation.js";
+import { parseKnownBlockedRules, annotateKnownBlocked, determineBlockedOutcome, buildBlockedMessage } from "../../core/lib/known-blocked.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -18,6 +19,14 @@ const composeEnv = {
   ...process.env,
   BUILDER_NAME: process.env.INPUT_BUILDER_NAME || "buildcage",
 };
+
+let knownBlockedRules;
+try {
+  knownBlockedRules = parseKnownBlockedRules(process.env.INPUT_KNOWN_BLOCKED_RULES);
+} catch (e) {
+  console.log(`::error::${e.message}`);
+  process.exit(1);
+}
 
 let jsonOutput;
 try {
@@ -68,17 +77,20 @@ if (report.mode === null) {
   process.exit(0);
 }
 
-function markdownTable(rows, { showReason = false } = {}) {
-  if (showReason) {
-    const lines = ["| Host | Rule | Reason | Count |", "| --- | --- | --- | ---: |"];
-    for (const r of rows) {
-      lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.reason} | ${r.count} |`);
-    }
-    return lines.join("\n");
-  }
-  const lines = ["| Host | Rule | Count |", "| --- | --- | ---: |"];
+function markdownTable(rows, { showReason = false, showExpected = false } = {}) {
+  const headers = ["Host", "Rule"];
+  const aligns = ["---", "---"];
+  if (showReason) { headers.push("Reason"); aligns.push("---"); }
+  headers.push("Count"); aligns.push("---:");
+  if (showExpected) { headers.push("Expected"); aligns.push(":---:"); }
+
+  const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
   for (const r of rows) {
-    lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.count} |`);
+    const cells = [`${r.host}:${r.port}`, r.ruleType];
+    if (showReason) cells.push(r.reason);
+    cells.push(r.count);
+    if (showExpected) cells.push(r.expected ? "✅" : "");
+    lines.push(`| ${cells.join(" | ")} |`);
   }
   return lines.join("\n");
 }
@@ -129,20 +141,22 @@ if (isExplicit) {
 
 let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
 
+const blocked = report.sections.blocked || [];
+const annotatedBlocked = annotateKnownBlocked(blocked, knownBlockedRules);
+const showExpected = knownBlockedRules.length > 0;
+
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
   if (audited.length > 0) {
     markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n";
   }
   markdown += buildRestrictExample(audited, actionRepo, actionRef);
-  const blocked = report.sections.blocked || [];
   if (blocked.length > 0) {
     if (audited.length > 0) markdown += "\n";
-    markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, { showReason: true }) + "\n";
+    markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
   }
 } else {
   const allowed = isExplicit ? aggregateAllowedHosts(builds, "ALLOWED") : report.sections.allowed || [];
-  const blocked = report.sections.blocked || [];
   if (allowed.length > 0) {
     markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n";
   }
@@ -150,7 +164,7 @@ if (isAudit) {
     markdown += "\n";
   }
   if (blocked.length > 0) {
-    markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, { showReason: true }) + "\n";
+    markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
   }
 }
 
@@ -177,23 +191,19 @@ if (summaryFile) {
 // 4. Error control for blocked connections
 const outputForAction = Boolean(summaryFile);
 const annotation = createAnnotation(outputForAction);
-if (report.blockedCount > 0) {
-  if (isAudit) {
-    annotation.notice(
-      `${report.blockedCount} blocked connection(s) detected by buildcage proxy`
-    );
+const failOnBlocked = (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
+const outcome = determineBlockedOutcome({ isAudit, failOnBlocked, blockedCount: report.blockedCount, blockedRows: annotatedBlocked });
+if (outcome.level !== "none") {
+  const message = buildBlockedMessage({
+    blockedCount: report.blockedCount,
+    blockedRows: annotatedBlocked,
+    knownBlockedRulesUsed: knownBlockedRules.length > 0,
+    engineLabel: "proxy",
+  });
+  if (outcome.level === "error") {
+    annotation.error(message);
+    process.exitCode = 1;
   } else {
-    const failOnBlocked =
-      (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
-    if (failOnBlocked) {
-      annotation.error(
-        `${report.blockedCount} blocked connection(s) detected by buildcage proxy`
-      );
-      process.exitCode = 1;
-    } else {
-      annotation.notice(
-        `${report.blockedCount} blocked connection(s) detected by buildcage proxy`
-      );
-    }
+    annotation.notice(message);
   }
 }

--- a/report/src/main.js
+++ b/report/src/main.js
@@ -6,7 +6,9 @@ import { buildRestrictExample } from "../../core/lib/build-example.js";
 import { renderCommunicationDetails } from "./lib/command-log.js";
 import { selectAllRefs, parseVertexAllowedLog, aggregateAllowedHosts } from "./lib/vertex-log.js";
 import { createAnnotation } from "../../core/lib/annotation.js";
-import { parseKnownBlockedRules, annotateKnownBlocked, determineBlockedOutcome, buildBlockedMessage } from "../../core/lib/known-blocked.js";
+import { evaluateBlockedReport } from "../../core/lib/known-blocked.js";
+import { markdownTable } from "../../core/lib/markdown-table.js";
+import { parseAndValidateRules } from "../../core/shared/lib/rules.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -22,7 +24,7 @@ const composeEnv = {
 
 let knownBlockedRules;
 try {
-  knownBlockedRules = parseKnownBlockedRules(process.env.INPUT_KNOWN_BLOCKED_RULES);
+  knownBlockedRules = parseAndValidateRules(process.env.INPUT_KNOWN_BLOCKED_RULES);
 } catch (e) {
   console.log(`::error::${e.message}`);
   process.exit(1);
@@ -77,24 +79,6 @@ if (report.mode === null) {
   process.exit(0);
 }
 
-function markdownTable(rows, { showReason = false, showExpected = false } = {}) {
-  const headers = ["Host", "Rule"];
-  const aligns = ["---", "---"];
-  if (showReason) { headers.push("Reason"); aligns.push("---"); }
-  headers.push("Count"); aligns.push("---:");
-  if (showExpected) { headers.push("Expected"); aligns.push(":---:"); }
-
-  const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
-  for (const r of rows) {
-    const cells = [`${r.host}:${r.port}`, r.ruleType];
-    if (showReason) cells.push(r.reason);
-    cells.push(r.count);
-    if (showExpected) cells.push(r.expected ? "✅" : "");
-    lines.push(`| ${cells.join(" | ")} |`);
-  }
-  return lines.join("\n");
-}
-
 const actionRepo = process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage";
 const actionRef = process.env.GITHUB_ACTION_REF || "v2";
 const isAudit = report.mode === "audit";
@@ -139,11 +123,12 @@ if (isExplicit) {
   }
 }
 
-let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
+const failOnBlocked = (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
+const { blockedRows: annotatedBlocked, showExpected, outcome, message } = evaluateBlockedReport(report, {
+  knownBlockedRules, failOnBlocked, engineLabel: "proxy",
+});
 
-const blocked = report.sections.blocked || [];
-const annotatedBlocked = annotateKnownBlocked(blocked, knownBlockedRules);
-const showExpected = knownBlockedRules.length > 0;
+let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} mode)\n\n`;
 
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
@@ -151,7 +136,7 @@ if (isAudit) {
     markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n";
   }
   markdown += buildRestrictExample(audited, actionRepo, actionRef);
-  if (blocked.length > 0) {
+  if (annotatedBlocked.length > 0) {
     if (audited.length > 0) markdown += "\n";
     markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
   }
@@ -160,10 +145,10 @@ if (isAudit) {
   if (allowed.length > 0) {
     markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n";
   }
-  if (allowed.length > 0 && blocked.length > 0) {
+  if (allowed.length > 0 && annotatedBlocked.length > 0) {
     markdown += "\n";
   }
-  if (blocked.length > 0) {
+  if (annotatedBlocked.length > 0) {
     markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
   }
 }
@@ -191,19 +176,9 @@ if (summaryFile) {
 // 4. Error control for blocked connections
 const outputForAction = Boolean(summaryFile);
 const annotation = createAnnotation(outputForAction);
-const failOnBlocked = (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
-const outcome = determineBlockedOutcome({ isAudit, failOnBlocked, blockedCount: report.blockedCount, blockedRows: annotatedBlocked });
-if (outcome.level !== "none") {
-  const message = buildBlockedMessage({
-    blockedCount: report.blockedCount,
-    blockedRows: annotatedBlocked,
-    knownBlockedRulesUsed: knownBlockedRules.length > 0,
-    engineLabel: "proxy",
-  });
-  if (outcome.level === "error") {
-    annotation.error(message);
-    process.exitCode = 1;
-  } else {
-    annotation.notice(message);
-  }
+if (outcome.level === "error") {
+  annotation.error(message);
+  process.exitCode = 1;
+} else if (outcome.level === "notice") {
+  annotation.notice(message);
 }

--- a/run/action.yml
+++ b/run/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Fail the step if any connection was blocked (restrict mode only)"
     required: false
     default: 'true'
+  known_blocked_rules:
+    description: "Domains expected to be blocked intentionally (wildcard or ~regex), separated by whitespace. Port required. Blocked connections matching these rules don't fail the step even when fail_on_blocked is true — only unmatched (unexpected) blocked connections do. e.g., 'known-noisy.example.com:443'"
+    required: false
+    default: ''
   writable:
     description: "Additional writable directories (newline-separated), on top of $GITHUB_WORKSPACE, $HOME, and /tmp which are always writable — everything else is read-only. Use '/' to disable the read-only restriction entirely."
     required: false

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -31,6 +31,14 @@ function convertRule(rule) {
   }(rule)}$`;
 }
 
+function annotateKnownBlocked(blockedRows, knownBlockedRules) {
+  const matchers = knownBlockedRules.map(rule => new RegExp(convertRule(rule)));
+  return blockedRows.map(row => ({
+    ...row,
+    expected: matchers.some(re => re.test(`${row.host}:${row.port}`))
+  }));
+}
+
 function resolveBuildcageImageRef({imageDigest: imageDigest, actionRepository: actionRepository}) {
   return `${`ghcr.io/${actionRepository}`.toLowerCase()}@${imageDigest}`;
 }
@@ -7446,22 +7454,25 @@ const ruleTypeToParam = {
   IP: "allowed_ip_rules"
 };
 
-function markdownTable(rows, {showReason: showReason = !1} = {}) {
-  if (showReason) {
-    const lines = [ "| Host | Rule | Reason | Count |", "| --- | --- | --- | ---: |" ];
-    for (const r of rows) lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.reason} | ${r.count} |`);
-    return lines.join("\n");
+function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
+  const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
+  showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
+  aligns.push("---:"), showExpected && (headers.push("Expected"), aligns.push(":---:"));
+  const lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
+  for (const r of rows) {
+    const cells = [ `${r.host}:${r.port}`, r.ruleType ];
+    showReason && cells.push(r.reason), cells.push(r.count), showExpected && cells.push(r.expected ? "✅" : ""), 
+    lines.push(`| ${cells.join(" | ")} |`);
   }
-  const lines = [ "| Host | Rule | Count |", "| --- | --- | ---: |" ];
-  for (const r of rows) lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.count} |`);
   return lines.join("\n");
 }
 
-function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand} = {}) {
+function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand, knownBlockedRules: knownBlockedRules = []} = {}) {
   const heading = "Outbound Traffic Report" + (stepLabel ? ` — ${stepLabel}` : "");
   if (null === report.mode) return `## ${heading}\n\nNo proxy logs found.\n`;
   const isAudit = "audit" === report.mode;
   let markdown = `## ${heading} (${report.mode} mode)\n\n`;
+  const blocked = report.sections.blocked || [], annotatedBlocked = annotateKnownBlocked(blocked, knownBlockedRules), showExpected = knownBlockedRules.length > 0;
   if (isAudit) {
     const audited = report.sections.audited || [];
     audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n\n"), 
@@ -7490,28 +7501,28 @@ function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRe
     }(audited, actionRepo, actionRef, {
       actionName: "run",
       runCommand: runCommand
-    });
-    const blocked = report.sections.blocked || [];
-    blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, {
-      showReason: !0
+    }), blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+      showReason: !0,
+      showExpected: showExpected
     }) + "\n\n");
   } else {
     const allowed = report.sections.allowed || [];
-    allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n");
-    const blocked = report.sections.blocked || [];
-    blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, {
-      showReason: !0
+    allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n"), 
+    blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+      showReason: !0,
+      showExpected: showExpected
     }) + "\n\n");
   }
   return markdown;
 }
 
-function writeReport(report, {stepLabel: stepLabel, failOnBlocked: failOnBlocked, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand} = {}) {
+function writeReport(report, {stepLabel: stepLabel, failOnBlocked: failOnBlocked, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand, knownBlockedRules: knownBlockedRules = []} = {}) {
   const markdown = buildReportMarkdown(report, {
     stepLabel: stepLabel,
     actionRepo: actionRepo,
     actionRef: actionRef,
-    runCommand: runCommand
+    runCommand: runCommand,
+    knownBlockedRules: knownBlockedRules
   }), summaryFile = process.env.GITHUB_STEP_SUMMARY;
   summaryFile ? node_fs.appendFileSync(summaryFile, markdown) : console.log(markdown);
   const debugSummaryFile = process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
@@ -7527,10 +7538,42 @@ function writeReport(report, {stepLabel: stepLabel, failOnBlocked: failOnBlocked
     notice() {},
     error() {}
   };
-  if (report.blockedCount > 0) {
-    const isAudit = "audit" === report.mode, message = `${report.blockedCount} blocked connection(s) detected by buildcage sandbox`;
-    isAudit || !failOnBlocked ? annotation.notice(message) : (annotation.error(message), 
-    process.exitCode = 1);
+  const blockedRows = annotateKnownBlocked(report.sections?.blocked || [], knownBlockedRules), outcome = function({isAudit: isAudit, failOnBlocked: failOnBlocked, blockedCount: blockedCount, blockedRows: blockedRows}) {
+    if (!blockedCount) return {
+      level: "none",
+      shouldFail: !1
+    };
+    if (isAudit) return {
+      level: "notice",
+      shouldFail: !1
+    };
+    const hasUnexpected = 0 === blockedRows.length || blockedRows.some(row => !row.expected);
+    return failOnBlocked && hasUnexpected ? {
+      level: "error",
+      shouldFail: !0
+    } : {
+      level: "notice",
+      shouldFail: !1
+    };
+  }({
+    isAudit: "audit" === report.mode,
+    failOnBlocked: failOnBlocked,
+    blockedCount: report.blockedCount ?? 0,
+    blockedRows: blockedRows
+  });
+  if ("none" !== outcome.level) {
+    const message = function({blockedCount: blockedCount, blockedRows: blockedRows, knownBlockedRulesUsed: knownBlockedRulesUsed, engineLabel: engineLabel}) {
+      const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
+      if (!knownBlockedRulesUsed) return base;
+      const unexpected = blockedRows.filter(row => !row.expected).length;
+      return 0 === blockedRows.length - unexpected ? base : 0 === unexpected ? `${base}, all matched known_blocked_rules (expected)` : `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
+    }({
+      blockedCount: report.blockedCount,
+      blockedRows: blockedRows,
+      knownBlockedRulesUsed: knownBlockedRules.length > 0,
+      engineLabel: "sandbox"
+    });
+    "error" === outcome.level ? (annotation.error(message), process.exitCode = 1) : annotation.notice(message);
   }
 }
 
@@ -7548,6 +7591,17 @@ function buildACLRules({httpsRulesInput: httpsRulesInput, httpRulesInput: httpRu
     httpRules: httpRules,
     ipRules: ipRules
   };
+}
+
+function readKnownBlockedRules(input) {
+  try {
+    return function(rulesInput) {
+      const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+      return rules.forEach(convertRule), rules;
+    }(input);
+  } catch (e) {
+    throw new SandboxError(e.message, "INVALID_RULES");
+  }
 }
 
 function parseWritablePaths(input) {
@@ -7591,9 +7645,10 @@ process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? requ
     httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
     httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
     ipRulesInput: env.INPUT_ALLOWED_IP_RULES
-  });
+  }), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
   console.log("::group::Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), 
-  logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), console.log("::endgroup::");
+  logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), 
+  console.log("::endgroup::");
   const writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = `buildcage-proxy-${node_crypto.randomBytes(4).toString("hex")}`, projectName = containerName, stateFile = env.GITHUB_STATE;
   stateFile && (node_fs.appendFileSync(stateFile, `container_name=${containerName}\n`), 
   node_fs.appendFileSync(stateFile, `project_name=${projectName}\n`));
@@ -7711,7 +7766,8 @@ process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? requ
         actionRef: actionRef,
         runCommand: runInput,
         stepLabel: env.INPUT_LABEL || void 0,
-        failOnBlocked: "true" === (env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase()
+        failOnBlocked: "true" === (env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase(),
+        knownBlockedRules: knownBlockedRules
       });
     } catch (e) {
       console.log(`::warning::Failed to fetch sandbox report: ${e.message}`);
@@ -7729,4 +7785,5 @@ process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? requ
   err instanceof SandboxError ? console.log(`::error::${err.message}`) : console.log(`::error::Unexpected error in sandbox: ${err.message}`), 
   process.exit(1);
 }), exports.buildACLRules = buildACLRules, exports.buildComposeDownArgs = buildComposeDownArgs, 
-exports.buildComposeUpArgs = buildComposeUpArgs, exports.parseWritablePaths = parseWritablePaths;
+exports.buildComposeUpArgs = buildComposeUpArgs, exports.parseWritablePaths = parseWritablePaths, 
+exports.readKnownBlockedRules = readKnownBlockedRules;

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -2,8 +2,11 @@
 
 var node_child_process = require("node:child_process"), node_fs = require("node:fs"), path = require("node:path"), node_url = require("node:url"), os = require("node:os"), require$$0 = require("os"), require$$1 = require("path"), require$$0$5 = require("fs"), require$$0$2 = require("util"), require$$0$1 = require("crypto"), require$$0$3 = require("tty"), require$$0$4 = require("fs/promises"), require$$0$6 = require("url"), node_crypto = require("node:crypto"), _documentCurrentScript = "undefined" != typeof document ? document.currentScript : null;
 
-function buildRules(rulesInput) {
-  return (rulesInput?.trim().split(/\s+/).filter(Boolean) ?? []).map(convertRule);
+function parseAndValidateRules(rulesInput) {
+  const rules = function(rulesInput) {
+    return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+  }(rulesInput);
+  return rules.forEach(convertRule), rules;
 }
 
 function convertRule(rule) {
@@ -29,14 +32,6 @@ function convertRule(rule) {
       return regexParts.join("\\.");
     }(domain)}:${portRegex}`;
   }(rule)}$`;
-}
-
-function annotateKnownBlocked(blockedRows, knownBlockedRules) {
-  const matchers = knownBlockedRules.map(rule => new RegExp(convertRule(rule)));
-  return blockedRows.map(row => ({
-    ...row,
-    expected: matchers.some(re => re.test(`${row.host}:${row.port}`))
-  }));
 }
 
 function resolveBuildcageImageRef({imageDigest: imageDigest, actionRepository: actionRepository}) {
@@ -7454,6 +7449,54 @@ const ruleTypeToParam = {
   IP: "allowed_ip_rules"
 };
 
+function evaluateBlockedReport(report, {knownBlockedRules: knownBlockedRules, failOnBlocked: failOnBlocked, engineLabel: engineLabel}) {
+  const isAudit = "audit" === report.mode, blockedRows = function(blockedRows, knownBlockedRules) {
+    const matchers = knownBlockedRules.map(rule => new RegExp(convertRule(rule)));
+    return blockedRows.map(row => ({
+      ...row,
+      expected: matchers.some(re => re.test(`${row.host}:${row.port}`))
+    }));
+  }(report.sections?.blocked ?? [], knownBlockedRules), outcome = function({isAudit: isAudit, failOnBlocked: failOnBlocked, blockedCount: blockedCount, blockedRows: blockedRows}) {
+    if (!blockedCount) return {
+      level: "none",
+      shouldFail: !1
+    };
+    if (isAudit) return {
+      level: "notice",
+      shouldFail: !1
+    };
+    const hasUnexpected = 0 === blockedRows.length || blockedRows.some(row => !row.expected);
+    return failOnBlocked && hasUnexpected ? {
+      level: "error",
+      shouldFail: !0
+    } : {
+      level: "notice",
+      shouldFail: !1
+    };
+  }({
+    isAudit: isAudit,
+    failOnBlocked: failOnBlocked,
+    blockedCount: report.blockedCount ?? 0,
+    blockedRows: blockedRows
+  }), message = "none" === outcome.level ? null : function({blockedCount: blockedCount, blockedRows: blockedRows, engineLabel: engineLabel, isAudit: isAudit}) {
+    const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
+    if (isAudit) return base;
+    const unexpected = blockedRows.filter(row => !row.expected).length;
+    return unexpected === blockedRows.length ? base : 0 === unexpected ? `${base}, all matched known_blocked_rules (expected)` : `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
+  }({
+    blockedCount: report.blockedCount ?? 0,
+    blockedRows: blockedRows,
+    engineLabel: engineLabel,
+    isAudit: isAudit
+  });
+  return {
+    blockedRows: blockedRows,
+    showExpected: knownBlockedRules.length > 0,
+    outcome: outcome,
+    message: message
+  };
+}
+
 function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
   const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
   showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
@@ -7467,12 +7510,11 @@ function markdownTable(rows, {showReason: showReason = !1, showExpected: showExp
   return lines.join("\n");
 }
 
-function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand, knownBlockedRules: knownBlockedRules = []} = {}) {
+function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand, blockedRows: blockedRows = [], showExpected: showExpected = !1} = {}) {
   const heading = "Outbound Traffic Report" + (stepLabel ? ` — ${stepLabel}` : "");
   if (null === report.mode) return `## ${heading}\n\nNo proxy logs found.\n`;
   const isAudit = "audit" === report.mode;
   let markdown = `## ${heading} (${report.mode} mode)\n\n`;
-  const blocked = report.sections.blocked || [], annotatedBlocked = annotateKnownBlocked(blocked, knownBlockedRules), showExpected = knownBlockedRules.length > 0;
   if (isAudit) {
     const audited = report.sections.audited || [];
     audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n\n"), 
@@ -7501,14 +7543,14 @@ function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRe
     }(audited, actionRepo, actionRef, {
       actionName: "run",
       runCommand: runCommand
-    }), blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+    }), blockedRows.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, {
       showReason: !0,
       showExpected: showExpected
     }) + "\n\n");
   } else {
     const allowed = report.sections.allowed || [];
     allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n"), 
-    blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+    blockedRows.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, {
       showReason: !0,
       showExpected: showExpected
     }) + "\n\n");
@@ -7517,12 +7559,17 @@ function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRe
 }
 
 function writeReport(report, {stepLabel: stepLabel, failOnBlocked: failOnBlocked, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand, knownBlockedRules: knownBlockedRules = []} = {}) {
-  const markdown = buildReportMarkdown(report, {
+  const {blockedRows: blockedRows, showExpected: showExpected, outcome: outcome, message: message} = evaluateBlockedReport(report, {
+    knownBlockedRules: knownBlockedRules,
+    failOnBlocked: failOnBlocked,
+    engineLabel: "sandbox"
+  }), markdown = buildReportMarkdown(report, {
     stepLabel: stepLabel,
     actionRepo: actionRepo,
     actionRef: actionRef,
     runCommand: runCommand,
-    knownBlockedRules: knownBlockedRules
+    blockedRows: blockedRows,
+    showExpected: showExpected
   }), summaryFile = process.env.GITHUB_STEP_SUMMARY;
   summaryFile ? node_fs.appendFileSync(summaryFile, markdown) : console.log(markdown);
   const debugSummaryFile = process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
@@ -7538,70 +7585,29 @@ function writeReport(report, {stepLabel: stepLabel, failOnBlocked: failOnBlocked
     notice() {},
     error() {}
   };
-  const blockedRows = annotateKnownBlocked(report.sections?.blocked || [], knownBlockedRules), outcome = function({isAudit: isAudit, failOnBlocked: failOnBlocked, blockedCount: blockedCount, blockedRows: blockedRows}) {
-    if (!blockedCount) return {
-      level: "none",
-      shouldFail: !1
-    };
-    if (isAudit) return {
-      level: "notice",
-      shouldFail: !1
-    };
-    const hasUnexpected = 0 === blockedRows.length || blockedRows.some(row => !row.expected);
-    return failOnBlocked && hasUnexpected ? {
-      level: "error",
-      shouldFail: !0
-    } : {
-      level: "notice",
-      shouldFail: !1
-    };
-  }({
-    isAudit: "audit" === report.mode,
-    failOnBlocked: failOnBlocked,
-    blockedCount: report.blockedCount ?? 0,
-    blockedRows: blockedRows
-  });
-  if ("none" !== outcome.level) {
-    const message = function({blockedCount: blockedCount, blockedRows: blockedRows, knownBlockedRulesUsed: knownBlockedRulesUsed, engineLabel: engineLabel}) {
-      const base = `${blockedCount} blocked connection(s) detected by buildcage ${engineLabel}`;
-      if (!knownBlockedRulesUsed) return base;
-      const unexpected = blockedRows.filter(row => !row.expected).length;
-      return 0 === blockedRows.length - unexpected ? base : 0 === unexpected ? `${base}, all matched known_blocked_rules (expected)` : `${base} (${unexpected} of ${blockedRows.length} distinct blocked host(s) unmatched by known_blocked_rules)`;
-    }({
-      blockedCount: report.blockedCount,
-      blockedRows: blockedRows,
-      knownBlockedRulesUsed: knownBlockedRules.length > 0,
-      engineLabel: "sandbox"
-    });
-    "error" === outcome.level ? (annotation.error(message), process.exitCode = 1) : annotation.notice(message);
-  }
+  "error" === outcome.level ? (annotation.error(message), process.exitCode = 1) : "notice" === outcome.level && annotation.notice(message);
 }
 
 const __dirname$1 = path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = path.join(__dirname$1, "../compose.yaml");
 
-function buildACLRules({httpsRulesInput: httpsRulesInput, httpRulesInput: httpRulesInput, ipRulesInput: ipRulesInput}) {
-  const httpsRules = httpsRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [], httpRules = httpRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [], ipRules = ipRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+function parseRulesOrThrow(rulesInput) {
   try {
-    buildRules(httpsRulesInput), buildRules(httpRulesInput), buildRules(ipRulesInput);
+    return parseAndValidateRules(rulesInput);
   } catch (e) {
     throw new SandboxError(e.message, "INVALID_RULES");
   }
+}
+
+function buildACLRules({httpsRulesInput: httpsRulesInput, httpRulesInput: httpRulesInput, ipRulesInput: ipRulesInput}) {
   return {
-    httpsRules: httpsRules,
-    httpRules: httpRules,
-    ipRules: ipRules
+    httpsRules: parseRulesOrThrow(httpsRulesInput),
+    httpRules: parseRulesOrThrow(httpRulesInput),
+    ipRules: parseRulesOrThrow(ipRulesInput)
   };
 }
 
 function readKnownBlockedRules(input) {
-  try {
-    return function(rulesInput) {
-      const rules = rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-      return rules.forEach(convertRule), rules;
-    }(input);
-  } catch (e) {
-    throw new SandboxError(e.message, "INVALID_RULES");
-  }
+  return parseRulesOrThrow(input);
 }
 
 function parseWritablePaths(input) {

--- a/run/src/lib/report.js
+++ b/run/src/lib/report.js
@@ -2,7 +2,8 @@ import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { createAnnotation } from "../../../core/lib/annotation.js";
 import { buildRestrictExample } from "../../../core/lib/build-example.js";
-import { annotateKnownBlocked, determineBlockedOutcome, buildBlockedMessage } from "../../../core/lib/known-blocked.js";
+import { evaluateBlockedReport } from "../../../core/lib/known-blocked.js";
+import { markdownTable } from "../../../core/lib/markdown-table.js";
 
 /**
  * Fetch the structured HAProxy-log report from the (still-running) proxy
@@ -19,30 +20,15 @@ export function fetchReport(containerName) {
   return JSON.parse(jsonOutput);
 }
 
-function markdownTable(rows, { showReason = false, showExpected = false } = {}) {
-  const headers = ["Host", "Rule"];
-  const aligns = ["---", "---"];
-  if (showReason) { headers.push("Reason"); aligns.push("---"); }
-  headers.push("Count"); aligns.push("---:");
-  if (showExpected) { headers.push("Expected"); aligns.push(":---:"); }
-
-  const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
-  for (const r of rows) {
-    const cells = [`${r.host}:${r.port}`, r.ruleType];
-    if (showReason) cells.push(r.reason);
-    cells.push(r.count);
-    if (showExpected) cells.push(r.expected ? "✅" : "");
-    lines.push(`| ${cells.join(" | ")} |`);
-  }
-  return lines.join("\n");
-}
-
 /**
  * Build the Job Summary markdown section for this run step's traffic
  * report. Each `run` step gets its own section (rather than one report
  * per job), matching the "one proxy container per step" execution model.
+ *
+ * `blockedRows`/`showExpected` come pre-computed from the caller so
+ * known_blocked_rules matching runs once per report, not once per render.
  */
-export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand, knownBlockedRules = [] } = {}) {
+export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand, blockedRows = [], showExpected = false } = {}) {
   // Mirrors report/src/main.js's "## Outbound Traffic Report during Docker
   // Build (mode)" heading, so both actions read as the same kind of report.
   const heading = `Outbound Traffic Report${stepLabel ? ` — ${stepLabel}` : ""}`;
@@ -53,19 +39,15 @@ export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, 
   const isAudit = report.mode === "audit";
   let markdown = `## ${heading} (${report.mode} mode)\n\n`;
 
-  const blocked = report.sections.blocked || [];
-  const annotatedBlocked = annotateKnownBlocked(blocked, knownBlockedRules);
-  const showExpected = knownBlockedRules.length > 0;
-
   if (isAudit) {
     const audited = report.sections.audited || [];
     if (audited.length > 0) markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n\n";
     markdown += buildRestrictExample(audited, actionRepo, actionRef, { actionName: "run", runCommand });
-    if (blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n\n";
+    if (blockedRows.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, { showReason: true, showExpected }) + "\n\n";
   } else {
     const allowed = report.sections.allowed || [];
     if (allowed.length > 0) markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n";
-    if (blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n\n";
+    if (blockedRows.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, { showReason: true, showExpected }) + "\n\n";
   }
 
   return markdown;
@@ -77,7 +59,11 @@ export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, 
  * behavior but scoped to a single run step's proxy container.
  */
 export function writeReport(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand, knownBlockedRules = [] } = {}) {
-  const markdown = buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand, knownBlockedRules });
+  const { blockedRows, showExpected, outcome, message } = evaluateBlockedReport(report, {
+    knownBlockedRules, failOnBlocked, engineLabel: "sandbox",
+  });
+
+  const markdown = buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand, blockedRows, showExpected });
   const summaryFile = process.env.GITHUB_STEP_SUMMARY;
   if (summaryFile) {
     appendFileSync(summaryFile, markdown);
@@ -96,25 +82,10 @@ export function writeReport(report, { stepLabel, failOnBlocked, actionRepo, acti
   }
 
   const annotation = createAnnotation(Boolean(summaryFile));
-  const blockedRows = annotateKnownBlocked(report.sections?.blocked || [], knownBlockedRules);
-  const outcome = determineBlockedOutcome({
-    isAudit: report.mode === "audit",
-    failOnBlocked,
-    blockedCount: report.blockedCount ?? 0,
-    blockedRows,
-  });
-  if (outcome.level !== "none") {
-    const message = buildBlockedMessage({
-      blockedCount: report.blockedCount,
-      blockedRows,
-      knownBlockedRulesUsed: knownBlockedRules.length > 0,
-      engineLabel: "sandbox",
-    });
-    if (outcome.level === "error") {
-      annotation.error(message);
-      process.exitCode = 1;
-    } else {
-      annotation.notice(message);
-    }
+  if (outcome.level === "error") {
+    annotation.error(message);
+    process.exitCode = 1;
+  } else if (outcome.level === "notice") {
+    annotation.notice(message);
   }
 }

--- a/run/src/lib/report.js
+++ b/run/src/lib/report.js
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { createAnnotation } from "../../../core/lib/annotation.js";
 import { buildRestrictExample } from "../../../core/lib/build-example.js";
+import { annotateKnownBlocked, determineBlockedOutcome, buildBlockedMessage } from "../../../core/lib/known-blocked.js";
 
 /**
  * Fetch the structured HAProxy-log report from the (still-running) proxy
@@ -18,14 +19,21 @@ export function fetchReport(containerName) {
   return JSON.parse(jsonOutput);
 }
 
-function markdownTable(rows, { showReason = false } = {}) {
-  if (showReason) {
-    const lines = ["| Host | Rule | Reason | Count |", "| --- | --- | --- | ---: |"];
-    for (const r of rows) lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.reason} | ${r.count} |`);
-    return lines.join("\n");
+function markdownTable(rows, { showReason = false, showExpected = false } = {}) {
+  const headers = ["Host", "Rule"];
+  const aligns = ["---", "---"];
+  if (showReason) { headers.push("Reason"); aligns.push("---"); }
+  headers.push("Count"); aligns.push("---:");
+  if (showExpected) { headers.push("Expected"); aligns.push(":---:"); }
+
+  const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
+  for (const r of rows) {
+    const cells = [`${r.host}:${r.port}`, r.ruleType];
+    if (showReason) cells.push(r.reason);
+    cells.push(r.count);
+    if (showExpected) cells.push(r.expected ? "✅" : "");
+    lines.push(`| ${cells.join(" | ")} |`);
   }
-  const lines = ["| Host | Rule | Count |", "| --- | --- | ---: |"];
-  for (const r of rows) lines.push(`| ${r.host}:${r.port} | ${r.ruleType} | ${r.count} |`);
   return lines.join("\n");
 }
 
@@ -34,7 +42,7 @@ function markdownTable(rows, { showReason = false } = {}) {
  * report. Each `run` step gets its own section (rather than one report
  * per job), matching the "one proxy container per step" execution model.
  */
-export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand } = {}) {
+export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand, knownBlockedRules = [] } = {}) {
   // Mirrors report/src/main.js's "## Outbound Traffic Report during Docker
   // Build (mode)" heading, so both actions read as the same kind of report.
   const heading = `Outbound Traffic Report${stepLabel ? ` — ${stepLabel}` : ""}`;
@@ -45,17 +53,19 @@ export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, 
   const isAudit = report.mode === "audit";
   let markdown = `## ${heading} (${report.mode} mode)\n\n`;
 
+  const blocked = report.sections.blocked || [];
+  const annotatedBlocked = annotateKnownBlocked(blocked, knownBlockedRules);
+  const showExpected = knownBlockedRules.length > 0;
+
   if (isAudit) {
     const audited = report.sections.audited || [];
     if (audited.length > 0) markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n\n";
     markdown += buildRestrictExample(audited, actionRepo, actionRef, { actionName: "run", runCommand });
-    const blocked = report.sections.blocked || [];
-    if (blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, { showReason: true }) + "\n\n";
+    if (blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n\n";
   } else {
     const allowed = report.sections.allowed || [];
     if (allowed.length > 0) markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n";
-    const blocked = report.sections.blocked || [];
-    if (blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blocked, { showReason: true }) + "\n\n";
+    if (blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n\n";
   }
 
   return markdown;
@@ -66,8 +76,8 @@ export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, 
  * set the exit code for blocked connections, mirroring report/src/main.js's
  * behavior but scoped to a single run step's proxy container.
  */
-export function writeReport(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand } = {}) {
-  const markdown = buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand });
+export function writeReport(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand, knownBlockedRules = [] } = {}) {
+  const markdown = buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand, knownBlockedRules });
   const summaryFile = process.env.GITHUB_STEP_SUMMARY;
   if (summaryFile) {
     appendFileSync(summaryFile, markdown);
@@ -86,14 +96,25 @@ export function writeReport(report, { stepLabel, failOnBlocked, actionRepo, acti
   }
 
   const annotation = createAnnotation(Boolean(summaryFile));
-  if (report.blockedCount > 0) {
-    const isAudit = report.mode === "audit";
-    const message = `${report.blockedCount} blocked connection(s) detected by buildcage sandbox`;
-    if (isAudit || !failOnBlocked) {
-      annotation.notice(message);
-    } else {
+  const blockedRows = annotateKnownBlocked(report.sections?.blocked || [], knownBlockedRules);
+  const outcome = determineBlockedOutcome({
+    isAudit: report.mode === "audit",
+    failOnBlocked,
+    blockedCount: report.blockedCount ?? 0,
+    blockedRows,
+  });
+  if (outcome.level !== "none") {
+    const message = buildBlockedMessage({
+      blockedCount: report.blockedCount,
+      blockedRows,
+      knownBlockedRulesUsed: knownBlockedRules.length > 0,
+      engineLabel: "sandbox",
+    });
+    if (outcome.level === "error") {
       annotation.error(message);
       process.exitCode = 1;
+    } else {
+      annotation.notice(message);
     }
   }
 }

--- a/run/src/lib/report.test.js
+++ b/run/src/lib/report.test.js
@@ -65,6 +65,49 @@ describe("writeReport", () => {
     const report = { mode: "audit", blockedCount: 2, sections: {} };
     assert.equal(writeReportWithSummary(report, { failOnBlocked: true }), undefined);
   });
+
+  it("leaves exitCode untouched when every blocked connection matches known_blocked_rules", () => {
+    const report = {
+      mode: "restrict",
+      blockedCount: 3,
+      sections: {
+        blocked: [{ host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 3 }],
+      },
+    };
+    assert.equal(
+      writeReportWithSummary(report, { failOnBlocked: true, knownBlockedRules: ["known-bad.example.com:443"] }),
+      undefined,
+    );
+  });
+
+  it("sets exitCode=1 when some blocked rows don't match known_blocked_rules", () => {
+    const report = {
+      mode: "restrict",
+      blockedCount: 4,
+      sections: {
+        blocked: [
+          { host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 3 },
+          { host: "unexpected.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
+        ],
+      },
+    };
+    assert.equal(
+      writeReportWithSummary(report, { failOnBlocked: true, knownBlockedRules: ["known-bad.example.com:443"] }),
+      1,
+    );
+  });
+
+  it("leaves exitCode untouched in audit mode even with known_blocked_rules set", () => {
+    const report = {
+      mode: "audit",
+      blockedCount: 1,
+      sections: { blocked: [{ host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 1 }] },
+    };
+    assert.equal(
+      writeReportWithSummary(report, { failOnBlocked: true, knownBlockedRules: ["known-bad.example.com:443"] }),
+      undefined,
+    );
+  });
 });
 
 describe("buildReportMarkdown", () => {
@@ -123,5 +166,36 @@ describe("buildReportMarkdown", () => {
     const report = { mode: null };
     const markdown = buildReportMarkdown(report, { stepLabel: "npm install" });
     assert.match(markdown, /^## Outbound Traffic Report — npm install\n\nNo proxy logs found\.\n$/);
+  });
+
+  it("adds an Expected column marking known_blocked_rules matches when set", () => {
+    const report = {
+      mode: "restrict",
+      blockedCount: 2,
+      sections: {
+        blocked: [
+          { host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
+          { host: "unexpected.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
+        ],
+      },
+    };
+    const markdown = buildReportMarkdown(report, {
+      actionRepo: "dash14/buildcage",
+      actionRef: "v2",
+      knownBlockedRules: ["known-bad.example.com:443"],
+    });
+    assert.match(markdown, /\| Host \| Rule \| Reason \| Count \| Expected \|/);
+    assert.match(markdown, /\| known-bad\.example\.com:443 \| HTTPS \| not in allowlist \| 1 \| ✅ \|/);
+    assert.match(markdown, /\| unexpected\.example\.com:443 \| HTTPS \| not in allowlist \| 1 \| {2}\|/);
+  });
+
+  it("omits the Expected column when known_blocked_rules is not set", () => {
+    const report = {
+      mode: "restrict",
+      blockedCount: 1,
+      sections: { blocked: [{ host: "evil.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 }] },
+    };
+    const markdown = buildReportMarkdown(report, { actionRepo: "dash14/buildcage", actionRef: "v2" });
+    assert.doesNotMatch(markdown, /Expected/);
   });
 });

--- a/run/src/lib/report.test.js
+++ b/run/src/lib/report.test.js
@@ -13,6 +13,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { writeReport, buildReportMarkdown } from "./report.js";
+import { annotateKnownBlocked } from "../../../core/lib/known-blocked.js";
 import { withScratchDir } from "./isolated-exec.js";
 
 // writeReport reads GITHUB_STEP_SUMMARY/BUILDCAGE_RUN_DEBUG_SUMMARY_FILE
@@ -108,6 +109,20 @@ describe("writeReport", () => {
       undefined,
     );
   });
+
+  // Audit's outcome never depends on known_blocked_rules matching, so the
+  // notice text shouldn't either.
+  it("audit-mode notice text stays fixed even when known_blocked_rules matches every blocked connection", (t) => {
+    const log = t.mock.method(console, "log", () => {});
+    const report = {
+      mode: "audit",
+      blockedCount: 2,
+      sections: { blocked: [{ host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 2 }] },
+    };
+    writeReportWithSummary(report, { failOnBlocked: true, knownBlockedRules: ["known-bad.example.com:443"] });
+    assert.equal(log.mock.calls.length, 1);
+    assert.equal(log.mock.calls[0].arguments[0], "::notice::2 blocked connection(s) detected by buildcage sandbox");
+  });
 });
 
 describe("buildReportMarkdown", () => {
@@ -169,20 +184,19 @@ describe("buildReportMarkdown", () => {
   });
 
   it("adds an Expected column marking known_blocked_rules matches when set", () => {
-    const report = {
-      mode: "restrict",
-      blockedCount: 2,
-      sections: {
-        blocked: [
-          { host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
-          { host: "unexpected.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
-        ],
-      },
-    };
+    const blockedRows = annotateKnownBlocked(
+      [
+        { host: "known-bad.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
+        { host: "unexpected.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 },
+      ],
+      ["known-bad.example.com:443"],
+    );
+    const report = { mode: "restrict", sections: {} };
     const markdown = buildReportMarkdown(report, {
       actionRepo: "dash14/buildcage",
       actionRef: "v2",
-      knownBlockedRules: ["known-bad.example.com:443"],
+      blockedRows,
+      showExpected: true,
     });
     assert.match(markdown, /\| Host \| Rule \| Reason \| Count \| Expected \|/);
     assert.match(markdown, /\| known-bad\.example\.com:443 \| HTTPS \| not in allowlist \| 1 \| ✅ \|/);
@@ -190,12 +204,12 @@ describe("buildReportMarkdown", () => {
   });
 
   it("omits the Expected column when known_blocked_rules is not set", () => {
-    const report = {
-      mode: "restrict",
-      blockedCount: 1,
-      sections: { blocked: [{ host: "evil.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 }] },
-    };
-    const markdown = buildReportMarkdown(report, { actionRepo: "dash14/buildcage", actionRef: "v2" });
+    const blockedRows = annotateKnownBlocked(
+      [{ host: "evil.example.com", port: "443", ruleType: "HTTPS", reason: "not in allowlist", count: 1 }],
+      [],
+    );
+    const report = { mode: "restrict", sections: {} };
+    const markdown = buildReportMarkdown(report, { actionRepo: "dash14/buildcage", actionRef: "v2", blockedRows });
     assert.doesNotMatch(markdown, /Expected/);
   });
 });

--- a/run/src/main.js
+++ b/run/src/main.js
@@ -4,6 +4,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { buildRules } from "../../core/shared/lib/rules.js";
+import { parseKnownBlockedRules } from "../../core/lib/known-blocked.js";
 import { resolveBuildcageImageRef } from "../../core/lib/image-ref.js";
 import { verifyImageDigest } from "../../core/lib/verify-image.js";
 import { SandboxError } from "./lib/errors.js";
@@ -76,6 +77,20 @@ export function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput })
 }
 
 /**
+ * Parse+validate `known_blocked_rules` — same wildcard/~regex syntax as the
+ * allowed_*_rules inputs, but never sent to the container's ACL (see
+ * core/lib/known-blocked.js): it only affects this action's own pass/fail
+ * decision and Job Summary table.
+ */
+export function readKnownBlockedRules(input) {
+  try {
+    return parseKnownBlockedRules(input);
+  } catch (e) {
+    throw new SandboxError(e.message, "INVALID_RULES");
+  }
+}
+
+/**
  * Parse the `writable` input into a list of directories. Newline-separated
  * (not whitespace-split like the ACL rule inputs above) since paths can
  * legitimately contain spaces.
@@ -125,10 +140,13 @@ async function main() {
     ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
   });
 
+  const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+
   console.log("::group::Configured ACL Rules");
   logRules("HTTPS", rules.httpsRules);
   logRules("HTTP", rules.httpRules);
   logRules("IP", rules.ipRules);
+  logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules);
   console.log("::endgroup::");
 
   const writablePaths = parseWritablePaths(env.INPUT_WRITABLE);
@@ -248,6 +266,7 @@ async function main() {
         runCommand: runInput,
         stepLabel: env.INPUT_LABEL || undefined,
         failOnBlocked: (env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true",
+        knownBlockedRules,
       });
     } catch (e) {
       console.log(`::warning::Failed to fetch sandbox report: ${e.message}`);

--- a/run/src/main.js
+++ b/run/src/main.js
@@ -3,8 +3,7 @@ import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { buildRules } from "../../core/shared/lib/rules.js";
-import { parseKnownBlockedRules } from "../../core/lib/known-blocked.js";
+import { parseAndValidateRules } from "../../core/shared/lib/rules.js";
 import { resolveBuildcageImageRef } from "../../core/lib/image-ref.js";
 import { verifyImageDigest } from "../../core/lib/verify-image.js";
 import { SandboxError } from "./lib/errors.js";
@@ -59,35 +58,34 @@ async function resolveVerifiedImage({ actionRef, actionRepo }) {
 }
 
 /**
- * Build ACL rules from input strings. Rules are passed through as-is
- * (wildcard format), validated by converting to regex.
+ * Rethrow a rule-parser's syntax errors as a SandboxError with the shared
+ * INVALID_RULES code, used by both buildACLRules and readKnownBlockedRules.
  */
-export function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput }) {
-  const httpsRules = httpsRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  const httpRules = httpRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  const ipRules = ipRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+function parseRulesOrThrow(rulesInput) {
   try {
-    buildRules(httpsRulesInput);
-    buildRules(httpRulesInput);
-    buildRules(ipRulesInput);
+    return parseAndValidateRules(rulesInput);
   } catch (e) {
     throw new SandboxError(e.message, "INVALID_RULES");
   }
-  return { httpsRules, httpRules, ipRules };
 }
 
 /**
- * Parse+validate `known_blocked_rules` — same wildcard/~regex syntax as the
- * allowed_*_rules inputs, but never sent to the container's ACL (see
- * core/lib/known-blocked.js): it only affects this action's own pass/fail
- * decision and Job Summary table.
+ * Build ACL rules from input strings. Rules are passed through as-is
+ * (wildcard format), validated eagerly.
+ */
+export function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput }) {
+  return {
+    httpsRules: parseRulesOrThrow(httpsRulesInput),
+    httpRules: parseRulesOrThrow(httpRulesInput),
+    ipRules: parseRulesOrThrow(ipRulesInput),
+  };
+}
+
+/**
+ * Never sent to the container's ACL — see core/lib/known-blocked.js.
  */
 export function readKnownBlockedRules(input) {
-  try {
-    return parseKnownBlockedRules(input);
-  } catch (e) {
-    throw new SandboxError(e.message, "INVALID_RULES");
-  }
+  return parseRulesOrThrow(input);
 }
 
 /**

--- a/run/src/main.test.js
+++ b/run/src/main.test.js
@@ -6,7 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { buildACLRules, buildComposeUpArgs, buildComposeDownArgs, parseWritablePaths } from "./main.js";
+import { buildACLRules, buildComposeUpArgs, buildComposeDownArgs, parseWritablePaths, readKnownBlockedRules } from "./main.js";
 import { SandboxError } from "./lib/errors.js";
 
 describe("buildACLRules", () => {
@@ -47,6 +47,31 @@ describe("buildACLRules", () => {
           httpRulesInput: "",
           ipRulesInput: "",
         }),
+      (err) => {
+        assert.ok(err instanceof SandboxError);
+        assert.equal(err.code, "INVALID_RULES");
+        return true;
+      },
+    );
+  });
+});
+
+describe("readKnownBlockedRules", () => {
+  it("parses whitespace-separated rules", () => {
+    assert.deepEqual(
+      readKnownBlockedRules("known-bad.example.com:443 *.noisy.example.com:80"),
+      ["known-bad.example.com:443", "*.noisy.example.com:80"],
+    );
+  });
+
+  it("returns an empty array for empty/undefined input", () => {
+    assert.deepEqual(readKnownBlockedRules(undefined), []);
+    assert.deepEqual(readKnownBlockedRules(""), []);
+  });
+
+  it("throws SandboxError with code INVALID_RULES for invalid rule syntax", () => {
+    assert.throws(
+      () => readKnownBlockedRules("no-port-specified"),
       (err) => {
         assert.ok(err instanceof SandboxError);
         assert.equal(err.code, "INVALID_RULES");

--- a/run/test/integration-test-known-blocked-rules.sh
+++ b/run/test/integration-test-known-blocked-rules.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-# Drives run/dist/main.cjs directly (rather than through a real `uses: ./run`
-# step) against a real proxy container/HAProxy log, proving the full
-# INPUT_KNOWN_BLOCKED_RULES -> container report -> pass/fail wiring works —
-# not just the mocked report-object logic already covered by
-# run/src/lib/report.test.js. See test-e2e.yml's
-# test_sandbox_known_blocked_rules for the Actions-level version of the
-# "all matched" case.
+# Drives run/dist/main.cjs directly against a real proxy container/HAProxy
+# log, proving the INPUT_KNOWN_BLOCKED_RULES -> report -> pass/fail wiring
+# end-to-end (the matching logic itself is already unit-tested). See
+# test-e2e.yml's test_sandbox_fail_on_blocked for the Actions-level version
+# of the "all matched" case.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -15,7 +13,6 @@ FAILURES=0
 
 run_instance() {
   local tmpdir="$1" known_blocked_rules="$2"
-  shift 2
   GITHUB_WORKSPACE="$tmpdir" \
   GITHUB_STATE="$tmpdir/state.env" \
   GITHUB_STEP_SUMMARY="$tmpdir/summary.md" \

--- a/run/test/integration-test-known-blocked-rules.sh
+++ b/run/test/integration-test-known-blocked-rules.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Drives run/dist/main.cjs directly (rather than through a real `uses: ./run`
+# step) against a real proxy container/HAProxy log, proving the full
+# INPUT_KNOWN_BLOCKED_RULES -> container report -> pass/fail wiring works —
+# not just the mocked report-object logic already covered by
+# run/src/lib/report.test.js. See test-e2e.yml's
+# test_sandbox_known_blocked_rules for the Actions-level version of the
+# "all matched" case.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FAILURES=0
+
+: "${BUILDCAGE_LOCAL_IMAGE_REF:?BUILDCAGE_LOCAL_IMAGE_REF must be set to the locally built proxy image}"
+
+run_instance() {
+  local tmpdir="$1" known_blocked_rules="$2"
+  shift 2
+  GITHUB_WORKSPACE="$tmpdir" \
+  GITHUB_STATE="$tmpdir/state.env" \
+  GITHUB_STEP_SUMMARY="$tmpdir/summary.md" \
+  BUILDCAGE_BUILD_TEST_HOOKS=1 \
+  BUILDCAGE_LOCAL_IMAGE_REF="$BUILDCAGE_LOCAL_IMAGE_REF" \
+  INPUT_ALLOWED_HTTPS_RULES="example.com:443" \
+  INPUT_ALLOWED_HTTP_RULES="example.com:80" \
+  INPUT_ALLOWED_IP_RULES="" \
+  INPUT_KNOWN_BLOCKED_RULES="$known_blocked_rules" \
+  INPUT_FAIL_ON_BLOCKED="true" \
+  INPUT_RUN="wget -q -T 5 -O /dev/null http://neverssl.com/ || true" \
+    node "$REPO_ROOT/run/dist/main.cjs" > "$tmpdir/out.log" 2>&1
+  echo $? > "$tmpdir/exit_code"
+}
+
+echo ""
+echo "=== Sandbox known_blocked_rules Assertions ==="
+echo ""
+
+# Case 1: the only blocked connection matches known_blocked_rules -> the
+# step must succeed despite fail_on_blocked defaulting to true.
+TMP_MATCH=$(mktemp -d)
+touch "$TMP_MATCH/state.env"
+run_instance "$TMP_MATCH" "neverssl.com:80"
+CODE_MATCH=$(cat "$TMP_MATCH/exit_code")
+if [ "$CODE_MATCH" = "0" ]; then
+  echo "  PASS  matching known_blocked_rules kept the step from failing"
+else
+  echo "  FAIL  matching known_blocked_rules did not prevent failure -- exit code $CODE_MATCH, see log below"
+  cat "$TMP_MATCH/out.log"
+  FAILURES=$((FAILURES + 1))
+fi
+rm -rf "$TMP_MATCH"
+
+# Case 2: known_blocked_rules is set but doesn't match the blocked
+# connection -> the step must still fail as normal (known_blocked_rules
+# isn't a backdoor allowlist).
+TMP_MISMATCH=$(mktemp -d)
+touch "$TMP_MISMATCH/state.env"
+run_instance "$TMP_MISMATCH" "some-other-domain.example.com:443"
+CODE_MISMATCH=$(cat "$TMP_MISMATCH/exit_code")
+if [ "$CODE_MISMATCH" != "0" ]; then
+  echo "  PASS  a non-matching known_blocked_rules entry still failed the step"
+else
+  echo "  FAIL  the step unexpectedly succeeded despite no known_blocked_rules match -- see log below"
+  cat "$TMP_MISMATCH/out.log"
+  FAILURES=$((FAILURES + 1))
+fi
+rm -rf "$TMP_MISMATCH"
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "❌ FAILED: $FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "✅ All assertions passed."
+echo ""

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -3,7 +3,9 @@
 var node_child_process = require("node:child_process"), path = require("node:path"), node_url = require("node:url"), node_fs = require("node:fs"), os = require("node:os"), require$$0 = require("os"), require$$1 = require("path"), require$$0$5 = require("fs"), require$$0$2 = require("util"), require$$0$1 = require("crypto"), require$$0$3 = require("tty"), require$$0$4 = require("fs/promises"), require$$0$6 = require("url"), _documentCurrentScript = "undefined" != typeof document ? document.currentScript : null;
 
 function buildRules(rulesInput) {
-  return (rulesInput?.trim().split(/\s+/).filter(Boolean) ?? []).map(convertRule);
+  return function(rulesInput) {
+    return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+  }(rulesInput).map(convertRule);
 }
 
 function convertRule(rule) {


### PR DESCRIPTION
## Summary

In `restrict` mode, `fail_on_blocked` fails the step on any blocked connection — a sensible default, but it also fails on connections you already expect and want blocked: a security check confirming a domain stays blocked, or a dependency that phones home to a known-noisy endpoint. The only existing workaround was `fail_on_blocked: false`, which silences *every* blocked connection, including the ones you actually want to catch.

`known_blocked_rules` (same wildcard/`~regex` syntax as `allowed_*_rules`) lets you name the destinations you expect to be blocked. A blocked connection matching it no longer fails the step even with `fail_on_blocked: true` — only genuinely unexpected blocks still do — and it's still shown in the Job Summary's Blocked Hosts table, marked with an "Expected" column, rather than silently disappearing.

One subtlety worth calling out: `report.blockedCount`'s meaning differs by proxy engine (transparent: total blocked events; explicit: aggregated row count), so the pass/fail decision matches per row rather than doing count arithmetic, to stay correct for both.

## Changes

- **Add a `known_blocked_rules` input** to mark destinations expected to be blocked, so they don't trigger `fail_on_blocked`
  - Same wildcard/`~regex` syntax as `allowed_*_rules`; never sent to the container's ACL — it only affects the pass/fail decision and report rendering
  - A matched blocked connection still shows up in the Job Summary's Blocked Hosts table, now marked with an "Expected" column
  - Available on both the `run` and `report` actions

- **Consolidate the blocked-connection decision logic**, previously duplicated between `run` and `report`, into one shared module
  - Matching, pass/fail decision, and message-building are each their own function, composed by a single entry point both actions call identically
  - Decides per row rather than by count arithmetic, since `blockedCount`'s meaning differs by proxy engine (transparent: total blocked events; explicit: aggregated row count)

- **Extract the Blocked/Allowed/Audited Hosts table renderer** into a shared module, replacing near-identical copies that had been maintained separately in `run` and `report`

- **Unify rule-string tokenizing and validation** so `known_blocked_rules` parsing and `run`'s `allowed_*_rules` validation share exactly the same tokenizer instead of each re-implementing it

- **Add test coverage**
  - Unit tests for the new shared modules and rule-parsing additions
  - An integration script driving a real proxy container through both the matched and unmatched cases
  - An e2e case folded into the existing `fail_on_blocked` job, reusing its already-built image instead of a redundant one

- **Document the new parameter** and its rule syntax in the reference and rule-syntax docs
