### PR TITLE
feat: note '(no communication)' in the report when a build has no outbound traffic

### DIFF
--- a/core/lib/report/render-report-markdown.test.ts
+++ b/core/lib/report/render-report-markdown.test.ts
@@ -64,6 +64,19 @@ describe("renderReportMarkdown — transparent", () => {
     const md = renderReportMarkdown(base, "dash14/buildcage", "v2");
     assertNotMatch(md, /### ✅ Allowed Hosts/);
   });
+
+  it("shows a '(no communication)' note when nothing passed and nothing blocked", () => {
+    const md = renderReportMarkdown(base, "dash14/buildcage", "v2");
+    assert.match(md, /_\(no communication\)_/);
+  });
+
+  it("omits the '(no communication)' note once anything passed or was blocked", () => {
+    const passedMd = renderReportMarkdown({ ...base, passed: [allowedRow] }, "dash14/buildcage", "v2");
+    assertNotMatch(passedMd, /_\(no communication\)_/);
+
+    const blockedMd = renderReportMarkdown({ ...base, blocked: [blockedRow], blockedCount: 1 }, "dash14/buildcage", "v2");
+    assertNotMatch(blockedMd, /_\(no communication\)_/);
+  });
 });
 
 describe("renderReportMarkdown — explicit", () => {

--- a/core/lib/report/render-report-markdown.ts
+++ b/core/lib/report/render-report-markdown.ts
@@ -23,6 +23,11 @@ export function renderReportMarkdown(report: ReportData, actionRepo: string, act
     if (report.passed.length > 0) markdown += "\n";
     markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(report.blocked, { showReason: true, showExpected }) + "\n";
   }
+  if (report.passed.length === 0 && report.blocked.length === 0) {
+    // Otherwise a no-traffic build leaves nothing between the heading and the
+    // footer — indistinguishable from a report that failed to generate.
+    markdown += "_(no communication)_\n\n";
+  }
 
   if (report.engine === "explicit") {
     markdown += renderCommunicationDetails(report.proxyLogs.builds, report.proxyLogs.denied);


### PR DESCRIPTION
## Summary

When a build made no outbound requests at all, both engines' report rendered nothing between the heading and the footer — no Allowed/Blocked Hosts table, no Communication details section, nothing. A quiet build was indistinguishable from a report that had failed to generate.

This adds a `_(no communication)_` note whenever nothing passed and nothing was blocked, reusing the wording already used per-step in the explicit engine's Communication details section.
