### PR TITLE
refactor: reorganize Makefile targets and drop the node -e project-name lookup

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -260,7 +260,7 @@ jobs:
           BUILDER_NAME: buildcage-multiarch
         run: docker compose down -v --rmi all 2>/dev/null || true
 
-  # Drives run/dist/main.cjs directly via `make test_sandbox_integration`
+  # Drives run/dist/main.cjs directly via `make test_integration_sandbox_linux`
   # (see run/test/integration-test-*.sh), not through the real run action —
   # mirrors how the `test` job above drives report/src/main.js directly.
   # test-e2e.yml's test_sandbox_* jobs keep one representative case each
@@ -296,7 +296,7 @@ jobs:
       - name: Run run-action integration tests
         env:
           BUILDCAGE_LOCAL_IMAGE_REF: ${{ steps.local_image.outputs.ref }}
-        run: make test_sandbox_integration
+        run: make test_integration_sandbox_linux
 
   # Single, stably-named required status check for branch protection: the
   # `test` job's own name varies per matrix entry (test (transparent-audit),

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check dist is free of the BUILDCAGE_BUILD_TEST_HOOKS test hooks
         run: |
-          for f in setup/dist/main.cjs run/dist/main.cjs report/dist/main.cjs; do
+          for f in setup/dist/main.cjs setup/dist/post.cjs run/dist/main.cjs report/dist/main.cjs; do
             if grep -q 'process\.env\.BUILDCAGE_BUILD_TEST_HOOKS' "$f"; then
               echo "::error::$f still contains a live process.env.BUILDCAGE_BUILD_TEST_HOOKS read — rolldown's replacePlugin failed to substitute it (see rolldown.config.js), leaving a test-only hook reachable in a published action. Do not merge until this passes."
               exit 1

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ TEST_COMPOSE_FILE ?= setup/compose.test-transparent.yaml
 # Scoped to the targets that touch this Compose project; test_unit_*,
 # test_integration_sandbox_linux, and the sandbox dev-loop targets are
 # excluded on purpose (see their own sections below).
-setup_buildkit_% test_integration_buildkit_% example_% clean_integration_buildkit report_buildkit: export COMPOSE_PROJECT_NAME := buildcage-project
-setup_buildkit_% test_integration_buildkit_% example_% clean_integration_buildkit report_buildkit: export BUILDCAGE_BUILD_TEST_HOOKS := 1
+setup_buildkit_% test_integration_buildkit_% example_% clean_buildkit report_buildkit: export COMPOSE_PROJECT_NAME := buildcage-project
+setup_buildkit_% test_integration_buildkit_% example_% clean_buildkit report_buildkit: export BUILDCAGE_BUILD_TEST_HOOKS := 1
 
 .PHONY: help
 help:
@@ -115,6 +115,13 @@ setup_buildkit_explicit_restrict: ## Start explicit proxy engine in restrict mod
 		--name buildcage \
 		--driver remote docker-container://buildcage
 
+.PHONY: clean_buildkit
+clean_buildkit: ## Stop and remove the buildkit builder's containers/images and buildx builder
+	@echo "Stopping and removing all containers..."
+	@docker buildx rm buildcage 2>/dev/null || true
+	@docker compose -p $(COMPOSE_PROJECT_NAME) -f compose.yaml -f $(TEST_COMPOSE_FILE) down -v --rmi all
+	@docker rmi buildcage-test 2>/dev/null || true
+
 .PHONY: report_buildkit
 report_buildkit: ## Show the buildcage report for the currently running builder
 	@node report/src/main.ts
@@ -140,7 +147,7 @@ test_integration_buildkit_transparent_audit: ## Run transparent-engine audit mod
 	@./setup/test/assert-transparent-audit.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@$(MAKE) clean_integration_buildkit
+	@$(MAKE) clean_buildkit
 
 .PHONY: test_integration_buildkit_transparent_restrict
 test_integration_buildkit_transparent_restrict: ## Run transparent-engine restrict mode tests
@@ -156,7 +163,7 @@ test_integration_buildkit_transparent_restrict: ## Run transparent-engine restri
 	@./setup/test/assert-transparent-restrict.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@$(MAKE) clean_integration_buildkit
+	@$(MAKE) clean_buildkit
 
 .PHONY: test_integration_buildkit_explicit_audit
 test_integration_buildkit_explicit_audit: ## Run explicit-engine audit mode tests
@@ -172,7 +179,7 @@ test_integration_buildkit_explicit_audit: ## Run explicit-engine audit mode test
 	@./setup/test/assert-explicit-audit.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean_integration_buildkit
+	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean_buildkit
 
 .PHONY: test_integration_buildkit_explicit_restrict
 test_integration_buildkit_explicit_restrict: ## Run explicit-engine restrict mode tests
@@ -188,14 +195,7 @@ test_integration_buildkit_explicit_restrict: ## Run explicit-engine restrict mod
 	@./setup/test/assert-explicit-restrict.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean_integration_buildkit
-
-.PHONY: clean_integration_buildkit
-clean_integration_buildkit: ## Stop and remove the buildkit builder's containers/images and buildx builder
-	@echo "Stopping and removing all containers..."
-	@docker buildx rm buildcage 2>/dev/null || true
-	@docker compose -p $(COMPOSE_PROJECT_NAME) -f compose.yaml -f $(TEST_COMPOSE_FILE) down -v --rmi all
-	@docker rmi buildcage-test 2>/dev/null || true
+	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean_buildkit
 
 # ---------------------------------------------------------------------------
 # setup_sandbox_dev / test_sandbox_dev — mac-friendly dev loop for the run
@@ -264,7 +264,7 @@ example_transparent_audit: ## Run audit mode example tests
 	  --progress=plain -f /tmp/build-context/Dockerfile /tmp/build-context \
 	  --load -t buildcage-test
 	@node report/src/main.ts
-	@$(MAKE) clean_integration_buildkit
+	@$(MAKE) clean_buildkit
 	rm -fr /tmp/build-context
 
 .PHONY: example_transparent_restrict
@@ -285,5 +285,5 @@ example_transparent_restrict: ## Run restrict mode example tests
 	  --progress=plain -f /tmp/build-context/Dockerfile /tmp/build-context \
 	  --load -t buildcage-test
 	@node report/src/main.ts || true
-	@$(MAKE) clean_integration_buildkit
+	@$(MAKE) clean_buildkit
 	rm -fr /tmp/build-context

--- a/Makefile
+++ b/Makefile
@@ -1,135 +1,136 @@
 COMPOSE_FILE ?= compose.yaml
-# Overridable so test_explicit_*_mode can clean up setup/compose.test-explicit.yaml's
-# containers/images instead of the default transparent-engine test overlay.
+# Lets test_integration_buildkit_explicit_* clean up the explicit-engine overlay.
 TEST_COMPOSE_FILE ?= setup/compose.test-transparent.yaml
 
-# Must equal deriveProjectName("buildcage") (core/lib/docker/container.ts).
-# Exported so setup/test/helpers.sh and assert-explicit-*.sh's plain
-# `docker compose exec` calls pick it up without needing -p every time.
-#
-# Skipped for `help` (the default goal), so it doesn't pay for a Node
-# startup just to print the command list.
-ifeq ($(strip $(filter-out help,$(or $(MAKECMDGOALS),help))),)
-BUILDER_PROJECT_NAME :=
-else
-export COMPOSE_PROJECT_NAME := $(shell node -e "import('./core/lib/docker/container.ts').then(m => process.stdout.write(m.deriveProjectName('buildcage')))")
-BUILDER_PROJECT_NAME := $(COMPOSE_PROJECT_NAME)
-endif
+# Fixed Compose project name, trusted by report/src/main.ts and
+# setup/src/post.ts via their own BUILDCAGE_BUILD_TEST_HOOKS-gated overrides
+# instead of deriveProjectName("buildcage") (core/lib/docker/container.ts).
+# Scoped to the targets that touch this Compose project; test_unit_*,
+# test_integration_sandbox_linux, and the sandbox dev-loop targets are
+# excluded on purpose (see their own sections below).
+setup_buildkit_% test_integration_buildkit_% example_% clean_integration_buildkit report_buildkit: export COMPOSE_PROJECT_NAME := buildcage-project
+setup_buildkit_% test_integration_buildkit_% example_% clean_integration_buildkit report_buildkit: export BUILDCAGE_BUILD_TEST_HOOKS := 1
 
-# Self-Documented Makefile
 .PHONY: help
 help:
-	@grep -E '^[a-zA-Z_0-9-]+(-%)?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_0-9-]+(-%)?:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: clean
-clean: ## Clean up all resources
-	@echo "Stopping and removing all containers..."
-	@docker buildx rm buildcage 2>/dev/null || true
-	@docker compose -p $(BUILDER_PROJECT_NAME) -f compose.yaml -f $(TEST_COMPOSE_FILE) down -v --rmi all
-	@docker rmi buildcage-test 2>/dev/null || true
+# ===========================================================================
+# Unit tests
+# ===========================================================================
+
+.PHONY: test_unit
+test_unit: test_unit_core test_unit_setup test_unit_report test_unit_sandbox test_unit_qjs ## Run unit tests
+
+.PHONY: test_unit_core
+test_unit_core: ## Run core unit tests
+	@node --test 'core/**/*.test.ts'
+
+.PHONY: test_unit_setup
+test_unit_setup: ## Run setup action unit tests
+	@node --test 'setup/src/**/*.test.ts'
+
+.PHONY: test_unit_report
+test_unit_report: ## Run report unit tests
+	@node --test 'report/src/**/*.test.ts'
+
+.PHONY: test_unit_sandbox
+test_unit_sandbox: ## Run the run action's unit tests
+	@node --test 'run/src/**/*.test.ts'
+
+# qjs can't execute .ts directly, so compile fresh (pnpm run build:qjs-test)
+# and bind-mount the output in. qjs itself is identical across images, so one
+# representative build is enough.
+QJS_MOUNTS := \
+	-v "$(CURDIR)/dist/test-qjs/core:/opt/buildcage/core:ro"
+QJS_TEST_DIRS := \
+	/opt/buildcage/core/lib/acl
+
+.PHONY: test_unit_qjs
+test_unit_qjs: ## Run unit tests in Docker
+	@pnpm run build:qjs-test
+	@docker build -f setup/docker/transparent/Dockerfile -t buildcage-qjs-test .
+	@docker run --rm --entrypoint qjs $(QJS_MOUNTS) buildcage-qjs-test \
+		--std -m /opt/buildcage/core/scripts/test/run-tests.qjs.js $(QJS_TEST_DIRS)
+
+# ===========================================================================
+# Integration tests
+# ===========================================================================
 
 # ---------------------------------------------------------------------------
-# run_{engine}_{mode}_mode — start the builder only (no build/verify/cleanup).
-# One target per (transparent, explicit) x (audit, restrict) combination.
+# setup_buildkit_{engine}_{mode} — start the builder only
 # ---------------------------------------------------------------------------
 
-.PHONY: run_transparent_audit_mode
-run_transparent_audit_mode: ## Start transparent engine in audit mode
+.PHONY: setup_buildkit_transparent_audit
+setup_buildkit_transparent_audit: ## Start transparent engine in audit mode
 	@echo "Starting buildcage (transparent engine) in AUDIT mode..."
 	@COMPOSE_FILE=$(COMPOSE_FILE) \
 	  PROXY_MODE=audit \
-	  docker compose -p $(BUILDER_PROJECT_NAME) up -d --wait --build
+	  docker compose -p $(COMPOSE_PROJECT_NAME) up -d --wait --build
 	@docker buildx rm buildcage 2>/dev/null || true
 	@echo "Creating buildx builder..."
 	@docker buildx create --bootstrap \
 		--name buildcage \
 		--driver remote docker-container://buildcage
 
-.PHONY: run_transparent_restrict_mode
-run_transparent_restrict_mode: ## Start transparent engine in restrict mode
+.PHONY: setup_buildkit_transparent_restrict
+setup_buildkit_transparent_restrict: ## Start transparent engine in restrict mode
 	@echo "Starting buildcage (transparent engine) in RESTRICT mode..."
 	@COMPOSE_FILE=$(COMPOSE_FILE) \
 	  PROXY_MODE=restrict \
 	  ALLOWED_HTTP_RULES="$${ALLOWED_HTTP_RULES:-}" \
 	  ALLOWED_HTTPS_RULES="$${ALLOWED_HTTPS_RULES:-github.com:443 registry.npmjs.org:443 api.github.com:443 objects.githubusercontent.com:443 httpbin.org:443 deb.debian.org:80 *.githubusercontent.com:443}" \
-	  docker compose -p $(BUILDER_PROJECT_NAME) up -d --wait --build
+	  docker compose -p $(COMPOSE_PROJECT_NAME) up -d --wait --build
 	@docker buildx rm buildcage 2>/dev/null || true
 	@echo "Creating buildx builder..."
 	@docker buildx create --bootstrap \
 		--name buildcage \
 		--driver remote docker-container://buildcage
 
-.PHONY: run_explicit_audit_mode
-run_explicit_audit_mode: ## Start explicit proxy engine in audit mode
+.PHONY: setup_buildkit_explicit_audit
+setup_buildkit_explicit_audit: ## Start explicit proxy engine in audit mode
 	@echo "Starting buildcage (explicit proxy engine) in AUDIT mode..."
 	@COMPOSE_FILE=$(COMPOSE_FILE) \
 	  PROXY_ENGINE=explicit \
 	  PROXY_MODE=audit \
-	  docker compose -p $(BUILDER_PROJECT_NAME) up -d --wait --build
+	  docker compose -p $(COMPOSE_PROJECT_NAME) up -d --wait --build
 	@docker buildx rm buildcage 2>/dev/null || true
 	@echo "Creating buildx builder..."
 	@docker buildx create --bootstrap \
 		--name buildcage \
 		--driver remote docker-container://buildcage
 
-.PHONY: run_explicit_restrict_mode
-run_explicit_restrict_mode: ## Start explicit proxy engine in restrict mode
+.PHONY: setup_buildkit_explicit_restrict
+setup_buildkit_explicit_restrict: ## Start explicit proxy engine in restrict mode
 	@echo "Starting buildcage (explicit proxy engine) in RESTRICT mode..."
 	@COMPOSE_FILE=$(COMPOSE_FILE) \
 	  PROXY_ENGINE=explicit \
 	  PROXY_MODE=restrict \
 	  ALLOWED_HTTP_RULES="$${ALLOWED_HTTP_RULES:-}" \
 	  ALLOWED_HTTPS_RULES="$${ALLOWED_HTTPS_RULES:-github.com:443 registry.npmjs.org:443 api.github.com:443 objects.githubusercontent.com:443 httpbin.org:443 deb.debian.org:80 *.githubusercontent.com:443}" \
-	  docker compose -p $(BUILDER_PROJECT_NAME) up -d --wait --build
+	  docker compose -p $(COMPOSE_PROJECT_NAME) up -d --wait --build
 	@docker buildx rm buildcage 2>/dev/null || true
 	@echo "Creating buildx builder..."
 	@docker buildx create --bootstrap \
 		--name buildcage \
 		--driver remote docker-container://buildcage
 
-# ---------------------------------------------------------------------------
-# run_sandbox_mode / test_sandbox_mode — mac-friendly dev loop for the
-# run action (see run/dev/Dockerfile). Production and CI's
-# test_sandbox job instead run run-isolated.sh directly on the host — see
-# docs/development.md.
-# ---------------------------------------------------------------------------
-
-.PHONY: run_sandbox_mode
-run_sandbox_mode: ## Start sandbox proxy + dev runner (mac-friendly dev loop)
-	@echo "Starting buildcage sandbox (dev loop)..."
-	@ALLOWED_HTTPS_RULES="$${ALLOWED_HTTPS_RULES:-example.com:443}" \
-	  ALLOWED_HTTP_RULES="$${ALLOWED_HTTP_RULES:-example.com:80}" \
-	  docker compose -f compose.yaml -f run/compose.sandbox-dev.yaml up -d --build --wait proxy sandbox-dev-runner
-	@echo "Proxy container:  buildcage-proxy"
-	@echo "Dev runner:       buildcage-sandbox-dev-runner"
-	@echo "Try: make test_sandbox_mode"
-
-.PHONY: test_sandbox_mode
-test_sandbox_mode: ## Run a sample isolated command in the dev loop and verify isolation
-	@$(MAKE) run_sandbox_mode
-	@PROXY_PID=$$(docker inspect --format '{{.State.Pid}}' buildcage-proxy); \
-	  docker compose -f compose.yaml -f run/compose.sandbox-dev.yaml exec sandbox-dev-runner sh -c " \
-	    set -e; \
-	    build-test-bundle.sh --netns-name buildcage-sandbox-dev --script /usr/local/bin/smoke-test.sh --bundle /var/tmp/buildcage/dev-bundle; \
-	    run-isolated.sh --proxy-pid $$PROXY_PID --runc /usr/local/bin/runc --bundle /var/tmp/buildcage/dev-bundle \
-	      --container-id buildcage-sandbox-dev --netns-name buildcage-sandbox-dev --rootfs-bind-dir /var/tmp/buildcage/dev-bundle/rootfs \
-	      --gateway 172.20.0.1 --dns 172.20.0.1 --target-ip 172.20.0.101"
-	@$(MAKE) clean_sandbox_mode
-
-.PHONY: clean_sandbox_mode
-clean_sandbox_mode: ## Stop and remove the sandbox dev-loop containers
-	@docker compose -f compose.yaml -f run/compose.sandbox-dev.yaml down -v --rmi local
+.PHONY: report_buildkit
+report_buildkit: ## Show the buildcage report for the currently running builder
+	@node report/src/main.ts
 
 # ---------------------------------------------------------------------------
-# test_{engine}_{mode}_mode — run_{engine}_{mode}_mode + build the matching
-# setup/test/Dockerfile.* + verify + clean up. One target per combination.
+# test_integration_buildkit_{engine}_{mode} — setup + build + verify + clean
 # ---------------------------------------------------------------------------
 
-.PHONY: test_transparent_audit_mode
-test_transparent_audit_mode: ## Run transparent-engine audit mode tests
+.PHONY: test_integration_buildkit
+test_integration_buildkit: test_integration_buildkit_transparent_audit test_integration_buildkit_transparent_restrict test_integration_buildkit_explicit_audit test_integration_buildkit_explicit_restrict ## Run all buildkit integration tests
+
+.PHONY: test_integration_buildkit_transparent_audit
+test_integration_buildkit_transparent_audit: ## Run transparent-engine audit mode tests
 	@echo "Running transparent-engine audit mode tests..."
 	@COMPOSE_FILE=compose.yaml:setup/compose.test-transparent.yaml \
-	  $(MAKE) run_transparent_audit_mode
+	  $(MAKE) setup_buildkit_transparent_audit
 	@docker buildx build --no-cache \
 	  --builder buildcage \
 	  --platform linux/arm64 \
@@ -139,13 +140,13 @@ test_transparent_audit_mode: ## Run transparent-engine audit mode tests
 	@./setup/test/assert-transparent-audit.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@$(MAKE) clean
+	@$(MAKE) clean_integration_buildkit
 
-.PHONY: test_transparent_restrict_mode
-test_transparent_restrict_mode: ## Run transparent-engine restrict mode tests
+.PHONY: test_integration_buildkit_transparent_restrict
+test_integration_buildkit_transparent_restrict: ## Run transparent-engine restrict mode tests
 	@echo "Running transparent-engine restrict mode tests..."
 	@COMPOSE_FILE=compose.yaml:setup/compose.test-transparent.yaml \
-	  $(MAKE) run_transparent_restrict_mode
+	  $(MAKE) setup_buildkit_transparent_restrict
 	@docker buildx build --no-cache \
 	  --builder buildcage \
 	  --platform linux/arm64 \
@@ -155,13 +156,13 @@ test_transparent_restrict_mode: ## Run transparent-engine restrict mode tests
 	@./setup/test/assert-transparent-restrict.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@$(MAKE) clean
+	@$(MAKE) clean_integration_buildkit
 
-.PHONY: test_explicit_audit_mode
-test_explicit_audit_mode: ## Run explicit-engine audit mode tests
+.PHONY: test_integration_buildkit_explicit_audit
+test_integration_buildkit_explicit_audit: ## Run explicit-engine audit mode tests
 	@echo "Running explicit-engine audit mode tests..."
 	@COMPOSE_FILE=compose.yaml:setup/compose.test-explicit.yaml \
-	  $(MAKE) run_explicit_audit_mode
+	  $(MAKE) setup_buildkit_explicit_audit
 	@docker buildx build --no-cache \
 	  --builder buildcage \
 	  --platform linux/arm64 \
@@ -171,13 +172,13 @@ test_explicit_audit_mode: ## Run explicit-engine audit mode tests
 	@./setup/test/assert-explicit-audit.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean
+	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean_integration_buildkit
 
-.PHONY: test_explicit_restrict_mode
-test_explicit_restrict_mode: ## Run explicit-engine restrict mode tests
+.PHONY: test_integration_buildkit_explicit_restrict
+test_integration_buildkit_explicit_restrict: ## Run explicit-engine restrict mode tests
 	@echo "Running explicit-engine restrict mode tests..."
 	@COMPOSE_FILE=compose.yaml:setup/compose.test-explicit.yaml \
-	  $(MAKE) run_explicit_restrict_mode
+	  $(MAKE) setup_buildkit_explicit_restrict
 	@docker buildx build --no-cache \
 	  --builder buildcage \
 	  --platform linux/arm64 \
@@ -187,13 +188,50 @@ test_explicit_restrict_mode: ## Run explicit-engine restrict mode tests
 	@./setup/test/assert-explicit-restrict.sh
 	@node setup/src/post.ts
 	@./setup/test/assert-post.sh
-	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean
+	@TEST_COMPOSE_FILE=setup/compose.test-explicit.yaml $(MAKE) clean_integration_buildkit
 
-# Unlike test_{engine}_{mode}_mode above, this drives run/dist/main.cjs
-# directly (see run/test/integration-test-*.sh) since the run action
-# isolates a host command, not a Docker build.
-.PHONY: test_sandbox_integration
-test_sandbox_integration: ## Run the run action's integration tests (needs BUILDCAGE_LOCAL_IMAGE_REF and a test-hook build of run/dist/main.cjs)
+.PHONY: clean_integration_buildkit
+clean_integration_buildkit: ## Stop and remove the buildkit builder's containers/images and buildx builder
+	@echo "Stopping and removing all containers..."
+	@docker buildx rm buildcage 2>/dev/null || true
+	@docker compose -p $(COMPOSE_PROJECT_NAME) -f compose.yaml -f $(TEST_COMPOSE_FILE) down -v --rmi all
+	@docker rmi buildcage-test 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# setup_sandbox_dev / test_sandbox_dev — mac-friendly dev loop for the run
+# action (see run/dev/Dockerfile). CI's test_sandbox job runs
+# run-isolated.sh directly on the host instead — see docs/development.md.
+# ---------------------------------------------------------------------------
+
+.PHONY: setup_sandbox_dev
+setup_sandbox_dev: ## Start sandbox proxy + dev runner (mac-friendly dev loop)
+	@echo "Starting buildcage sandbox (dev loop)..."
+	@ALLOWED_HTTPS_RULES="$${ALLOWED_HTTPS_RULES:-example.com:443}" \
+	  ALLOWED_HTTP_RULES="$${ALLOWED_HTTP_RULES:-example.com:80}" \
+	  docker compose -f compose.yaml -f run/compose.sandbox-dev.yaml up -d --build --wait proxy sandbox-dev-runner
+	@echo "Proxy container:  buildcage-proxy"
+	@echo "Dev runner:       buildcage-sandbox-dev-runner"
+	@echo "Try: make test_sandbox_dev"
+
+.PHONY: test_sandbox_dev
+test_sandbox_dev: ## Run a sample isolated command in the dev loop and verify isolation
+	@$(MAKE) setup_sandbox_dev
+	@PROXY_PID=$$(docker inspect --format '{{.State.Pid}}' buildcage-proxy); \
+	  docker compose -f compose.yaml -f run/compose.sandbox-dev.yaml exec sandbox-dev-runner sh -c " \
+	    set -e; \
+	    build-test-bundle.sh --netns-name buildcage-sandbox-dev --script /usr/local/bin/smoke-test.sh --bundle /var/tmp/buildcage/dev-bundle; \
+	    run-isolated.sh --proxy-pid $$PROXY_PID --runc /usr/local/bin/runc --bundle /var/tmp/buildcage/dev-bundle \
+	      --container-id buildcage-sandbox-dev --netns-name buildcage-sandbox-dev --rootfs-bind-dir /var/tmp/buildcage/dev-bundle/rootfs \
+	      --gateway 172.20.0.1 --dns 172.20.0.1 --target-ip 172.20.0.101"
+	@$(MAKE) clean_sandbox_dev
+
+.PHONY: clean_sandbox_dev
+clean_sandbox_dev: ## Stop and remove the sandbox dev-loop containers
+	@docker compose -f compose.yaml -f run/compose.sandbox-dev.yaml down -v --rmi local
+
+# Drives run/dist/main.cjs directly (a host command, not a Docker build).
+.PHONY: test_integration_sandbox_linux
+test_integration_sandbox_linux: ## Run the run action's integration tests (needs BUILDCAGE_LOCAL_IMAGE_REF and a test-hook build of run/dist/main.cjs)
 	@./run/test/integration-test-writable-dir.sh
 	@./run/test/integration-test-writable-disabled.sh
 	@./run/test/integration-test-defaults.sh
@@ -206,50 +244,14 @@ test_sandbox_integration: ## Run the run action's integration tests (needs BUILD
 	@./run/test/integration-test-concurrent.sh
 	@./run/test/integration-test-known-blocked-rules.sh
 
-.PHONY: test_unit
-test_unit: test_core test_setup test_report test_sandbox_unit test_qjs ## Run unit tests
+# ---------------------------------------------------------------------------
+# example_{engine}_{mode} — smoke test against a plain Dockerfile
+# ---------------------------------------------------------------------------
 
-# Most of core/lib/{acl,log} is dual-consumed (Node and QuickJS both import
-# it), and its *.test.ts run under both here and test_qjs below via the
-# portable shim in core/lib/test/test-shim.ts. *.property.test.ts siblings use
-# node:test/fast-check only, so they run here (not qjs-compatible) instead.
-.PHONY: test_core
-test_core: ## Run core/lib unit tests
-	@node --test 'core/lib/**/*.test.ts'
-
-.PHONY: test_setup
-test_setup: ## Run setup action unit tests
-	@node --test 'setup/src/**/*.test.ts'
-
-.PHONY: test_report
-test_report: ## Run report unit tests
-	@node --test 'report/src/**/*.test.ts'
-
-.PHONY: test_sandbox_unit
-test_sandbox_unit: ## Run the run action's unit tests
-	@node --test 'run/src/**/*.test.ts'
-
-# *.test.ts is excluded from the built images (see .dockerignore) and qjs can't execute
-# .ts directly, so compile fresh on the host (pnpm run build:qjs-test, output to
-# dist/test-qjs/) and bind-mount that compiled output in for qjs to exec. qjs itself is
-# identical across images, so one representative build (setup's transparent engine) is
-# enough — the scripts-build stage's own bundles are unused here (bind-mounted over).
-QJS_MOUNTS := \
-	-v "$(CURDIR)/dist/test-qjs/core:/opt/buildcage/core:ro"
-QJS_TEST_DIRS := \
-	/opt/buildcage/core/lib/acl
-
-.PHONY: test_qjs
-test_qjs: ## Run unit tests in Docker
-	@pnpm run build:qjs-test
-	@docker build -f setup/docker/transparent/Dockerfile -t buildcage-qjs-test .
-	@docker run --rm --entrypoint qjs $(QJS_MOUNTS) buildcage-qjs-test \
-		--std -m /opt/buildcage/core/scripts/test/run-tests.qjs.js $(QJS_TEST_DIRS)
-
-.PHONY: test_audit_example
-run_audit_example: ## Run audit mode example tests
+.PHONY: example_transparent_audit
+example_transparent_audit: ## Run audit mode example tests
 	@echo "Running audit mode example tests..."
-	@$(MAKE) run_transparent_audit_mode
+	@$(MAKE) setup_buildkit_transparent_audit
 	@mkdir -p /tmp/build-context
 	@printf '%s\n' \
 	  "FROM node:24-alpine" \
@@ -262,14 +264,14 @@ run_audit_example: ## Run audit mode example tests
 	  --progress=plain -f /tmp/build-context/Dockerfile /tmp/build-context \
 	  --load -t buildcage-test
 	@node report/src/main.ts
-	@$(MAKE) clean
+	@$(MAKE) clean_integration_buildkit
 	rm -fr /tmp/build-context
 
-.PHONY: run_restrict_example
-run_restrict_example: ## Run restrict mode example tests
+.PHONY: example_transparent_restrict
+example_transparent_restrict: ## Run restrict mode example tests
 	@echo "Running restrict mode example tests..."
 	@ALLOWED_HTTPS_RULES="registry.npmjs.org:443" \
-	  $(MAKE) run_transparent_restrict_mode
+	  $(MAKE) setup_buildkit_transparent_restrict
 	@mkdir -p /tmp/build-context
 	@printf '%s\n' \
 	  "FROM node:24-alpine" \
@@ -283,5 +285,5 @@ run_restrict_example: ## Run restrict mode example tests
 	  --progress=plain -f /tmp/build-context/Dockerfile /tmp/build-context \
 	  --load -t buildcage-test
 	@node report/src/main.ts || true
-	@$(MAKE) clean
+	@$(MAKE) clean_integration_buildkit
 	rm -fr /tmp/build-context

--- a/core/scripts/test/run-tests.qjs.ts
+++ b/core/scripts/test/run-tests.qjs.ts
@@ -20,11 +20,7 @@ for (const dir of dirs) {
     std.err.puts(`cannot read directory ${dir}: errno ${err}\n`);
     std.exit(1);
   }
-  // *.property.test.js files are node:test-based (run via `node --test`,
-  // not qjs) and live alongside these — exclude them explicitly.
-  const testFiles = entries
-    .filter((f) => f.endsWith(".test.js") && !f.endsWith(".property.test.js"))
-    .sort();
+  const testFiles = entries.filter((f) => f.endsWith(".test.js")).sort();
   for (const f of testFiles) {
     await import(`${dir}/${f}`);
   }

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,20 +10,20 @@ You can run Buildcage locally without GitHub Actions using Docker Compose and Ma
 
 ### Starting the Builder
 
-There's one `run_{engine}_{mode}_mode` target per (`transparent`, `explicit`) x (`audit`, `restrict`)
+There's one `setup_buildkit_{engine}_{mode}` target per (`transparent`, `explicit`) x (`audit`, `restrict`)
 combination:
 
 ```bash
-make run_transparent_audit_mode
-make run_transparent_restrict_mode
-make run_explicit_audit_mode
-make run_explicit_restrict_mode
+make setup_buildkit_transparent_audit
+make setup_buildkit_transparent_restrict
+make setup_buildkit_explicit_audit
+make setup_buildkit_explicit_restrict
 ```
 
 **Start with custom domains** (restrict mode only):
 
 ```bash
-ALLOWED_HTTPS_RULES="github.com:443 npmjs.org:443 example.com:443" make run_transparent_restrict_mode
+ALLOWED_HTTPS_RULES="github.com:443 npmjs.org:443 example.com:443" make setup_buildkit_transparent_restrict
 ```
 
 The `explicit_*` targets use BuildKit's native `--proxy-network` instead of the CNI/DNS-redirect/HAProxy
@@ -36,23 +36,28 @@ stack (see [Proxy Engines](./reference.md#proxy-engines)). `PROXY_ENGINE=explici
 
 ```bash
 # 1. Start Buildcage
-make run_transparent_audit_mode
+make setup_buildkit_transparent_audit
 
 # 2. Build
 docker buildx build --builder buildcage --progress=plain -f Dockerfile .
 
 # 3. View report
-docker compose logs builder
+make report_buildkit
 
 # 4. Clean up
-make clean
+make clean_integration_buildkit
 ```
+
+`make report_buildkit` runs `node report/src/main.ts` with the same `COMPOSE_PROJECT_NAME`/`BUILDCAGE_BUILD_TEST_HOOKS`
+override the `setup_buildkit_*`/`clean_integration_buildkit` targets use (see the pattern rule near the top of the
+Makefile) — running `node report/src/main.ts` directly, without going through `make`, won't find the running
+builder container. Raw builder logs are also available via `docker compose logs builder`.
 
 ### Sandbox Dev Loop (mac-friendly)
 
 The `run` action's own isolation mechanism (`run-isolated.sh`) uses Linux-only primitives
-(`ip netns`, `nsenter`, `runc`) that can't run natively on macOS. `make run_sandbox_mode` /
-`make test_sandbox_mode` instead drive it from inside a container with `pid: host` (see
+(`ip netns`, `nsenter`, `runc`) that can't run natively on macOS. `make setup_sandbox_dev` /
+`make test_sandbox_dev` instead drive it from inside a container with `pid: host` (see
 `run/dev/Dockerfile` and `run/compose.sandbox-dev.yaml`), which can see the proxy
 container's PID/netns via `/proc` — close enough to the real "runner host + separate proxy
 container" arrangement for day-to-day iteration, though it can't validate the container-boundary
@@ -66,25 +71,26 @@ production exactly — treat those as the final word on whether a change actuall
 dev loop.
 
 ```bash
-make run_sandbox_mode   # start the proxy + dev-loop runner container
-make test_sandbox_mode  # run a sample isolated command and verify allow/block + capability drop
+make setup_sandbox_dev  # start the proxy + dev-loop runner container
+make test_sandbox_dev   # run a sample isolated command and verify allow/block + capability drop
 ```
 
 ## Testing
 
-Each `run_{engine}_{mode}_mode` target has a matching `test_{engine}_{mode}_mode` target
-(start → build the matching `setup/test/Dockerfile.*` → verify → clean up):
+Each `setup_buildkit_{engine}_{mode}` target has a matching
+`test_integration_buildkit_{engine}_{mode}` target (start → build the matching
+`setup/test/Dockerfile.*` → verify → clean up):
 
 ```bash
-make test_transparent_audit_mode
-make test_transparent_restrict_mode
-make test_explicit_audit_mode
-make test_explicit_restrict_mode
+make test_integration_buildkit_transparent_audit
+make test_integration_buildkit_transparent_restrict
+make test_integration_buildkit_explicit_audit
+make test_integration_buildkit_explicit_restrict
 ```
 
-`make test_sandbox_unit` runs the run action's Node.js unit tests
-(`node --test 'run/src/**/*.test.ts'`); `make test_sandbox_mode` is the dev-loop end-to-end
-check described above; `make test_sandbox_integration` drives `run/dist/main.cjs` directly for
+`make test_unit_sandbox` runs the run action's Node.js unit tests
+(`node --test 'run/src/**/*.test.ts'`); `make test_sandbox_dev` is the dev-loop end-to-end
+check described above; `make test_integration_sandbox_linux` drives `run/dist/main.cjs` directly for
 checks that don't depend on the real action wrapper (see `run/test/integration-test-*.sh`) and
 is what CI's `test_sandbox` job in `test-integration.yml` runs. The CI-only `test_sandbox_*`
 end-to-end jobs (real runner host, no nested container) are described in
@@ -286,20 +292,22 @@ reports for the allowed side.
 | Command | Description |
 |---------|-------------|
 | `make help` | Show available commands |
-| `make run_transparent_audit_mode` | Start transparent engine in audit mode |
-| `make run_transparent_restrict_mode` | Start transparent engine in restrict mode (default domains) |
-| `make run_explicit_audit_mode` | Start explicit proxy engine in audit mode |
-| `make run_explicit_restrict_mode` | Start explicit proxy engine in restrict mode |
-| `make test_transparent_audit_mode` | Run transparent-engine audit mode tests (start → build → verify → clean up) |
-| `make test_transparent_restrict_mode` | Run transparent-engine restrict mode tests (start → build → verify → clean up) |
-| `make test_explicit_audit_mode` | Run explicit-engine audit mode tests (start → build → verify → clean up) |
-| `make test_explicit_restrict_mode` | Run explicit-engine restrict mode tests (start → build → verify → clean up) |
-| `make run_sandbox_mode` | Start the run action's proxy + mac-friendly dev-loop runner |
-| `make test_sandbox_mode` | Run a sample isolated command in the dev loop and verify isolation |
-| `make test_unit` | Run unit tests (includes `test_sandbox_unit`) |
-| `make test_sandbox_unit` | Run the run action's Node.js unit tests |
-| `make test_sandbox_integration` | Run the run action's integration tests (needs `BUILDCAGE_LOCAL_IMAGE_REF` and a test-hook build of `run/dist/main.cjs`) |
-| `make clean` | Remove all resources |
+| `make setup_buildkit_transparent_audit` | Start transparent engine in audit mode |
+| `make setup_buildkit_transparent_restrict` | Start transparent engine in restrict mode (default domains) |
+| `make setup_buildkit_explicit_audit` | Start explicit proxy engine in audit mode |
+| `make setup_buildkit_explicit_restrict` | Start explicit proxy engine in restrict mode |
+| `make report_buildkit` | Show the buildcage report for the currently running builder |
+| `make test_integration_buildkit` | Run all `test_integration_buildkit_*` tests |
+| `make test_integration_buildkit_transparent_audit` | Run transparent-engine audit mode tests (start → build → verify → clean up) |
+| `make test_integration_buildkit_transparent_restrict` | Run transparent-engine restrict mode tests (start → build → verify → clean up) |
+| `make test_integration_buildkit_explicit_audit` | Run explicit-engine audit mode tests (start → build → verify → clean up) |
+| `make test_integration_buildkit_explicit_restrict` | Run explicit-engine restrict mode tests (start → build → verify → clean up) |
+| `make setup_sandbox_dev` | Start the run action's proxy + mac-friendly dev-loop runner |
+| `make test_sandbox_dev` | Run a sample isolated command in the dev loop and verify isolation |
+| `make test_unit` | Run unit tests (includes `test_unit_sandbox`) |
+| `make test_unit_sandbox` | Run the run action's Node.js unit tests |
+| `make test_integration_sandbox_linux` | Run the run action's integration tests (needs `BUILDCAGE_LOCAL_IMAGE_REF` and a test-hook build of `run/dist/main.cjs`) |
+| `make clean_integration_buildkit` | Stop and remove the buildkit builder's containers/images and buildx builder |
 
 ## Directory Structure
 
@@ -374,8 +382,8 @@ If you encounter issues, try reproducing the problem locally to get detailed log
 
 2. **Run in audit mode** to understand your build's network behavior:
    ```bash
-   make clean
-   make run_transparent_audit_mode
+   make clean_integration_buildkit
+   make setup_buildkit_transparent_audit
    docker buildx build --builder buildcage --no-cache -f Dockerfile .
    docker compose logs builder
    ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,11 +45,11 @@ docker buildx build --builder buildcage --progress=plain -f Dockerfile .
 make report_buildkit
 
 # 4. Clean up
-make clean_integration_buildkit
+make clean_buildkit
 ```
 
 `make report_buildkit` runs `node report/src/main.ts` with the same `COMPOSE_PROJECT_NAME`/`BUILDCAGE_BUILD_TEST_HOOKS`
-override the `setup_buildkit_*`/`clean_integration_buildkit` targets use (see the pattern rule near the top of the
+override the `setup_buildkit_*`/`clean_buildkit` targets use (see the pattern rule near the top of the
 Makefile) — running `node report/src/main.ts` directly, without going through `make`, won't find the running
 builder container. Raw builder logs are also available via `docker compose logs builder`.
 
@@ -307,7 +307,7 @@ reports for the allowed side.
 | `make test_unit` | Run unit tests (includes `test_unit_sandbox`) |
 | `make test_unit_sandbox` | Run the run action's Node.js unit tests |
 | `make test_integration_sandbox_linux` | Run the run action's integration tests (needs `BUILDCAGE_LOCAL_IMAGE_REF` and a test-hook build of `run/dist/main.cjs`) |
-| `make clean_integration_buildkit` | Stop and remove the buildkit builder's containers/images and buildx builder |
+| `make clean_buildkit` | Stop and remove the buildkit builder's containers/images and buildx builder |
 
 ## Directory Structure
 
@@ -382,7 +382,7 @@ If you encounter issues, try reproducing the problem locally to get detailed log
 
 2. **Run in audit mode** to understand your build's network behavior:
    ```bash
-   make clean_integration_buildkit
+   make clean_buildkit
    make setup_buildkit_transparent_audit
    docker buildx build --builder buildcage --no-cache -f Dockerfile .
    docker compose logs builder

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -23,7 +23,11 @@ const configs = [
     // sigstore uses dynamic imports; inline them so dist is a single file.
     codeSplitting: false,
   },
-  { input: "setup/src/post.ts", file: "setup/dist/post.cjs" },
+  {
+    input: "setup/src/post.ts",
+    file: "setup/dist/post.cjs",
+    plugins: mainPlugins,
+  },
   {
     input: "report/src/main.ts",
     file: "report/dist/main.cjs",

--- a/run/compose.sandbox-dev.yaml
+++ b/run/compose.sandbox-dev.yaml
@@ -1,7 +1,7 @@
 # Mac-friendly dev-loop overlay for the run action (see run/dev/Dockerfile
 # for why this exists and how it differs from production / CI's test_sandbox).
 #
-# Usage: make run_sandbox_mode / make test_sandbox_mode
+# Usage: make setup_sandbox_dev / make test_sandbox_dev
 services:
   sandbox-dev-runner:
     container_name: buildcage-sandbox-dev-runner

--- a/run/dev/build-test-bundle.sh
+++ b/run/dev/build-test-bundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # build-test-bundle.sh — dev-only stand-in for isolated-exec.ts's
-# buildOciConfig, used by `make test_sandbox_mode` to build just enough of
+# buildOciConfig, used by `make test_sandbox_dev` to build just enough of
 # an OCI bundle to exercise run-isolated.sh directly (see
 # ../compose.sandbox-dev.yaml and ../dev/Dockerfile for why this dev loop
 # doesn't run the real run/dist/main.cjs, and so needs a minimal

--- a/run/dev/smoke-test.sh
+++ b/run/dev/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Sample isolated command for `make test_sandbox_mode` — exercises the same
+# Sample isolated command for `make test_sandbox_dev` — exercises the same
 # checks the CI test_sandbox job performs, run from the mac dev loop instead.
 set -e
 

--- a/setup/dist/post.cjs
+++ b/setup/dist/post.cjs
@@ -1,3 +1,4 @@
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
 let node_child_process = require("node:child_process"), node_path = require("node:path"), node_url = require("node:url"), node_crypto = require("node:crypto");
 //#region core/lib/docker/container.ts
 /**
@@ -15,19 +16,26 @@ function deriveProjectName(containerName) {
 }
 //#endregion
 //#region setup/src/post.ts
-const __dirname$1 = (0, node_path.dirname)((0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href)), builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
-(0, node_child_process.execFileSync)("docker", [
-	"compose",
-	"-p",
-	deriveProjectName(builderName),
-	"-f",
-	(0, node_path.join)(__dirname$1, "../compose.yaml"),
-	"down"
-], {
-	stdio: "inherit",
-	env: {
-		...process.env,
-		BUILDER_NAME: builderName
-	}
-});
+const __dirname$1 = (0, node_path.dirname)((0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href));
+function resolveProjectName(builderName, env) {
+	return deriveProjectName(builderName);
+}
+function main() {
+	let builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
+	(0, node_child_process.execFileSync)("docker", [
+		"compose",
+		"-p",
+		resolveProjectName(builderName, process.env),
+		"-f",
+		(0, node_path.join)(__dirname$1, "../compose.yaml"),
+		"down"
+	], {
+		stdio: "inherit",
+		env: {
+			...process.env,
+			BUILDER_NAME: builderName
+		}
+	});
+}
 //#endregion
+process.argv[1] === (0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href) && main(), exports.resolveProjectName = resolveProjectName;

--- a/setup/src/post.test.ts
+++ b/setup/src/post.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { deriveProjectName } from "../../core/lib/docker/container.ts";
+import { resolveProjectName } from "./post.ts";
+
+// The override gate is fixed at module load, so both cases below exercise
+// the "disabled" path — matching a normal build/test run.
+describe("resolveProjectName", () => {
+  it("falls back to deriveProjectName(builderName) when COMPOSE_PROJECT_NAME is unset", () => {
+    assert.equal(
+      resolveProjectName("buildcage-transparent-audit", {}),
+      deriveProjectName("buildcage-transparent-audit"),
+    );
+  });
+
+  it("ignores COMPOSE_PROJECT_NAME when the test-hooks gate isn't on for this build", () => {
+    assert.equal(
+      resolveProjectName("buildcage-transparent-audit", { COMPOSE_PROJECT_NAME: "buildcage-project" }),
+      deriveProjectName("buildcage-transparent-audit"),
+    );
+  });
+});

--- a/setup/src/post.ts
+++ b/setup/src/post.ts
@@ -5,19 +5,36 @@ import { deriveProjectName } from "../../core/lib/docker/container.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// builder_name is a real input, so post.ts can recompute the same project
-// name main.ts used directly, without round-tripping it through GITHUB_STATE.
-const builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
-const projectName = deriveProjectName(builderName);
+// CI-only override gate, mirrors report/src/main.ts's resolveProjectName.
+const PROJECT_NAME_OVERRIDE_ENABLED = process.env.BUILDCAGE_BUILD_TEST_HOOKS === "1";
 
-execFileSync(
-  "docker",
-  ["compose", "-p", projectName, "-f", join(__dirname, "../compose.yaml"), "down"],
-  {
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      BUILDER_NAME: builderName,
-    },
+// Same derivation report uses for its own lookup.
+export function resolveProjectName(builderName: string, env: NodeJS.ProcessEnv): string {
+  if (PROJECT_NAME_OVERRIDE_ENABLED && env.COMPOSE_PROJECT_NAME) {
+    return env.COMPOSE_PROJECT_NAME;
   }
-);
+  return deriveProjectName(builderName);
+}
+
+function main(): void {
+  // builder_name is a real input, so post.ts can recompute the same project
+  // name main.ts used directly, without round-tripping it through GITHUB_STATE.
+  const builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
+  const projectName = resolveProjectName(builderName, process.env);
+
+  execFileSync(
+    "docker",
+    ["compose", "-p", projectName, "-f", join(__dirname, "../compose.yaml"), "down"],
+    {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        BUILDER_NAME: builderName,
+      },
+    }
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
## Summary

`Makefile` derived `COMPOSE_PROJECT_NAME` by shelling out to `node -e` on every invocation, and its local-dev targets had grown a flat, inconsistent naming scheme (`run_transparent_audit_mode`, `test_explicit_restrict_mode`, `run_audit_example`, `test_sandbox_mode`, ...) that didn't distinguish unit tests from integration tests or make target families obvious. This extends `report/src/main.ts`'s existing `BUILDCAGE_BUILD_TEST_HOOKS`-gated `COMPOSE_PROJECT_NAME` override to `setup/src/post.ts`, pins the Makefile to that same fixed project name via GNU Make pattern-specific variables instead of a per-invocation `node -e` lookup, and renames/reorganizes every target into a consistent `{verb}_{category}_...` scheme grouped by Unit Tests / Integration Tests.

## Changes

- Extend the `BUILDCAGE_BUILD_TEST_HOOKS`-gated `COMPOSE_PROJECT_NAME` override (previously `report/src/main.ts`-only) to `setup/src/post.ts`, and build-time-eliminate it from `setup/dist/post.cjs` the same way `setup/dist/main.cjs`/`report/dist/main.cjs` already are.
- Drop the `node -e` `deriveProjectName` shell-out in `Makefile`; pin `COMPOSE_PROJECT_NAME` to a fixed value via pattern-specific variables (`setup_buildkit_%`, `test_integration_buildkit_%`, `example_%`, plus `clean_buildkit`/`report_buildkit`) instead of an `ifeq`/`MAKECMDGOALS` goal list.
- Reorganize the `Makefile` into clearly separated Unit Tests / Integration Tests sections, with the sandbox dev-loop family grouped together.
- Rename targets to a consistent scheme:
  - `test_core`/`test_setup`/`test_report`/`test_sandbox_unit`/`test_qjs` → `test_unit_core`/`test_unit_setup`/`test_unit_report`/`test_unit_sandbox`/`test_unit_qjs`
  - `run_{engine}_{mode}_mode` → `setup_buildkit_{engine}_{mode}`
  - `test_{engine}_{mode}_mode` → `test_integration_buildkit_{engine}_{mode}`
  - `clean` → `clean_buildkit`
  - `run_audit_example`/`run_restrict_example` → `example_transparent_audit`/`example_transparent_restrict`
  - `run_sandbox_mode`/`test_sandbox_mode`/`clean_sandbox_mode` → `setup_sandbox_dev`/`test_sandbox_dev`/`clean_sandbox_dev`
  - `test_sandbox_integration` → `test_integration_sandbox_linux`
- Add `test_integration_buildkit` (runs all four buildkit integration targets) and `report_buildkit` (prints the report for the currently running builder — `node report/src/main.ts` alone can't find the container without the same env override).
- Update `docs/development.md` and the target-name references in `run/compose.sandbox-dev.yaml`, `run/dev/build-test-bundle.sh`, `run/dev/smoke-test.sh`, and `.github/workflows/test-integration.yml` to match.
- Remove `run-tests.qjs.ts`'s now-dead `.property.test.js` filter — `rolldown.scripts.config.js` already excludes `*.property.test.ts` from the qjs-test build, so no `.property.test.js` file ever reaches that directory.

