### PR TITLE
refactor: extract a generic markdown table formatter from host-table rendering

### DIFF
--- a/core/lib/host-table.js
+++ b/core/lib/host-table.js
@@ -1,0 +1,28 @@
+import { markdownTable } from "./markdown-table.js";
+
+/**
+ * Render aggregated host rows as a GitHub-flavored markdown table.
+ *
+ * @param {{host:string, port:string, ruleType:string, reason?:string, count:number, expected?:boolean}[]} rows
+ * @param {{showReason?: boolean, showExpected?: boolean}} [options]
+ * @returns {string}
+ */
+export function renderHostTable(rows, { showReason = false, showExpected = false } = {}) {
+  const formats = [
+    { key: "host", title: "Host" },
+    { key: "ruleType", title: "Rule" },
+  ];
+  if (showReason) formats.push({ key: "reason", title: "Reason" });
+  formats.push({ key: "count", title: "Count", align: "right" });
+  if (showExpected) formats.push({ key: "expected", title: "Expected", align: "center" });
+
+  const tableRows = rows.map((r) => ({
+    host: `${r.host}:${r.port}`,
+    ruleType: r.ruleType,
+    reason: r.reason,
+    count: r.count,
+    expected: r.expected ? "✅" : "",
+  }));
+
+  return markdownTable(formats, tableRows);
+}

--- a/core/lib/host-table.test.js
+++ b/core/lib/host-table.test.js
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { renderHostTable } from "./host-table.js";
+
+describe("renderHostTable", () => {
+  const row = (overrides = {}) => ({
+    host: "example.com",
+    port: "443",
+    ruleType: "HTTPS",
+    reason: "not in allowlist",
+    count: 2,
+    ...overrides,
+  });
+
+  it("renders a default 3-column table (Host, Rule, Count)", () => {
+    const table = renderHostTable([row()]);
+    assert.equal(
+      table,
+      "| Host | Rule | Count |\n| --- | --- | ---: |\n| example.com:443 | HTTPS | 2 |",
+    );
+  });
+
+  it("adds a Reason column when showReason is true", () => {
+    const table = renderHostTable([row()], { showReason: true });
+    assert.match(table, /^\| Host \| Rule \| Reason \| Count \|/);
+    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \|/);
+  });
+
+  it("adds an Expected column with a checkmark when showExpected is true and the row matched", () => {
+    const table = renderHostTable([row({ expected: true })], { showExpected: true });
+    assert.match(table, /^\| Host \| Rule \| Count \| Expected \|/);
+    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| ✅ \|/);
+  });
+
+  it("leaves the Expected cell blank when the row did not match", () => {
+    const table = renderHostTable([row({ expected: false })], { showExpected: true });
+    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| {2}\|/);
+  });
+
+  it("renders all 5 columns when both showReason and showExpected are true", () => {
+    const table = renderHostTable([row({ expected: true })], { showReason: true, showExpected: true });
+    assert.match(table, /^\| Host \| Rule \| Reason \| Count \| Expected \|/);
+    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \| ✅ \|/);
+  });
+
+  it("renders only the header rows for an empty list", () => {
+    const table = renderHostTable([]);
+    assert.equal(table, "| Host | Rule | Count |\n| --- | --- | ---: |");
+  });
+});

--- a/core/lib/markdown-table.js
+++ b/core/lib/markdown-table.js
@@ -1,25 +1,19 @@
+const ALIGN_MARKERS = { left: "---", right: "---:", center: ":---:" };
+const alignMarker = (align) => ALIGN_MARKERS[align] ?? ALIGN_MARKERS.left;
+
 /**
- * Render aggregated host rows as a GitHub-flavored markdown table. Shared by
- * run/src/lib/report.js and report/src/main.js so both actions' Job Summary
- * tables render identically.
+ * Render a generic GitHub-flavored markdown table.
  *
- * @param {{host:string, port:string, ruleType:string, reason?:string, count:number, expected?:boolean}[]} rows
- * @param {{showReason?: boolean, showExpected?: boolean}} [options]
+ * @param {{key: string, title: string, align?: "left"|"right"|"center"}[]} formats
+ * @param {Record<string, string|number>[]} rows
  * @returns {string}
  */
-export function markdownTable(rows, { showReason = false, showExpected = false } = {}) {
-  const headers = ["Host", "Rule"];
-  const aligns = ["---", "---"];
-  if (showReason) { headers.push("Reason"); aligns.push("---"); }
-  headers.push("Count"); aligns.push("---:");
-  if (showExpected) { headers.push("Expected"); aligns.push(":---:"); }
-
+export function markdownTable(formats, rows) {
+  const headers = formats.map((f) => f.title);
+  const aligns = formats.map((f) => alignMarker(f.align));
   const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
-  for (const r of rows) {
-    const cells = [`${r.host}:${r.port}`, r.ruleType];
-    if (showReason) cells.push(r.reason);
-    cells.push(r.count);
-    if (showExpected) cells.push(r.expected ? "✅" : "");
+  for (const row of rows) {
+    const cells = formats.map((f) => row[f.key]);
     lines.push(`| ${cells.join(" | ")} |`);
   }
   return lines.join("\n");

--- a/core/lib/markdown-table.test.js
+++ b/core/lib/markdown-table.test.js
@@ -3,48 +3,28 @@ import assert from "node:assert/strict";
 import { markdownTable } from "./markdown-table.js";
 
 describe("markdownTable", () => {
-  const row = (overrides = {}) => ({
-    host: "example.com",
-    port: "443",
-    ruleType: "HTTPS",
-    reason: "not in allowlist",
-    count: 2,
-    ...overrides,
-  });
-
-  it("renders a default 3-column table (Host, Rule, Count)", () => {
-    const table = markdownTable([row()]);
-    assert.equal(
-      table,
-      "| Host | Rule | Count |\n| --- | --- | ---: |\n| example.com:443 | HTTPS | 2 |",
+  it("renders headers, a left-aligned divider row, and cells pulled by key", () => {
+    const table = markdownTable(
+      [{ key: "a", title: "A" }, { key: "b", title: "B" }],
+      [{ a: "1", b: "2" }],
     );
+    assert.equal(table, "| A | B |\n| --- | --- |\n| 1 | 2 |");
   });
 
-  it("adds a Reason column when showReason is true", () => {
-    const table = markdownTable([row()], { showReason: true });
-    assert.match(table, /^\| Host \| Rule \| Reason \| Count \|/);
-    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \|/);
+  it("supports right and center alignment per column", () => {
+    const table = markdownTable(
+      [
+        { key: "a", title: "A", align: "right" },
+        { key: "b", title: "B", align: "center" },
+        { key: "c", title: "C" },
+      ],
+      [{ a: 1, b: 2, c: 3 }],
+    );
+    assert.equal(table, "| A | B | C |\n| ---: | :---: | --- |\n| 1 | 2 | 3 |");
   });
 
-  it("adds an Expected column with a checkmark when showExpected is true and the row matched", () => {
-    const table = markdownTable([row({ expected: true })], { showExpected: true });
-    assert.match(table, /^\| Host \| Rule \| Count \| Expected \|/);
-    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| ✅ \|/);
-  });
-
-  it("leaves the Expected cell blank when the row did not match", () => {
-    const table = markdownTable([row({ expected: false })], { showExpected: true });
-    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| {2}\|/);
-  });
-
-  it("renders all 5 columns when both showReason and showExpected are true", () => {
-    const table = markdownTable([row({ expected: true })], { showReason: true, showExpected: true });
-    assert.match(table, /^\| Host \| Rule \| Reason \| Count \| Expected \|/);
-    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \| ✅ \|/);
-  });
-
-  it("renders only the header rows for an empty list", () => {
-    const table = markdownTable([]);
-    assert.equal(table, "| Host | Rule | Count |\n| --- | --- | ---: |");
+  it("renders only the header rows for an empty row list", () => {
+    const table = markdownTable([{ key: "a", title: "A" }], []);
+    assert.equal(table, "| A |\n| --- |");
   });
 });

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -134,17 +134,51 @@ function convertRule(rule) {
   }(rule)}$`;
 }
 
-function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
-  const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
-  showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
-  aligns.push("---:"), showExpected && (headers.push("Expected"), aligns.push(":---:"));
-  const lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
-  for (const r of rows) {
-    const cells = [ `${r.host}:${r.port}`, r.ruleType ];
-    showReason && cells.push(r.reason), cells.push(r.count), showExpected && cells.push(r.expected ? "✅" : ""), 
+const ALIGN_MARKERS = {
+  left: "---",
+  right: "---:",
+  center: ":---:"
+};
+
+function markdownTable(formats, rows) {
+  const headers = formats.map(f => f.title), aligns = formats.map(f => {
+    return align = f.align, ALIGN_MARKERS[align] ?? ALIGN_MARKERS.left;
+    var align;
+  }), lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
+  for (const row of rows) {
+    const cells = formats.map(f => row[f.key]);
     lines.push(`| ${cells.join(" | ")} |`);
   }
   return lines.join("\n");
+}
+
+function renderHostTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
+  const formats = [ {
+    key: "host",
+    title: "Host"
+  }, {
+    key: "ruleType",
+    title: "Rule"
+  } ];
+  showReason && formats.push({
+    key: "reason",
+    title: "Reason"
+  }), formats.push({
+    key: "count",
+    title: "Count",
+    align: "right"
+  }), showExpected && formats.push({
+    key: "expected",
+    title: "Expected",
+    align: "center"
+  });
+  return markdownTable(formats, rows.map(r => ({
+    host: `${r.host}:${r.port}`,
+    ruleType: r.ruleType,
+    reason: r.reason,
+    count: r.count,
+    expected: r.expected ? "✅" : ""
+  })));
 }
 
 const __dirname$1 = node_path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = process.argv[2] || node_path.join(__dirname$1, "../..", "setup", "compose.yaml"), composeEnv = {
@@ -321,7 +355,7 @@ let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} m
 
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
-  audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n"), 
+  audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + renderHostTable(audited) + "\n"), 
   markdown += function(auditedRows, actionRepo, actionRef, {actionName: actionName = "setup", runCommand: runCommand} = {}) {
     if (!auditedRows || 0 === auditedRows.length) return "";
     const ref = /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef, groups = new Map;
@@ -345,14 +379,14 @@ if (isAudit) {
     return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", 
     md += yaml, md += "```\n\n", md += "</details>\n", md;
   }(audited, actionRepo, actionRef), annotatedBlocked.length > 0 && (audited.length > 0 && (markdown += "\n"), 
-  markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+  markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(annotatedBlocked, {
     showReason: !0,
     showExpected: showExpected
   }) + "\n");
 } else {
   const allowed = isExplicit ? aggregateAllowedHosts(builds, "ALLOWED") : report.sections.allowed || [];
-  allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n"), 
-  allowed.length > 0 && annotatedBlocked.length > 0 && (markdown += "\n"), annotatedBlocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, {
+  allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(allowed) + "\n"), 
+  allowed.length > 0 && annotatedBlocked.length > 0 && (markdown += "\n"), annotatedBlocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(annotatedBlocked, {
     showReason: !0,
     showExpected: showExpected
   }) + "\n");

--- a/report/src/main.js
+++ b/report/src/main.js
@@ -7,7 +7,7 @@ import { renderCommunicationDetails } from "./lib/command-log.js";
 import { selectAllRefs, parseVertexAllowedLog, aggregateAllowedHosts } from "./lib/vertex-log.js";
 import { createAnnotation } from "../../core/lib/annotation.js";
 import { evaluateBlockedReport } from "../../core/lib/known-blocked.js";
-import { markdownTable } from "../../core/lib/markdown-table.js";
+import { renderHostTable } from "../../core/lib/host-table.js";
 import { parseAndValidateRules } from "../../core/shared/lib/rules.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -133,23 +133,23 @@ let markdown = `## Outbound Traffic Report during Docker Build (${report.mode} m
 if (isAudit) {
   const audited = isExplicit ? aggregateAllowedHosts(builds, "AUDIT") : report.sections.audited || [];
   if (audited.length > 0) {
-    markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n";
+    markdown += "### 📋 Audited Hosts\n\n" + renderHostTable(audited) + "\n";
   }
   markdown += buildRestrictExample(audited, actionRepo, actionRef);
   if (annotatedBlocked.length > 0) {
     if (audited.length > 0) markdown += "\n";
-    markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
+    markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
   }
 } else {
   const allowed = isExplicit ? aggregateAllowedHosts(builds, "ALLOWED") : report.sections.allowed || [];
   if (allowed.length > 0) {
-    markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n";
+    markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(allowed) + "\n";
   }
   if (allowed.length > 0 && annotatedBlocked.length > 0) {
     markdown += "\n";
   }
   if (annotatedBlocked.length > 0) {
-    markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
+    markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(annotatedBlocked, { showReason: true, showExpected }) + "\n";
   }
 }
 

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7497,17 +7497,51 @@ function evaluateBlockedReport(report, {knownBlockedRules: knownBlockedRules, fa
   };
 }
 
-function markdownTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
-  const headers = [ "Host", "Rule" ], aligns = [ "---", "---" ];
-  showReason && (headers.push("Reason"), aligns.push("---")), headers.push("Count"), 
-  aligns.push("---:"), showExpected && (headers.push("Expected"), aligns.push(":---:"));
-  const lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
-  for (const r of rows) {
-    const cells = [ `${r.host}:${r.port}`, r.ruleType ];
-    showReason && cells.push(r.reason), cells.push(r.count), showExpected && cells.push(r.expected ? "✅" : ""), 
+const ALIGN_MARKERS = {
+  left: "---",
+  right: "---:",
+  center: ":---:"
+};
+
+function markdownTable(formats, rows) {
+  const headers = formats.map(f => f.title), aligns = formats.map(f => {
+    return align = f.align, ALIGN_MARKERS[align] ?? ALIGN_MARKERS.left;
+    var align;
+  }), lines = [ `| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |` ];
+  for (const row of rows) {
+    const cells = formats.map(f => row[f.key]);
     lines.push(`| ${cells.join(" | ")} |`);
   }
   return lines.join("\n");
+}
+
+function renderHostTable(rows, {showReason: showReason = !1, showExpected: showExpected = !1} = {}) {
+  const formats = [ {
+    key: "host",
+    title: "Host"
+  }, {
+    key: "ruleType",
+    title: "Rule"
+  } ];
+  showReason && formats.push({
+    key: "reason",
+    title: "Reason"
+  }), formats.push({
+    key: "count",
+    title: "Count",
+    align: "right"
+  }), showExpected && formats.push({
+    key: "expected",
+    title: "Expected",
+    align: "center"
+  });
+  return markdownTable(formats, rows.map(r => ({
+    host: `${r.host}:${r.port}`,
+    ruleType: r.ruleType,
+    reason: r.reason,
+    count: r.count,
+    expected: r.expected ? "✅" : ""
+  })));
 }
 
 function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRepo, actionRef: actionRef, runCommand: runCommand, blockedRows: blockedRows = [], showExpected: showExpected = !1} = {}) {
@@ -7517,7 +7551,7 @@ function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRe
   let markdown = `## ${heading} (${report.mode} mode)\n\n`;
   if (isAudit) {
     const audited = report.sections.audited || [];
-    audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n\n"), 
+    audited.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + renderHostTable(audited) + "\n\n"), 
     markdown += function(auditedRows, actionRepo, actionRef, {actionName: actionName = "setup", runCommand: runCommand} = {}) {
       if (!auditedRows || 0 === auditedRows.length) return "";
       const ref = /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef, groups = new Map;
@@ -7543,14 +7577,14 @@ function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRe
     }(audited, actionRepo, actionRef, {
       actionName: "run",
       runCommand: runCommand
-    }), blockedRows.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, {
+    }), blockedRows.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(blockedRows, {
       showReason: !0,
       showExpected: showExpected
     }) + "\n\n");
   } else {
     const allowed = report.sections.allowed || [];
-    allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n"), 
-    blockedRows.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, {
+    allowed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(allowed) + "\n\n"), 
+    blockedRows.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(blockedRows, {
       showReason: !0,
       showExpected: showExpected
     }) + "\n\n");

--- a/run/src/lib/report.js
+++ b/run/src/lib/report.js
@@ -3,7 +3,7 @@ import { appendFileSync } from "node:fs";
 import { createAnnotation } from "../../../core/lib/annotation.js";
 import { buildRestrictExample } from "../../../core/lib/build-example.js";
 import { evaluateBlockedReport } from "../../../core/lib/known-blocked.js";
-import { markdownTable } from "../../../core/lib/markdown-table.js";
+import { renderHostTable } from "../../../core/lib/host-table.js";
 
 /**
  * Fetch the structured HAProxy-log report from the (still-running) proxy
@@ -41,13 +41,13 @@ export function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, 
 
   if (isAudit) {
     const audited = report.sections.audited || [];
-    if (audited.length > 0) markdown += "### 📋 Audited Hosts\n\n" + markdownTable(audited) + "\n\n";
+    if (audited.length > 0) markdown += "### 📋 Audited Hosts\n\n" + renderHostTable(audited) + "\n\n";
     markdown += buildRestrictExample(audited, actionRepo, actionRef, { actionName: "run", runCommand });
-    if (blockedRows.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, { showReason: true, showExpected }) + "\n\n";
+    if (blockedRows.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(blockedRows, { showReason: true, showExpected }) + "\n\n";
   } else {
     const allowed = report.sections.allowed || [];
-    if (allowed.length > 0) markdown += "### ✅ Allowed Hosts\n\n" + markdownTable(allowed) + "\n\n";
-    if (blockedRows.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + markdownTable(blockedRows, { showReason: true, showExpected }) + "\n\n";
+    if (allowed.length > 0) markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(allowed) + "\n\n";
+    if (blockedRows.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(blockedRows, { showReason: true, showExpected }) + "\n\n";
   }
 
   return markdown;


### PR DESCRIPTION
## Summary

`core/lib/markdown-table.js`'s `markdownTable()` (extracted in #181 to share known_blocked_rules rendering between `run` and `report`) rendered one specific shape of table: aggregated host rows with a fixed Host/Rule/Reason/Count/Expected column set. That coupling made it useless for anything beyond that one table, even though the actual table-building logic — headers, alignment markers, joining cells into `| ... |` rows — has nothing host-specific about it.

This splits the two concerns into their own files: a generic markdown table formatter, and the host-row-specific renderer built on top of it.

## Changes

- **Add `markdownTable(formats, rows)`** to `core/lib/markdown-table.js` — a generic GitHub-flavored markdown table formatter driven by a `{key, title, align}` column format list and plain row objects, with no knowledge of hosts, rules, or any other domain concept
- **Extract `renderHostTable(rows, options)`** into a new `core/lib/host-table.js`, carrying over the Host/Rule/Reason/Count/Expected rendering (previously `markdownTable()`) and building its columns/rows on top of the generic formatter
- **Update `run/src/lib/report.js` and `report/src/main.js`** to import `renderHostTable` from `core/lib/host-table.js`
- **Split the test file accordingly**: `markdown-table.test.js` covers the generic formatter, `host-table.test.js` covers the host-row renderer