### PR TITLE
refactor: share image provenance verification between setup and run

### DIFF
--- a/core/lib/general/action-error.js
+++ b/core/lib/general/action-error.js
@@ -1,0 +1,14 @@
+/**
+ * Base class for an action's own "intentional" errors — a caught failure
+ * whose message is safe to print directly via ::error::, as opposed to an
+ * unexpected one. A top-level catch checks `instanceof ActionError`.
+ * `name` is derived from `new.target`, so a subclass needs no constructor
+ * of its own to get its own name.
+ */
+export class ActionError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}

--- a/core/lib/general/action-error.test.js
+++ b/core/lib/general/action-error.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ActionError } from "./action-error.js";
+
+describe("ActionError", () => {
+  it("sets name, message, and code, and is an instanceof Error", () => {
+    const err = new ActionError("msg", "CODE");
+    assert.equal(err.name, "ActionError");
+    assert.equal(err.message, "msg");
+    assert.equal(err.code, "CODE");
+    assert.ok(err instanceof Error);
+  });
+
+  it("derives name from the concrete subclass via new.target", () => {
+    class FooError extends ActionError {}
+    const err = new FooError("msg2", "CODE2");
+    assert.equal(err.name, "FooError");
+    assert.equal(err.message, "msg2");
+    assert.equal(err.code, "CODE2");
+    assert.ok(err instanceof ActionError);
+  });
+});

--- a/core/lib/provenance/errors.js
+++ b/core/lib/provenance/errors.js
@@ -1,3 +1,5 @@
+import { ActionError } from "../general/action-error.js";
+
 /**
  * VerifyImageError — intentional error in the image provenance verification
  * flow (Sigstore bundle fetch/verify, OCI registry lookups, image ref
@@ -16,3 +18,18 @@ export class VerifyImageError extends Error {
     this.code = code;
   }
 }
+
+/**
+ * ProvenanceError — thrown by verifyImageDigestOrThrow (see verify-image.js)
+ * when image provenance can't be established. Extends ActionError so a
+ * caller's own top-level catch (checking `instanceof ActionError`)
+ * recognizes it as a safe-to-print error.
+ *
+ * Codes:
+ *   NOT_FOUND        – resource does not exist (missing tag or bundle)
+ *   TRANSIENT        – network or 5xx error; do not treat as "resource absent"
+ *   TOKEN_ERROR      – registry token endpoint returned a client error
+ *   VERIFY_FAILED    – Sigstore bundle verification failed
+ *   UNVERIFIABLE_REF – action ref cannot be verified (branch / local path)
+ */
+export class ProvenanceError extends ActionError {}

--- a/core/lib/provenance/verify-image.js
+++ b/core/lib/provenance/verify-image.js
@@ -11,6 +11,7 @@
 
 import { fetchManifestDigest, fetchRegistryToken, fetchBundle, readGhcrBasicAuth } from "./oci-registry.js";
 import { derUtf8, verifyBundle } from "./sigstore.js";
+import { ProvenanceError } from "./errors.js";
 
 const REGISTRY = "ghcr.io";
 const EXPECTED_ISSUER = "https://token.actions.githubusercontent.com";
@@ -110,5 +111,32 @@ export async function verifyImageDigest({ actionRef, actionRepo, proxyEngine = "
   const digest = await fetchManifestDigest(REGISTRY, repoPath, tag, regToken);
   const bundle = await fetchBundle(REGISTRY, repoPath, digest, regToken);
   await verifyBundle(bundle, verifyOptions, digest);
+  return digest;
+}
+
+/**
+ * Like verifyImageDigest, but throws ProvenanceError (see errors.js) instead
+ * of the low-level VerifyImageError, so a caller gets one already-typed
+ * error to catch rather than having to translate the result itself.
+ *
+ * `verifyImageDigestFn` is an injectable seam (defaults to the real
+ * verifyImageDigest) for unit-testing without hitting the network/sigstore.
+ */
+export async function verifyImageDigestOrThrow({
+  actionRef, actionRepo, proxyEngine, verifyImageDigestFn = verifyImageDigest,
+}) {
+  let digest;
+  try {
+    digest = await verifyImageDigestFn({ actionRef, actionRepo, proxyEngine });
+  } catch (e) {
+    throw new ProvenanceError(e.message, e.code ?? "VERIFY_FAILED");
+  }
+  if (digest === null) {
+    throw new ProvenanceError(
+      `Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. ` +
+        `Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`,
+      "UNVERIFIABLE_REF",
+    );
+  }
   return digest;
 }

--- a/core/lib/provenance/verify-image.test.js
+++ b/core/lib/provenance/verify-image.test.js
@@ -16,7 +16,9 @@ import assert from "node:assert/strict";
 import {
   imageTagFromRef,
   buildVerifyOptions,
+  verifyImageDigestOrThrow,
 } from "./verify-image.js";
+import { ProvenanceError } from "./errors.js";
 
 // ── Constants mirrored from verify-image.js (for assertion readability) ──────
 
@@ -179,5 +181,62 @@ describe("buildVerifyOptions — unverifiable refs", () => {
 
   it("returns null for an empty ref", () => {
     assert.equal(buildVerifyOptions({ actionRef: "", actionRepo: REPO }), null);
+  });
+});
+
+describe("verifyImageDigestOrThrow", () => {
+  it("returns the digest on success", async () => {
+    const digest = await verifyImageDigestOrThrow({
+      actionRef: "v2.1.0",
+      actionRepo: REPO,
+      proxyEngine: "transparent",
+      verifyImageDigestFn: async () => "sha256:abc123",
+    });
+    assert.equal(digest, "sha256:abc123");
+  });
+
+  it("throws ProvenanceError carrying the original error's code on failure", async () => {
+    await assert.rejects(
+      () =>
+        verifyImageDigestOrThrow({
+          actionRef: "v2.1.0",
+          actionRepo: REPO,
+          proxyEngine: "transparent",
+          verifyImageDigestFn: async () => {
+            const e = new Error("registry token request failed");
+            e.code = "TOKEN_ERROR";
+            throw e;
+          },
+        }),
+      (err) => err instanceof ProvenanceError && err.code === "TOKEN_ERROR" && err.message === "registry token request failed",
+    );
+  });
+
+  it("defaults to VERIFY_FAILED when the original error has no code", async () => {
+    await assert.rejects(
+      () =>
+        verifyImageDigestOrThrow({
+          actionRef: "v2.1.0",
+          actionRepo: REPO,
+          proxyEngine: "transparent",
+          verifyImageDigestFn: async () => {
+            throw new Error("boom");
+          },
+        }),
+      (err) => err instanceof ProvenanceError && err.code === "VERIFY_FAILED",
+    );
+  });
+
+  it("throws ProvenanceError with UNVERIFIABLE_REF when the digest is null", async () => {
+    await assert.rejects(
+      () =>
+        verifyImageDigestOrThrow({
+          actionRef: "main",
+          actionRepo: REPO,
+          proxyEngine: "transparent",
+          verifyImageDigestFn: async () => null,
+        }),
+      (err) => err instanceof ProvenanceError && err.code === "UNVERIFIABLE_REF",
+    );
   });
 });

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -38,11 +38,19 @@ function resolveBuildcageImageRef({imageDigest: imageDigest, actionRepository: a
   return `${`ghcr.io/${actionRepository}`.toLowerCase()}@${imageDigest}`;
 }
 
+class ActionError extends Error {
+  constructor(message, code) {
+    super(message), this.name = new.target.name, this.code = code;
+  }
+}
+
 class VerifyImageError extends Error {
   constructor(message, code) {
     super(message), this.name = "VerifyImageError", this.code = code;
   }
 }
+
+class ProvenanceError extends ActionError {}
 
 const BUNDLE_MEDIA_TYPE = "application/vnd.dev.sigstore.bundle.v0.3+json";
 
@@ -7147,6 +7155,7 @@ async function verifyImageDigest({actionRef: actionRef, actionRepo: actionRepo, 
   });
   if (!verifyOptions) return null;
   const tag = function(actionRef, proxyEngine = "transparent") {
+    if (!actionRef) return "";
     let base;
     return base = /^[0-9a-f]{40}$/i.test(actionRef) ? `sha-${actionRef.toLowerCase()}` : actionRef.startsWith("v") ? actionRef.slice(1) : actionRef, 
     "explicit" === proxyEngine || "proxy" === proxyEngine ? `${base}-${proxyEngine}` : base;
@@ -7294,11 +7303,7 @@ function createAnnotation(enabled) {
   };
 }
 
-class SandboxError extends Error {
-  constructor(message, code) {
-    super(message), this.name = "SandboxError", this.code = code;
-  }
-}
+class SandboxError extends ActionError {}
 
 function checkPasswordlessSudo() {
   try {
@@ -7640,6 +7645,35 @@ function buildReportMarkdown(report, {stepLabel: stepLabel, actionRepo: actionRe
 
 const __dirname$1 = path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = path.join(__dirname$1, "../compose.yaml");
 
+async function resolveVerifiedImage({actionRef: actionRef, actionRepo: actionRepo}) {
+  const digest = await async function({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine, verifyImageDigestFn: verifyImageDigestFn = verifyImageDigest}) {
+    let digest;
+    try {
+      digest = await verifyImageDigestFn({
+        actionRef: actionRef,
+        actionRepo: actionRepo,
+        proxyEngine: proxyEngine
+      });
+    } catch (e) {
+      throw new ProvenanceError(e.message, e.code ?? "VERIFY_FAILED");
+    }
+    if (null === digest) throw new ProvenanceError(`Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`, "UNVERIFIABLE_REF");
+    return digest;
+  }({
+    actionRef: actionRef,
+    actionRepo: actionRepo,
+    proxyEngine: "proxy"
+  });
+  return console.log(`Image provenance verified for ref: ${JSON.stringify(actionRef)} (digest ${digest}).`), 
+  {
+    imageRef: resolveBuildcageImageRef({
+      imageDigest: digest,
+      actionRepository: actionRepo
+    }),
+    pullPolicy: "always"
+  };
+}
+
 function parseRulesOrThrow(rulesInput) {
   try {
     return parseAndValidateRules(rulesInput);
@@ -7673,27 +7707,7 @@ process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? requ
   const env = process.env, actionRef = env.GITHUB_ACTION_REF || "v2", actionRepo = env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", runInput = env.INPUT_RUN ?? "";
   if (!runInput.trim()) throw new SandboxError("Input 'run' is required.", "MISSING_RUN");
   checkPasswordlessSudo();
-  const annotation = createAnnotation(Boolean(env.GITHUB_STEP_SUMMARY)), {imageRef: imageRef, pullPolicy: pullPolicy} = await async function({actionRef: actionRef, actionRepo: actionRepo}) {
-    let digest;
-    try {
-      digest = await verifyImageDigest({
-        actionRef: actionRef,
-        actionRepo: actionRepo,
-        proxyEngine: "proxy"
-      });
-    } catch (e) {
-      throw new SandboxError(e.message, e.code ?? "VERIFY_FAILED");
-    }
-    if (null === digest) throw new SandboxError(`Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`, "UNVERIFIABLE_REF");
-    return console.log(`Image provenance verified for ref: ${JSON.stringify(actionRef)} (digest ${digest}).`), 
-    {
-      imageRef: resolveBuildcageImageRef({
-        imageDigest: digest,
-        actionRepository: actionRepo
-      }),
-      pullPolicy: "always"
-    };
-  }({
+  const annotation = createAnnotation(Boolean(env.GITHUB_STEP_SUMMARY)), {imageRef: imageRef, pullPolicy: pullPolicy} = await resolveVerifiedImage({
     actionRef: actionRef,
     actionRepo: actionRepo
   });
@@ -7881,7 +7895,7 @@ process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? requ
   }
   0 !== exitCode && (process.exitCode = exitCode);
 }().catch(err => {
-  err instanceof SandboxError ? console.log(`::error::${err.message}`) : console.log(`::error::Unexpected error in sandbox: ${err.message}`), 
+  err instanceof ActionError ? console.log(`::error::${err.message}`) : console.log(`::error::Unexpected error in sandbox: ${err.message}`), 
   process.exit(1);
 }), exports.buildACLRules = buildACLRules, exports.buildComposeDownArgs = buildComposeDownArgs, 
 exports.buildComposeUpArgs = buildComposeUpArgs, exports.parseWritablePaths = parseWritablePaths, 

--- a/run/src/lib/errors.js
+++ b/run/src/lib/errors.js
@@ -1,28 +1,17 @@
+import { ActionError } from "../../../core/lib/general/action-error.js";
+
 /**
- * SandboxError — intentional error in the run action.
- *
- * All expected failure paths (missing image, network error, verification
- * failure, invalid config) throw SandboxError. Anything that is NOT a
- * SandboxError is treated as an unexpected error by the main entry point.
+ * SandboxError — intentional error in the run action's own logic. Image
+ * provenance failures throw ProvenanceError instead (see
+ * core/lib/provenance/errors.js).
  *
  * Codes:
- *   NOT_FOUND        – resource does not exist (missing tag or bundle)
- *   TRANSIENT        – network or 5xx error; do not treat as "resource absent"
- *   TOKEN_ERROR      – registry token endpoint returned a client error
- *   VERIFY_FAILED    – Sigstore bundle verification failed
- *   UNVERIFIABLE_REF – action ref cannot be verified (branch / local path)
- *   INVALID_RULES    – ACL rule syntax error
- *   MISSING_RUN      – required `run` input was empty
- *   PROXY_NOT_RUNNING – sandbox proxy container isn't running after `docker compose up`
- *   RUNC_EXTRACT_FAILED – failed to `docker cp` runc/gen-seccomp-profile out of the proxy image
- *   OCI_CONFIG_BUILD_FAILED – failed to run gen-seccomp-profile/runc spec or assemble config.json
- *   DOCKER_UNAVAILABLE – docker CLI missing from PATH or a docker command failed
+ *   INVALID_RULES              – ACL rule syntax error
+ *   MISSING_RUN                – required `run` input was empty
+ *   PROXY_NOT_RUNNING          – sandbox proxy container isn't running after `docker compose up`
+ *   RUNC_EXTRACT_FAILED        – failed to `docker cp` runc/gen-seccomp-profile out of the proxy image
+ *   OCI_CONFIG_BUILD_FAILED    – failed to run gen-seccomp-profile/runc spec or assemble config.json
+ *   DOCKER_UNAVAILABLE         – docker CLI missing from PATH or a docker command failed
  *   PASSWORDLESS_SUDO_REQUIRED – sudo -n check failed; passwordless sudo isn't configured
  */
-export class SandboxError extends Error {
-  constructor(message, code) {
-    super(message);
-    this.name = "SandboxError";
-    this.code = code;
-  }
-}
+export class SandboxError extends ActionError {}

--- a/run/src/main.js
+++ b/run/src/main.js
@@ -5,9 +5,10 @@ import { fileURLToPath } from "node:url";
 
 import { parseAndValidateRules } from "../../core/shared/lib/rules.js";
 import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.js";
-import { verifyImageDigest } from "../../core/lib/provenance/verify-image.js";
+import { verifyImageDigestOrThrow } from "../../core/lib/provenance/verify-image.js";
 import { describeDockerFailure } from "../../core/lib/actions/docker-error.js";
 import { createAnnotation } from "../../core/lib/actions/annotation.js";
+import { ActionError } from "../../core/lib/general/action-error.js";
 import { SandboxError } from "./lib/errors.js";
 import { checkPasswordlessSudo } from "./lib/sudo-preflight.js";
 import { generateContainerName, getContainerPid, deriveProjectName } from "./lib/container.js";
@@ -40,19 +41,7 @@ const LOCAL_IMAGE_OVERRIDE_ENABLED = process.env.BUILDCAGE_BUILD_TEST_HOOKS === 
  * tag suffix (see imageTagFromRef in core/lib/provenance/verify-image.js).
  */
 async function resolveVerifiedImage({ actionRef, actionRepo }) {
-  let digest;
-  try {
-    digest = await verifyImageDigest({ actionRef, actionRepo, proxyEngine: "proxy" });
-  } catch (e) {
-    throw new SandboxError(e.message, e.code ?? "VERIFY_FAILED");
-  }
-  if (digest === null) {
-    throw new SandboxError(
-      `Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. ` +
-        `Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`,
-      "UNVERIFIABLE_REF",
-    );
-  }
+  const digest = await verifyImageDigestOrThrow({ actionRef, actionRepo, proxyEngine: "proxy" });
   console.log(`Image provenance verified for ref: ${JSON.stringify(actionRef)} (digest ${digest}).`);
   return {
     imageRef: resolveBuildcageImageRef({ imageDigest: digest, actionRepository: actionRepo }),
@@ -303,7 +292,7 @@ async function main() {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((err) => {
-    if (err instanceof SandboxError) {
+    if (err instanceof ActionError) {
       console.log(`::error::${err.message}`);
     } else {
       console.log(`::error::Unexpected error in sandbox: ${err.message}`);

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -2,10 +2,11 @@
 
 var node_child_process = require("node:child_process"), path = require("node:path"), node_url = require("node:url"), node_fs = require("node:fs"), os = require("node:os"), require$$0 = require("os"), require$$1 = require("path"), require$$0$5 = require("fs"), require$$0$2 = require("util"), require$$0$1 = require("crypto"), require$$0$3 = require("tty"), require$$0$4 = require("fs/promises"), require$$0$6 = require("url"), _documentCurrentScript = "undefined" != typeof document ? document.currentScript : null;
 
-function buildRules(rulesInput) {
-  return function(rulesInput) {
+function parseAndValidateRules(rulesInput) {
+  const rules = function(rulesInput) {
     return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  }(rulesInput).map(convertRule);
+  }(rulesInput);
+  return rules.forEach(convertRule), rules;
 }
 
 function convertRule(rule) {
@@ -33,17 +34,21 @@ function convertRule(rule) {
   }(rule)}$`;
 }
 
-class SetupError extends Error {
+class ActionError extends Error {
   constructor(message, code) {
-    super(message), this.name = "SetupError", this.code = code;
+    super(message), this.name = new.target.name, this.code = code;
   }
 }
+
+class SetupError extends ActionError {}
 
 class VerifyImageError extends Error {
   constructor(message, code) {
     super(message), this.name = "VerifyImageError", this.code = code;
   }
 }
+
+class ProvenanceError extends ActionError {}
 
 const BUNDLE_MEDIA_TYPE = "application/vnd.dev.sigstore.bundle.v0.3+json";
 
@@ -7282,23 +7287,54 @@ function describeDockerFailure(e, {operation: operation = "docker", env: env = p
 
 const __dirname$1 = path.dirname(node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href)), composeFile = path.join(__dirname$1, "../compose.yaml");
 
+async function resolveVerifiedImage({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine}) {
+  const digest = await async function({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine, verifyImageDigestFn: verifyImageDigestFn = verifyImageDigest}) {
+    let digest;
+    try {
+      digest = await verifyImageDigestFn({
+        actionRef: actionRef,
+        actionRepo: actionRepo,
+        proxyEngine: proxyEngine
+      });
+    } catch (e) {
+      throw new ProvenanceError(e.message, e.code ?? "VERIFY_FAILED");
+    }
+    if (null === digest) throw new ProvenanceError(`Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`, "UNVERIFIABLE_REF");
+    return digest;
+  }({
+    actionRef: actionRef,
+    actionRepo: actionRepo,
+    proxyEngine: proxyEngine
+  });
+  return console.log(`Image provenance verified for ref: ${JSON.stringify(actionRef)} (digest ${digest}).`), 
+  {
+    imageRef: resolveBuildcageImageRef({
+      imageDigest: digest,
+      actionRepository: actionRepo
+    }),
+    pullPolicy: "always"
+  };
+}
+
 function resolveProxyEngine(input) {
   const engine = input?.trim() || "transparent";
   if ("transparent" !== engine && "explicit" !== engine) throw new SetupError(`Invalid proxy_engine: ${JSON.stringify(input)}. Must be "transparent" or "explicit".`, "INVALID_PROXY_ENGINE");
   return engine;
 }
 
-function buildACLRules({httpsRulesInput: httpsRulesInput, httpRulesInput: httpRulesInput, ipRulesInput: ipRulesInput}) {
-  const httpsRules = httpsRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [], httpRules = httpRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [], ipRules = ipRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+function parseRulesOrThrow(rulesInput) {
   try {
-    buildRules(httpsRulesInput), buildRules(httpRulesInput), buildRules(ipRulesInput);
+    return parseAndValidateRules(rulesInput);
   } catch (e) {
     throw new SetupError(e.message, "INVALID_RULES");
   }
+}
+
+function buildACLRules({httpsRulesInput: httpsRulesInput, httpRulesInput: httpRulesInput, ipRulesInput: ipRulesInput}) {
   return {
-    httpsRules: httpsRules,
-    httpRules: httpRules,
-    ipRules: ipRules
+    httpsRules: parseRulesOrThrow(httpsRulesInput),
+    httpRules: parseRulesOrThrow(httpRulesInput),
+    ipRules: parseRulesOrThrow(ipRulesInput)
   };
 }
 
@@ -7310,27 +7346,7 @@ function logRules(label, rules) {
 process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && "SCRIPT" === _documentCurrentScript.tagName.toUpperCase() && _documentCurrentScript.src || new URL("main.cjs", document.baseURI).href) && async function() {
   const env = process.env, actionRef = env.GITHUB_ACTION_REF ?? "", actionRepo = env.GITHUB_ACTION_REPOSITORY ?? "", proxyEngine = resolveProxyEngine(env.INPUT_PROXY_ENGINE);
   console.log(`Proxy engine: ${proxyEngine}`);
-  const {imageRef: imageRef, pullPolicy: pullPolicy} = await async function({actionRef: actionRef, actionRepo: actionRepo, proxyEngine: proxyEngine}) {
-    let digest;
-    try {
-      digest = await verifyImageDigest({
-        actionRef: actionRef,
-        actionRepo: actionRepo,
-        proxyEngine: proxyEngine
-      });
-    } catch (e) {
-      throw new SetupError(e.message, e.code ?? "VERIFY_FAILED");
-    }
-    if (null === digest) throw new SetupError(`Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`, "UNVERIFIABLE_REF");
-    return console.log(`Image provenance verified for ref: ${JSON.stringify(actionRef)} (digest ${digest}).`), 
-    {
-      imageRef: resolveBuildcageImageRef({
-        imageDigest: digest,
-        actionRepository: actionRepo
-      }),
-      pullPolicy: "always"
-    };
-  }({
+  const {imageRef: imageRef, pullPolicy: pullPolicy} = await resolveVerifiedImage({
     actionRef: actionRef,
     actionRepo: actionRepo,
     proxyEngine: proxyEngine
@@ -7374,6 +7390,6 @@ process.argv[1] === node_url.fileURLToPath("undefined" == typeof document ? requ
     }), "DOCKER_UNAVAILABLE");
   }
 }().catch(err => {
-  err instanceof SetupError ? console.log(`::error::${err.message}`) : console.log(`::error::Unexpected error in setup: ${err.message}`), 
+  err instanceof ActionError ? console.log(`::error::${err.message}`) : console.log(`::error::Unexpected error in setup: ${err.message}`), 
   process.exit(1);
 }), exports.buildACLRules = buildACLRules, exports.resolveProxyEngine = resolveProxyEngine;

--- a/setup/src/lib/errors.js
+++ b/setup/src/lib/errors.js
@@ -1,23 +1,13 @@
+import { ActionError } from "../../../core/lib/general/action-error.js";
+
 /**
- * SetupError — intentional error in the setup action.
- *
- * All expected failure paths (missing image, network error, verification
- * failure, invalid config) throw SetupError.  Anything that is NOT a
- * SetupError is treated as an unexpected error by the main entry point.
+ * SetupError — intentional error in the setup action's own logic. Image
+ * provenance failures throw ProvenanceError instead (see
+ * core/lib/provenance/errors.js).
  *
  * Codes:
- *   NOT_FOUND        – resource does not exist (missing tag or bundle)
- *   TRANSIENT        – network or 5xx error; do not treat as "resource absent"
- *   TOKEN_ERROR      – registry token endpoint returned a client error
- *   VERIFY_FAILED    – Sigstore bundle verification failed
- *   UNVERIFIABLE_REF – action ref cannot be verified (branch / local path)
- *   INVALID_RULES    – ACL rule syntax error
- *   DOCKER_UNAVAILABLE – docker CLI missing from PATH or a docker command failed
+ *   INVALID_RULES        – ACL rule syntax error
+ *   DOCKER_UNAVAILABLE    – docker CLI missing from PATH or a docker command failed
+ *   INVALID_PROXY_ENGINE  – proxy_engine input isn't "transparent" or "explicit"
  */
-export class SetupError extends Error {
-  constructor(message, code) {
-    super(message);
-    this.name = "SetupError";
-    this.code = code;
-  }
-}
+export class SetupError extends ActionError {}

--- a/setup/src/main.js
+++ b/setup/src/main.js
@@ -2,9 +2,10 @@ import { execFileSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { buildRules } from "../../core/shared/lib/rules.js";
+import { parseAndValidateRules } from "../../core/shared/lib/rules.js";
 import { SetupError } from "./lib/errors.js";
-import { verifyImageDigest } from "../../core/lib/provenance/verify-image.js";
+import { ActionError } from "../../core/lib/general/action-error.js";
+import { verifyImageDigestOrThrow } from "../../core/lib/provenance/verify-image.js";
 import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.js";
 import { describeDockerFailure } from "../../core/lib/actions/docker-error.js";
 
@@ -20,23 +21,11 @@ const LOCAL_IMAGE_OVERRIDE_ENABLED = process.env.BUILDCAGE_BUILD_TEST_HOOKS === 
 
 /**
  * Verifies image provenance and resolves the digest-pinned image ref.
- * Throws SetupError("UNVERIFIABLE_REF") if verification can't be performed
- * (branch ref / local ./setup) — printed by the top-level catch.
+ * Throws ProvenanceError("UNVERIFIABLE_REF") if verification can't be
+ * performed (branch ref / local ./setup) — printed by the top-level catch.
  */
 async function resolveVerifiedImage({ actionRef, actionRepo, proxyEngine }) {
-  let digest;
-  try {
-    digest = await verifyImageDigest({ actionRef, actionRepo, proxyEngine });
-  } catch (e) {
-    throw new SetupError(e.message, e.code ?? "VERIFY_FAILED");
-  }
-  if (digest === null) {
-    throw new SetupError(
-      `Cannot verify image provenance for ref: ${JSON.stringify(actionRef)}. ` +
-        `Pin the action to a version tag (e.g. @v2.1.0) or a commit SHA.`,
-      "UNVERIFIABLE_REF",
-    );
-  }
+  const digest = await verifyImageDigestOrThrow({ actionRef, actionRepo, proxyEngine });
   console.log(`Image provenance verified for ref: ${JSON.stringify(actionRef)} (digest ${digest}).`);
   return {
     imageRef: resolveBuildcageImageRef({ imageDigest: digest, actionRepository: actionRepo }),
@@ -142,22 +131,27 @@ export function resolveProxyEngine(input) {
 }
 
 /**
- * Build ACL rules from input strings.
- * Rules are passed through as-is (wildcard format), validated by converting to regex.
+ * Rethrow a rule-parser's syntax errors as a SetupError with the shared
+ * INVALID_RULES code.
  */
-export function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput }) {
-  const httpsRules = httpsRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  const httpRules = httpRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-  const ipRules = ipRulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+function parseRulesOrThrow(rulesInput) {
   try {
-    buildRules(httpsRulesInput);
-    buildRules(httpRulesInput);
-    buildRules(ipRulesInput);
+    return parseAndValidateRules(rulesInput);
   } catch (e) {
     throw new SetupError(e.message, "INVALID_RULES");
   }
+}
 
-  return { httpsRules, httpRules, ipRules };
+/**
+ * Build ACL rules from input strings. Rules are passed through as-is
+ * (wildcard format), validated eagerly.
+ */
+export function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput }) {
+  return {
+    httpsRules: parseRulesOrThrow(httpsRulesInput),
+    httpRules: parseRulesOrThrow(httpRulesInput),
+    ipRules: parseRulesOrThrow(ipRulesInput),
+  };
 }
 
 function logRules(label, rules) {
@@ -167,7 +161,7 @@ function logRules(label, rules) {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((err) => {
-    if (err instanceof SetupError) {
+    if (err instanceof ActionError) {
       console.log(`::error::${err.message}`);
     } else {
       console.log(`::error::Unexpected error in setup: ${err.message}`);


### PR DESCRIPTION
## Summary

`setup/src/main.js` and `run/src/main.js` each independently implemented near-identical image-provenance verification logic (`resolveVerifiedImage`) and their own error class (`SetupError`/`SandboxError`) with duplicated constructors. Both error classes' `Codes:` lists also carried the same provenance-verification codes (`NOT_FOUND`, `TRANSIENT`, `TOKEN_ERROR`, `VERIFY_FAILED`, `UNVERIFIABLE_REF`) — codes that didn't actually belong to either action specifically, since they came from `resolveVerifiedImage` re-wrapping the same underlying verification result each time.

## Changes

- **Add a shared `ActionError` base class** (`core/lib/general/action-error.js`) for "this action's own recognized error, safe to print via `::error::`"
  - `name` is derived from `new.target`, so a subclass needs no constructor of its own to get its own name
  - Each main.js's top-level catch now checks `instanceof ActionError` instead of its own specific error class, so any `ActionError` subclass — including ones thrown by shared helpers — is recognized correctly

- **Extract image-provenance verification into a shared, testable component**
  - New `verifyImageDigestOrThrow` (`core/lib/provenance/verify-image.js`) verifies the digest and throws a new `ProvenanceError` (`core/lib/provenance/errors.js`, extends `ActionError`) carrying only the codes that are genuinely about provenance verification
  - `SetupError`/`SandboxError` become bare `ActionError` subclasses with their `Codes:` docs trimmed to just their own action-specific codes
  - `verifyImageDigestFn` is an injectable seam, giving this logic its first-ever unit test coverage — previously only reachable via e2e
  - Each action's `resolveVerifiedImage` shrinks to calling the shared verifier, logging, and assembling the result; the `BUILDCAGE_BUILD_TEST_HOOKS` local-image-override bypass and its console output stay local to each main.js, since that behavior is specific to each build/action rather than a shared component

- **Fix `setup`'s `buildACLRules`** to call `parseAndValidateRules` directly (matching `run`'s own version) instead of re-implementing `splitRuleTokens`'s split logic by hand and calling `buildRules` purely for its throw-on-invalid-syntax side effect while discarding the converted output