### PR TITLE
docs: use literal block scalars for multiline rule examples

### DIFF
--- a/.github/workflows/example-explicit.yml
+++ b/.github/workflows/example-explicit.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           proxy_mode: restrict
           proxy_engine: explicit
-          allowed_https_rules: >-
+          allowed_https_rules: |
             registry.npmjs.org:443
             fonts.googleapis.com:443
 

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -24,7 +24,7 @@ jobs:
         uses: dash14/buildcage/setup@39444cc894f62cc065d088f4a07821179d560f5e # v2.2.3
         with:
           proxy_mode: restrict
-          allowed_https_rules: >-
+          allowed_https_rules: |
             registry.npmjs.org:443
             fonts.googleapis.com:443
 

--- a/.github/workflows/example-run-restrict.yml
+++ b/.github/workflows/example-run-restrict.yml
@@ -26,7 +26,7 @@ jobs:
         uses: dash14/buildcage/run@39444cc894f62cc065d088f4a07821179d560f5e # v2.2.3
         with:
           proxy_mode: restrict
-          allowed_https_rules: >-
+          allowed_https_rules: |
             registry.npmjs.org:443
           # This step intentionally triggers a blocked connection below to
           # demonstrate enforcement — that's expected, not a failure.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Copy these domain names into `allowed_https_rules` or `allowed_http_rules` for S
   uses: dash14/buildcage/setup@39444cc894f62cc065d088f4a07821179d560f5e # v2.2.3
   with:
     proxy_mode: restrict  # Block every destination except the ones you allow
-    allowed_https_rules: >-
+    allowed_https_rules: |
       registry.npmjs.org:443
       fonts.googleapis.com:443
 
@@ -124,7 +124,7 @@ report, just applied to one step rather than a whole `docker build`.
   uses: dash14/buildcage/run@39444cc894f62cc065d088f4a07821179d560f5e # v2.2.3
   with:
     proxy_mode: restrict
-    allowed_https_rules: >-
+    allowed_https_rules: |
       registry.npmjs.org:443
     run: |
       npm install

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,7 +10,7 @@ Starts the Buildcage builder container.
   uses: dash14/buildcage/setup@39444cc894f62cc065d088f4a07821179d560f5e # v2.2.3
   with:
     proxy_mode: restrict
-    allowed_https_rules: >-
+    allowed_https_rules: |
       registry.npmjs.org:443
       github.com:443
 ```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -9,7 +9,7 @@ Rules are separated by **whitespace** (spaces, tabs, newlines).
 ```yaml
 # These are equivalent:
 allowed_https_rules: "a.com:443 b.com:443"
-allowed_https_rules: >-
+allowed_https_rules: |
   a.com:443
   b.com:443
 ```
@@ -72,25 +72,25 @@ Since the regex is tested against the `domain:port` string, include a port patte
     proxy_mode: restrict
 
     # Wildcard rules
-    allowed_https_rules: >-
+    allowed_https_rules: |
       registry.npmjs.org:443
       *.githubusercontent.com:443
       fonts.googleapis.com:443
 
     # HTTP rules with port
-    allowed_http_rules: >-
+    allowed_http_rules: |
       deb.debian.org:80
       archive.ubuntu.com:8080
 
     # IP address rules
-    allowed_ip_rules: >-
+    allowed_ip_rules: |
       192.168.1.1:443
       10.0.0.1:8080
 ```
 
 ```yaml
 # Regex rules
-allowed_https_rules: >-
+allowed_https_rules: |
   ~^registry\.npmjs\.org:\d+$
   ~^.*\.githubusercontent\.com:443$
 ```


### PR DESCRIPTION
## Summary

Multi-line `allowed_https_rules` / `allowed_http_rules` / `allowed_ip_rules` examples used YAML's folded scalar `>-`, while `|` is the more familiar way to write multi-line values and is what the rest of the docs already use for `run: |` steps. Switched all examples to `|` for consistency and readability. The parser splits rules on any whitespace, so this is purely cosmetic — behavior is unchanged.