### PR TITLE
ci: scope example workflow permissions to job level and make docker-login optional

### DIFF
--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -3,21 +3,24 @@ name: Example (audit mode)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # Uncomment when self-hosting under a private GHCR package; the public
+      # dash14/buildcage image is pulled anonymously and needs no login.
+      # - name: Login to GHCR
+      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Buildcage builder
         # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>

--- a/.github/workflows/example-explicit.yml
+++ b/.github/workflows/example-explicit.yml
@@ -3,21 +3,24 @@ name: Example (explicit engine)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # Uncomment when self-hosting under a private GHCR package; the public
+      # dash14/buildcage image is pulled anonymously and needs no login.
+      # - name: Login to GHCR
+      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Buildcage builder
         # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -3,21 +3,24 @@ name: Example (restrict mode)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # Uncomment when self-hosting under a private GHCR package; the public
+      # dash14/buildcage image is pulled anonymously and needs no login.
+      # - name: Login to GHCR
+      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Buildcage builder
         # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>

--- a/.github/workflows/example-run-audit.yml
+++ b/.github/workflows/example-run-audit.yml
@@ -3,23 +3,24 @@ name: Example (run action, audit mode)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Only needed for self-hosting under a private GHCR package; the public
+      # Uncomment when self-hosting under a private GHCR package; the public
       # dash14/buildcage image is pulled anonymously and needs no login.
-      - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Login to GHCR
+      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Discover required domains with the run action
         # For self-hosting, replace with: <your-org>/buildcage/run@<SHA>

--- a/.github/workflows/example-run-restrict.yml
+++ b/.github/workflows/example-run-restrict.yml
@@ -3,23 +3,24 @@ name: Example (run action, restrict mode)
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Only needed for self-hosting under a private GHCR package; the public
+      # Uncomment when self-hosting under a private GHCR package; the public
       # dash14/buildcage image is pulled anonymously and needs no login.
-      - name: Login to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Login to GHCR
+      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests with outbound network isolation
         # For self-hosting, replace with: <your-org>/buildcage/run@<SHA>


### PR DESCRIPTION
## Summary

The example workflows logged in to GHCR with `docker/login-action` before every run, but the setup action's OCI registry client already falls back to anonymous pulls when no Docker credentials are present (`core/lib/oci-registry.js`), and the public `dash14/buildcage` package needs no authentication to pull. The login step and its `packages: read` permission were therefore dead weight for the default, non-self-hosted path — only `docs/self-hosting.md` actually requires them, for private GHCR packages.

## Changes

- **Comment out the `docker/login-action` step** in all five example workflows, with a note to uncomment it when self-hosting under a private GHCR package
- **Comment out the corresponding `packages: read` permission** alongside it, so both toggle together
- **Move `permissions` from the workflow level to the job level** in each example, following least-privilege practice — the top-level block is now `permissions: {}`
