### PR TITLE
fix: harden IPv6 egress blocking and its documentation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -91,7 +91,7 @@ An attacker may attempt to tunnel data using non-TCP protocols such as ICMP echo
 
 An attacker may attempt to use IPv6 to circumvent IPv4-based iptables rules.
 
-**Why this is prevented:** Equivalent ip6tables rules drop all forwarded IPv6 traffic from the isolated network. Additionally, the internal DNS server returns the IPv6 unspecified address (::) for all queries, effectively disabling IPv6 name resolution within build containers.
+**Why this is prevented:** Equivalent ip6tables rules drop all forwarded IPv6 traffic from the isolated network. Additionally, the internal DNS server returns the IPv6 unspecified address (::) for all queries, effectively disabling IPv6 name resolution within build containers, and the proxy resolves allowed domains over IPv4 only — so even an allowed domain is never reached over IPv6. The ip6tables rule is skipped only when the kernel has no IPv6 support at all (no `/proc/net/if_inet6`), in which case no IPv6 traffic can occur regardless; if IPv6 support is present, applying the rule is mandatory and startup fails closed if it can't be applied, rather than silently leaving IPv6 unfiltered.
 
 #### Alternative DNS Transports (DoH / DoT)
 
@@ -231,8 +231,10 @@ an OCI `config.json` and enforced by runc natively.
 - **Network namespace**: the isolated command runs in its own network namespace, connected to the
   proxy container's netns by a dedicated veth pair (no bridge — it's always a 1:1 connection, one
   sandbox to one proxy) — the same enforcement `transparent` mode applies to Docker `RUN` steps
-  (iptables `REDIRECT`/`DROP`, DNS redirect, SNI/Host allowlist). runc joins this namespace itself,
-  driven by the OCI spec's `linux.namespaces` path — no wrapper needed.
+  (iptables `REDIRECT`/`DROP`, DNS redirect, SNI/Host allowlist), including the
+  [IPv6 Bypass](#ipv6-bypass) protections above — `ip6tables` `FORWARD` drop and DNS returning `::`
+  for all queries. runc joins this namespace itself, driven by the OCI spec's `linux.namespaces`
+  path — no wrapper needed.
 - **Seccomp filter**: derived from Docker's own default seccomp profile (allowlist-based;
   `moby/profiles`), resolved against an empty capability set to match the capability drop below —
   so any syscall Docker's default profile only conditionally allows for a *held* capability is

--- a/run/docker/files/dnsmasq.conf
+++ b/run/docker/files/dnsmasq.conf
@@ -9,7 +9,7 @@ no-resolv
 # Do not use upstream DNS servers
 no-poll
 
-# Redirect all domains to buildkit0 gateway (this container)
+# Redirect all domains to the proxy gateway (this container)
 address=/#/172.20.0.1
 
 # Disable IPv6

--- a/run/docker/files/s6-scripts/init-iptables
+++ b/run/docker/files/s6-scripts/init-iptables
@@ -7,5 +7,14 @@ iptables -t nat -A PREROUTING -i sandbox0 -p tcp \
   -j REDIRECT --to-ports 10024
 
 iptables -A FORWARD -i sandbox0 -j DROP
-ip6tables -A FORWARD -i sandbox0 -j DROP
-echo "init-iptables: REDIRECT configured, FORWARD from sandbox0 blocked (IPv4/IPv6)"
+
+# /proc/net/if_inet6 only exists when the kernel has IPv6 support compiled in
+# and active. If it's absent, no IPv6 traffic can occur at all, so skipping
+# ip6tables is safe. If it's present, ip6tables must succeed -- set -e keeps
+# this fail-closed rather than silently leaving IPv6 unfiltered.
+if [ -e /proc/net/if_inet6 ]; then
+  ip6tables -A FORWARD -i sandbox0 -j DROP
+  echo "init-iptables: REDIRECT configured, FORWARD from sandbox0 blocked (IPv4/IPv6)"
+else
+  echo "init-iptables: REDIRECT configured, FORWARD from sandbox0 blocked (IPv4); kernel has no IPv6 support, skipping ip6tables"
+fi

--- a/setup/docker/transparent/files/s6-scripts/init-iptables
+++ b/setup/docker/transparent/files/s6-scripts/init-iptables
@@ -7,5 +7,10 @@ iptables -t nat -A PREROUTING -i buildkit0 -p tcp \
   -j REDIRECT --to-ports 10024
 
 iptables -A FORWARD -i buildkit0 -j DROP
-ip6tables -A FORWARD -i buildkit0 -j DROP
-echo "init-iptables: REDIRECT configured, FORWARD from buildkit0 blocked (IPv4/IPv6)"
+
+if [ -e /proc/net/if_inet6 ]; then
+  ip6tables -A FORWARD -i buildkit0 -j DROP
+  echo "init-iptables: REDIRECT configured, FORWARD from buildkit0 blocked (IPv4/IPv6)"
+else
+  echo "init-iptables: REDIRECT configured, FORWARD from buildkit0 blocked (IPv4); kernel has no IPv6 support, skipping ip6tables"
+fi


### PR DESCRIPTION
## Summary

Neither engine's `init-iptables` had a fallback for kernels without IPv6 support: `ip6tables` ran unconditionally under `set -e`, so a kernel lacking `ip6_tables` would fail container startup outright instead of degrading gracefully — even though IPv6 traffic can't exist there in the first place. This checks `/proc/net/if_inet6` first and only skips `ip6tables` when the kernel truly has no IPv6 support; if IPv6 support is present, applying the rule stays mandatory and startup still fails closed.

While auditing this, `run/docker/files/dnsmasq.conf` turned out to have a stray comment left over from copying `setup/docker/transparent`'s config — it referenced the `buildkit0` bridge, which doesn't exist in the `run` action's `sandbox0` topology.

`docs/security.md`'s IPv6 Bypass section is updated to describe this fallback and the IPv4-only resolution behavior it depends on.
