### PR TITLE
chore(deps): update Node.js from 24 to 26

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: '24'
+        node-version: '26'
         cache: pnpm
 
     - name: Install dependencies

--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir -p /tmp/build-context
           cat <<'EOF' > /tmp/build-context/Dockerfile
-          FROM node:24-alpine
+          FROM node:26-alpine
           WORKDIR /app
           RUN npm init -y && npm install --ignore-scripts express
           EOF

--- a/.github/workflows/example-explicit.yml
+++ b/.github/workflows/example-explicit.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir -p /tmp/build-context
           cat <<'EOF' > /tmp/build-context/Dockerfile
-          FROM node:24-alpine
+          FROM node:26-alpine
           WORKDIR /app
           RUN npm init -y
           # npm bundles its own CA store, so it needs NODE_USE_SYSTEM_CA=1 to trust

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           mkdir -p /tmp/build-context
           cat <<'EOF' > /tmp/build-context/Dockerfile
-          FROM node:24-alpine
+          FROM node:26-alpine
           WORKDIR /app
           RUN npm init -y && npm install --ignore-scripts express
           RUN wget -q -O /dev/null --timeout=5 https://example.com/ || true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           mkdir -p /tmp/build-context
           cat <<'EOF' > /tmp/build-context/Dockerfile
-          FROM node:24-alpine
+          FROM node:26-alpine
           WORKDIR /app
           # NODE_USE_SYSTEM_CA=1: required for the explicit engine (always
           # MITMs TLS); harmless for transparent.

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ example_transparent_audit: ## Run audit mode example tests
 	@$(MAKE) setup_buildkit_transparent_audit
 	@mkdir -p /tmp/build-context
 	@printf '%s\n' \
-	  "FROM node:24-alpine" \
+	  "FROM node:26-alpine" \
 	  "WORKDIR /app" \
 	  "RUN npm init -y && npm install --ignore-scripts express" \
 	  > /tmp/build-context/Dockerfile
@@ -274,7 +274,7 @@ example_transparent_restrict: ## Run restrict mode example tests
 	  $(MAKE) setup_buildkit_transparent_restrict
 	@mkdir -p /tmp/build-context
 	@printf '%s\n' \
-	  "FROM node:24-alpine" \
+	  "FROM node:26-alpine" \
 	  "WORKDIR /app" \
 	  "RUN npm init -y && npm install --ignore-scripts express" \
 	  "RUN wget -q -O /dev/null --timeout=5 https://example.com/ || true" \

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "buildcage",
   "private": true,
   "engines": {
-    "node": ">=24",
+    "node": ">=26",
     "pnpm": ">=11"
   },
   "packageManager": "pnpm@11.11.0",
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "24.16.0",
+      "version": "26.5.0",
       "onFail": "download"
     },
     "packageManager": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,8 +224,8 @@ importers:
         specifier: ^4.8.0
         version: 4.9.0
       node:
-        specifier: runtime:24.16.0
-        version: runtime:24.16.0
+        specifier: runtime:26.5.0
+        version: runtime:26.5.0
       rolldown:
         specifier: ^1.1.5
         version: 1.1.5
@@ -537,7 +537,7 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  node@runtime:24.16.0:
+  node@runtime:26.5.0:
     resolution:
       type: variations
       variants:
@@ -545,9 +545,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-MN/Y5EMiwnEoE/JeFjwlPK1TvkPgmJB7i1NIvxdKSWg=
+            integrity: sha256-JFZ51EYpEte5pfFnqBBXligSgXt8+LKcIux5MnGS7eA=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -555,9 +555,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-ORidq07rFXBsQkrwrAijBEyeSPfbEqfXf2t6r8fdXfY=
+            integrity: sha256-7pIFWaqiORVpz/TXN+O4OWNDDjoU3t2Rv+D/UxcbWvk=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -565,9 +565,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-KYtMezy4B2XIcD5CuQMkpOzjtmNJR7iedpw8mAq1UYU=
+            integrity: sha256-mCkzlMlFok5k4AtBd78HXslj6nCzTR0uJL1KcXFtM08=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -575,9 +575,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-WJ9bbdT8/uTf2nMBOQPJZquqir2T28nUNlRORytPDnQ=
+            integrity: sha256-MI5f6JqCRhulps8V/1Ihss29euh2AKpyuzw/vcZkEtE=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -585,9 +585,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-JStYIFNNwDBKKFQcmkRDfPpyAufyAiXSjUk5MsWOl6o=
+            integrity: sha256-ftjaaaLvAIhT4o+v4Tz+2drA/gHg74OxqOxbm4VX7Sg=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -595,9 +595,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-Vnrwl1s0BVFrmx3cZEKaI+yMWi+mzwE5EmGkzHdOPt0=
+            integrity: sha256-1nOVmxOQ4dCGX9euj7mBsWaX22NFoQsU4TDDAs9MvCg=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -605,9 +605,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-L69qOH6bYriI4hxU8BJJ+ydTf/7PGELyn0yRnQpZoP8=
+            integrity: sha256-IrX0etaueIN+TCuEYBmWXOGga6FD3hdhAilKG/RPxnc=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -615,10 +615,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-FINGEdTGs8BgVOcAdzK5BHTBbgsy85XgW1Wlce9xxtI=
-            prefix: node-v24.16.0-win-arm64
+            integrity: sha256-wM+lh3tt50MwHmIvWrxNJvsP+HmK3/yP/9KIX0JgCLo=
+            prefix: node-v26.5.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -626,10 +626,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-7aypvVjsjpIDfaxOh31S9rj0MLgcGLV+JktOL7ERzVY=
-            prefix: node-v24.16.0-win-x64
+            integrity: sha256-07InfbzM/fJO9jApKPZPSEz/HXem08qjoo9NIM6RWPY=
+            prefix: node-v26.5.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-x64.zip
+            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-win-x64.zip
           targets:
             - cpu: x64
               os: win32
@@ -637,9 +637,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-hd3ieqc1A7A9rfoEEKgABntOP3Avt/yqO+ryhN/Maek=
+            integrity: sha256-GrMa72VhGRaT82bKzXW7zvoDAeSaGLwFVUwhiTu9tJA=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-arm64-musl.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -648,14 +648,14 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-UN9djUdIktT3uQYWffNvd/W5OQj2PcUy3FaCGcq2WEE=
+            integrity: sha256-APE5hBGkIWxabsqtO4JaDaXsAOee6MFzq2WglNl7mtg=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
               libc: musl
-    version: 24.16.0
+    version: 26.5.0
     hasBin: true
 
   pure-rand@8.4.2:
@@ -878,7 +878,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  node@runtime:24.16.0: {}
+  node@runtime:26.5.0: {}
 
   pure-rand@8.4.2: {}
 

--- a/setup/test/Dockerfile.explicit-audit
+++ b/setup/test/Dockerfile.explicit-audit
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+FROM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66
 
 # DNS check — buildkit-proxy writes /etc/resolv.conf from EXTERNAL_RESOLVER at
 # container startup (no dnsmasq in this image).

--- a/setup/test/Dockerfile.explicit-restrict
+++ b/setup/test/Dockerfile.explicit-restrict
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+FROM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66
 
 # The FROM pull above already exercises the "base image pulls are unaffected
 # by the explicit-mode source policy" guarantee: registry-1.docker.io is never

--- a/setup/test/Dockerfile.transparent-audit
+++ b/setup/test/Dockerfile.transparent-audit
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+FROM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \

--- a/setup/test/Dockerfile.transparent-restrict
+++ b/setup/test/Dockerfile.transparent-restrict
@@ -1,4 +1,4 @@
-FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+FROM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66
 
 # DNS check
 RUN echo "=== DNS Configuration ===" && \


### PR DESCRIPTION
## Summary

The project pinned Node.js 24 throughout — `package.json`'s `engines`/`devEngines`, the `setup-pnpm` composite action's `actions/setup-node` step, and the `node:24-alpine` base image used by the CI smoke-test workflows, `Makefile` example targets, and `setup/test/` Dockerfile fixtures. This bumps all of them to Node.js 26.

## Changes

- Update `package.json`'s `engines.node`/`devEngines.runtime` and `pnpm-lock.yaml` to Node.js 26.5.0
- Bump the `setup-pnpm` action's `actions/setup-node` `node-version` to `26`
- Bump `node:24-alpine` → `node:26-alpine` in the `example-*`/`test-e2e` workflows, `Makefile`'s `example_transparent_*` targets, and the `setup/test/Dockerfile.*` fixtures (pinned to the current `node:26-alpine` digest)