### PR TITLE
refactor: stream proxy log reads and aggregate them incrementally

### DIFF
--- a/core/lib/docker/client.test.ts
+++ b/core/lib/docker/client.test.ts
@@ -1,5 +1,7 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { createDocker, parseContainerIds } from "./client.ts";
+import { createDocker, parseContainerIds, type SpawnCommand } from "./client.ts";
 
 describe("parseContainerIds", () => {
   it("splits one ID per line", () => {
@@ -43,13 +45,6 @@ describe("createDocker", () => {
     assert.deepEqual(calls, [["cp", "abc123:/opt/buildcage/scripts/report-action.js", "/tmp/report-action.js"]]);
   });
 
-  it("readFile runs docker exec cat and returns its stdout", () => {
-    const { run, calls } = fakeRun(["log contents\n"]);
-    const text = createDocker(run).readFile("abc123", "/var/log/haproxy/current");
-    assert.equal(text, "log contents\n");
-    assert.deepEqual(calls, [["exec", "abc123", "cat", "/var/log/haproxy/current"]]);
-  });
-
   it("readEnv runs docker inspect and parses the Env JSON array", () => {
     const { run, calls } = fakeRun(['["PROXY_MODE=restrict","FOO=bar"]']);
     const env = createDocker(run).readEnv("abc123");
@@ -62,6 +57,111 @@ describe("createDocker", () => {
     const out = createDocker(run).exec("abc123", ["buildctl", "debug", "histories", "--format", "{{json .}}"]);
     assert.equal(out, "histories output");
     assert.deepEqual(calls, [["exec", "abc123", "buildctl", "debug", "histories", "--format", "{{json .}}"]]);
+  });
+});
+
+/** Minimal stand-in for node:child_process's ChildProcess, just enough
+ *  surface for streamDockerLines: stdout/stderr streams, 'error'/'close'
+ *  events, exitCode/signalCode, and a kill() the test can observe. */
+class FakeChild extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  kill() {
+    this.killed = true;
+    this.signalCode = "SIGTERM";
+    this.stdout.end();
+    this.emit("close", null, "SIGTERM");
+  }
+  finish(code: number) {
+    this.exitCode = code;
+    this.stdout.end();
+    this.stderr.end();
+    this.emit("close", code, null);
+  }
+  failToSpawn(err: NodeJS.ErrnoException) {
+    this.emit("error", err);
+    this.stdout.end();
+    this.stderr.end();
+    this.emit("close", null, null);
+  }
+}
+
+// Same shape as fakeRun, but for the spawn-based second constructor param.
+function fakeSpawn(): { spawnDocker: SpawnCommand; calls: string[][]; children: FakeChild[] } {
+  const calls: string[][] = [];
+  const children: FakeChild[] = [];
+  return {
+    calls,
+    children,
+    spawnDocker(args: string[]) {
+      calls.push(args);
+      const child = new FakeChild();
+      children.push(child);
+      return child as unknown as ReturnType<SpawnCommand>;
+    },
+  };
+}
+
+async function drain(iterable: AsyncIterable<string>): Promise<string[]> {
+  const lines: string[] = [];
+  for await (const line of iterable) lines.push(line);
+  return lines;
+}
+
+describe("createDocker readFileLines", () => {
+  it("is lazy — nothing spawns until iteration actually starts", () => {
+    const { spawnDocker, calls } = fakeSpawn();
+    createDocker(undefined, spawnDocker).readFileLines("abc123", "/var/log/haproxy/current");
+    assert.deepEqual(calls, []);
+  });
+
+  it("streams docker exec cat's stdout as lines, in argv order", async () => {
+    const { spawnDocker, calls, children } = fakeSpawn();
+    const iterablePromise = drain(createDocker(undefined, spawnDocker).readFileLines("abc123", "/var/log/haproxy/current"));
+    // drain()'s first pull has already triggered the spawn synchronously.
+    assert.deepEqual(calls, [["exec", "abc123", "cat", "/var/log/haproxy/current"]]);
+    children[0].stdout.write("line one\nline two\n");
+    children[0].finish(0);
+    assert.deepEqual(await iterablePromise, ["line one", "line two"]);
+  });
+
+  it("throws {status, stderr} on a non-zero exit", async () => {
+    const { spawnDocker, children } = fakeSpawn();
+    const drained = drain(createDocker(undefined, spawnDocker).readFileLines("abc123", "/missing"));
+    // Ensure the child has been created before driving it.
+    await Promise.resolve();
+    children[0].stderr.write("cat: /missing: No such file or directory\n");
+    children[0].finish(1);
+    await assert.rejects(
+      drained,
+      (e) =>
+        (e as { status?: number; stderr?: string }).status === 1 &&
+        Boolean((e as { stderr?: string }).stderr?.includes("No such file or directory")),
+    );
+  });
+
+  it("surfaces a spawn-level ENOENT as-is", async () => {
+    const { spawnDocker, children } = fakeSpawn();
+    const drained = drain(createDocker(undefined, spawnDocker).readFileLines("abc123", "/path"));
+    await Promise.resolve();
+    children[0].failToSpawn(Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" }));
+    await assert.rejects(drained, (e) => (e as NodeJS.ErrnoException).code === "ENOENT");
+  });
+
+  it("kills the child if the consumer stops iterating early", async () => {
+    const { spawnDocker, children } = fakeSpawn();
+    const iterable = createDocker(undefined, spawnDocker).readFileLines("abc123", "/var/log/haproxy/current");
+    const iterator = iterable[Symbol.asyncIterator]();
+    // .next() runs synchronously through spawnDocker(args), so the child
+    // already exists once this returns.
+    const firstLine = iterator.next();
+    children[0].stdout.write("line one\nline two\n"); // never finish()'d — simulates a still-running process
+    assert.equal((await firstLine).value, "line one");
+    await iterator.return?.(undefined); // what `for await...of` does on an early break
+    assert.ok(children[0].killed);
   });
 });
 

--- a/core/lib/docker/client.ts
+++ b/core/lib/docker/client.ts
@@ -1,4 +1,6 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
 import { buildDockerCpArgs } from "./container.ts";
 import { parseDockerInspectEnv } from "./container-env.ts";
 
@@ -9,6 +11,7 @@ export function parseContainerIds(psOutput: string): string[] {
 }
 
 export type RunCommand = (args: string[]) => string;
+export type SpawnCommand = (args: string[]) => ChildProcess;
 
 // 64MB, up from Node's 1MB default — `buildctl debug logs --progress=rawjson`
 // output for a verbose build can exceed the default easily.
@@ -20,13 +23,85 @@ function defaultRunCommand(args: string[]): string {
   });
 }
 
+function defaultSpawnCommand(args: string[]): ChildProcess {
+  return spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/**
+ * Drives a `docker <args>` child process and yields its stdout line by
+ * line, never buffering more than the current line. Lazy — nothing spawns
+ * until the caller starts iterating.
+ *
+ * Throws `{status, stderr}` on a non-zero exit and Node's own
+ * `{code: "ENOENT", ...}` on a spawn failure, matching the shape
+ * describeDockerFailure() (core/lib/actions/docker-error.ts) expects from
+ * execFileSync elsewhere in this module.
+ */
+async function* streamDockerLines(
+  spawnDocker: SpawnCommand,
+  args: string[],
+  operation: string,
+): AsyncGenerator<string, void, void> {
+  const child = spawnDocker(args);
+
+  // Must be attached before any `await` — an EventEmitter with no 'error'
+  // listener throws synchronously the instant one fires.
+  let spawnError: NodeJS.ErrnoException | undefined;
+  child.on("error", (err) => {
+    spawnError = err as NodeJS.ErrnoException;
+  });
+
+  // Registered up front too, so a 'close' firing while suspended at `yield`
+  // can't be missed.
+  const closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }> = once(child, "close").then(
+    ([code, signal]) => ({ code, signal }),
+    () => ({ code: null, signal: null }),
+  );
+
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  const rl = createInterface({ input: child.stdout!, crlfDelay: Infinity });
+
+  // True only if stdout was drained to EOF on its own, not if the consumer
+  // broke out early — that distinction decides whether reaching the end is
+  // a failure or a deliberate stop.
+  let exhausted = false;
+  try {
+    for await (const line of rl) {
+      yield line;
+    }
+    exhausted = true;
+  } finally {
+    rl.close();
+    if (!exhausted && child.exitCode === null && child.signalCode === null) {
+      child.kill();
+    }
+  }
+
+  if (!exhausted) return;
+
+  const { code, signal } = await closed;
+  if (spawnError) throw spawnError;
+  if (code !== 0) {
+    throw Object.assign(
+      new Error(`${operation} exited with code ${code}${signal ? ` (signal ${signal})` : ""}: ${stderr.trim()}`),
+      { status: code ?? undefined, stderr },
+    );
+  }
+}
+
 export interface Docker {
   /** Container IDs matching every given `docker ps --filter` expression (AND'd together). */
   findContainers(filters: string[]): string[];
   /** `docker cp <containerId>:<containerPath> <hostPath>`. */
   copyFromContainer(containerId: string, containerPath: string, hostPath: string): void;
-  /** `docker exec <containerId> cat <path>` — the file's contents. */
-  readFile(containerId: string, path: string): string;
+  /** `docker exec <containerId> cat <path>`, streamed one line at a time —
+   *  see streamDockerLines() for the error-shape/cleanup contract. */
+  readFileLines(containerId: string, path: string): AsyncIterable<string>;
   /** `docker inspect <containerId>`'s own env, as a lookup map. */
   readEnv(containerId: string): Record<string, string>;
   /** `docker exec <containerId> <...args>` — raw stdout, for anything else
@@ -34,9 +109,12 @@ export interface Docker {
   exec(containerId: string, args: string[]): string;
 }
 
-/** `run` is injectable so tests can assert on argv instead of mocking
- *  node:child_process directly. */
-export function createDocker(run: RunCommand = defaultRunCommand): Docker {
+/** `run`/`spawnDocker` are injectable so tests can assert on argv instead of
+ *  mocking node:child_process directly. */
+export function createDocker(
+  run: RunCommand = defaultRunCommand,
+  spawnDocker: SpawnCommand = defaultSpawnCommand,
+): Docker {
   return {
     findContainers(filters) {
       const args = ["ps"];
@@ -47,8 +125,8 @@ export function createDocker(run: RunCommand = defaultRunCommand): Docker {
     copyFromContainer(containerId, containerPath, hostPath) {
       run(buildDockerCpArgs({ containerName: containerId, containerPath, hostPath }));
     },
-    readFile(containerId, path) {
-      return run(["exec", containerId, "cat", path]);
+    readFileLines(containerId, path) {
+      return streamDockerLines(spawnDocker, ["exec", containerId, "cat", path], `docker exec cat ${path}`);
     },
     readEnv(containerId) {
       return parseDockerInspectEnv(run(["inspect", containerId, "--format", "{{json .Config.Env}}"]));

--- a/core/lib/log/aggregate.ts
+++ b/core/lib/log/aggregate.ts
@@ -9,6 +9,14 @@ export interface AggregatedEntry extends LogEntry {
   count: number;
 }
 
+function compareAggregated(a: AggregatedEntry, b: AggregatedEntry): number {
+  return (
+    b.count - a.count ||
+    (a.host < b.host ? -1 : a.host > b.host ? 1 : 0) ||
+    Number(a.port) - Number(b.port)
+  );
+}
+
 /**
  * Aggregate log entries by (host, port, ruleType, reason) with counts, sorted
  * descending.
@@ -24,10 +32,31 @@ export function aggregate(filtered: LogEntry[]): AggregatedEntry[] {
       const [host, portStr, ruleType, reason] = key.split("\t");
       return { host, port: portStr, ruleType, reason, count: map[key] };
     })
-    .sort(
-      (a, b) =>
-        b.count - a.count ||
-        (a.host < b.host ? -1 : a.host > b.host ? 1 : 0) ||
-        Number(a.port) - Number(b.port),
-    );
+    .sort(compareAggregated);
+}
+
+export interface IncrementalAggregator {
+  add(entry: LogEntry): void;
+  toSortedArray(): AggregatedEntry[];
+}
+
+/** Streaming counterpart to aggregate(): folds one entry at a time into a
+ *  running Map, bounding memory by the number of unique combinations seen
+ *  rather than by input length. */
+export function createIncrementalAggregator(): IncrementalAggregator {
+  const map = new Map<string, AggregatedEntry>();
+  return {
+    add(entry) {
+      const key = `${entry.host}\t${entry.port}\t${entry.ruleType}\t${entry.reason}`;
+      const existing = map.get(key);
+      if (existing) {
+        existing.count++;
+      } else {
+        map.set(key, { ...entry, count: 1 });
+      }
+    },
+    toSortedArray() {
+      return [...map.values()].sort(compareAggregated);
+    },
+  };
 }

--- a/core/lib/log/buildkitd-log-parser.test.ts
+++ b/core/lib/log/buildkitd-log-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { parseEntries, parseDenialTimeline, hasNonDenialContent } from "./buildkitd-log-parser.ts";
+import { scanBuildkitdLog } from "./buildkitd-log-parser.ts";
 
 // Real line captured from a live moby/buildkit v0.31.1 explicit-mode container.
 const REAL_DENY_LINE =
@@ -8,95 +8,110 @@ const REAL_DENY_LINE =
 const REAL_DENY_LINE_WITH_PATH =
   'time="2026-07-05T02:26:21Z" level=debug msg="Evaluated source policy" error="source \\"https://dl-cdn.alpinelinux.org:443/alpine/v3.20/main/aarch64/APKINDEX.tar.gz\\" denied by policy: source denied by policy" mutated=false orig="identifier:\\"https://dl-cdn.alpinelinux.org:443/alpine/v3.20/main/aarch64/APKINDEX.tar.gz\\"" ref="https://dl-cdn.alpinelinux.org:443/alpine/v3.20/main/aarch64/APKINDEX.tar.gz" updated="https://dl-cdn.alpinelinux.org:443/alpine/v3.20/main/aarch64/APKINDEX.tar.gz"';
 
-describe("parseEntries", () => {
-  it("parses a real denial line (no explicit port in URL)", () => {
-    const entries = parseEntries(REAL_DENY_LINE);
-    assert.deepEqual(entries, [
-      { decision: "BLOCKED", ruleType: "HTTPS", host: "blocked.example.com", port: "443", reason: "not-allowed" },
+describe("scanBuildkitdLog — blocked", () => {
+  it("aggregates a real denial line (no explicit port in URL)", async () => {
+    const result = await scanBuildkitdLog(REAL_DENY_LINE.split("\n"));
+    assert.deepEqual(result.blocked, [
+      { ruleType: "HTTPS", host: "blocked.example.com", port: "443", reason: "not-allowed", count: 1 },
     ]);
   });
 
-  it("parses a real denial line with an explicit port and path", () => {
-    const entries = parseEntries(REAL_DENY_LINE_WITH_PATH);
-    assert.deepEqual(entries, [
-      { decision: "BLOCKED", ruleType: "HTTPS", host: "dl-cdn.alpinelinux.org", port: "443", reason: "not-allowed" },
+  it("aggregates a real denial line with an explicit port and path", async () => {
+    const result = await scanBuildkitdLog(REAL_DENY_LINE_WITH_PATH.split("\n"));
+    assert.deepEqual(result.blocked, [
+      { ruleType: "HTTPS", host: "dl-cdn.alpinelinux.org", port: "443", reason: "not-allowed", count: 1 },
     ]);
   });
 
-  it("parses an http:// denial as ruleType HTTP", () => {
+  it("aggregates an http:// denial as ruleType HTTP", async () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="Evaluated source policy" error="source \\"http://blocked.example.com:80/\\" denied by policy: source denied by policy" mutated=false ref="http://blocked.example.com:80/" updated="http://blocked.example.com:80/"';
-    const entries = parseEntries(line);
-    assert.deepEqual(entries, [
-      { decision: "BLOCKED", ruleType: "HTTP", host: "blocked.example.com", port: "80", reason: "not-allowed" },
+    const result = await scanBuildkitdLog(line.split("\n"));
+    assert.deepEqual(result.blocked, [
+      { ruleType: "HTTP", host: "blocked.example.com", port: "80", reason: "not-allowed", count: 1 },
     ]);
   });
 
-  it("ignores unrelated debug lines", () => {
+  it("ignores unrelated debug lines", async () => {
     const line = 'time="2026-07-05T00:00:00Z" level=debug msg="finished setting up network namespace abc"';
-    assert.deepEqual(parseEntries(line), []);
+    const result = await scanBuildkitdLog(line.split("\n"));
+    assert.deepEqual(result.blocked, []);
   });
 
-  it("ignores 'Evaluated source policy' lines that are not denials (e.g. a CONVERT)", () => {
+  it("ignores 'Evaluated source policy' lines that are not denials (e.g. a CONVERT)", async () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="Evaluated source policy" mutated=true updated="https://mirror.example.com/" ref="https://example.com/"';
-    assert.deepEqual(parseEntries(line), []);
+    const result = await scanBuildkitdLog(line.split("\n"));
+    assert.deepEqual(result.blocked, []);
   });
 
-  it("ignores non-http(s) identifiers (defensive — buildcage never denies these)", () => {
+  it("ignores non-http(s) identifiers (defensive — buildcage never denies these)", async () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="Evaluated source policy" error="source \\"docker-image://docker.io/library/alpine:latest\\" denied by policy: source denied by policy" ref="docker-image://docker.io/library/alpine:latest"';
-    assert.deepEqual(parseEntries(line), []);
+    const result = await scanBuildkitdLog(line.split("\n"));
+    assert.deepEqual(result.blocked, []);
   });
 
-  it("parses multiple lines and skips non-matching ones", () => {
+  it("aggregates repeated identical denials into one row with a count", async () => {
+    const logText = [REAL_DENY_LINE, REAL_DENY_LINE].join("\n");
+    const result = await scanBuildkitdLog(logText.split("\n"));
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].count, 2);
+  });
+
+  it("parses multiple lines and skips non-matching ones", async () => {
     const logText = [REAL_DENY_LINE, 'time="x" level=info msg="found worker"', REAL_DENY_LINE_WITH_PATH].join("\n");
-    assert.equal(parseEntries(logText).length, 2);
+    const result = await scanBuildkitdLog(logText.split("\n"));
+    assert.equal(result.blocked.length, 2);
   });
 });
 
-describe("parseDenialTimeline", () => {
-  it("parses a real denial line's url and timestamp, in chronological order", () => {
+describe("scanBuildkitdLog — denied (chronological, unaggregated)", () => {
+  it("parses a real denial line's url and timestamp, in chronological order", async () => {
     const logText = [REAL_DENY_LINE, REAL_DENY_LINE_WITH_PATH].join("\n");
-    assert.deepEqual(parseDenialTimeline(logText), [
+    const result = await scanBuildkitdLog(logText.split("\n"));
+    assert.deepEqual(result.denied, [
       { url: "https://blocked.example.com/", timestamp: "2026-07-05T02:26:34Z" },
       { url: "https://dl-cdn.alpinelinux.org:443/alpine/v3.20/main/aarch64/APKINDEX.tar.gz", timestamp: "2026-07-05T02:26:21Z" },
     ]);
   });
 
-  it("does not aggregate — repeated denials for the same URL each get their own entry", () => {
+  it("does not aggregate — repeated denials for the same URL each get their own entry", async () => {
     const logText = [REAL_DENY_LINE, REAL_DENY_LINE].join("\n");
-    assert.equal(parseDenialTimeline(logText).length, 2);
+    const result = await scanBuildkitdLog(logText.split("\n"));
+    assert.equal(result.denied.length, 2);
   });
 
-  it("ignores non-denial lines", () => {
-    assert.deepEqual(parseDenialTimeline('time="2026-07-05T00:00:00Z" level=info msg="found worker"'), []);
+  it("ignores non-denial lines", async () => {
+    const result = await scanBuildkitdLog('time="2026-07-05T00:00:00Z" level=info msg="found worker"'.split("\n"));
+    assert.deepEqual(result.denied, []);
   });
 });
 
-// ---------------------------------------------------------------------------
-// hasNonDenialContent
-// ---------------------------------------------------------------------------
-describe("hasNonDenialContent", () => {
-  it("returns false for empty log text", () => {
-    assert.equal(hasNonDenialContent(""), false);
+describe("scanBuildkitdLog — hasNonDenialContent", () => {
+  it("returns false for empty log text", async () => {
+    const result = await scanBuildkitdLog("".split("\n"));
+    assert.equal(result.hasNonDenialContent, false);
   });
 
-  it("returns false when the log has only denial lines", () => {
-    assert.equal(hasNonDenialContent(REAL_DENY_LINE), false);
+  it("returns false when the log has only denial lines", async () => {
+    const result = await scanBuildkitdLog(REAL_DENY_LINE.split("\n"));
+    assert.equal(result.hasNonDenialContent, false);
   });
 
-  it("returns true when the log contains buildkitd's own non-denial debug output", () => {
+  it("returns true when the log contains buildkitd's own non-denial debug output", async () => {
     const logText = [REAL_DENY_LINE, 'time="x" level=info msg="found worker"'].join("\n");
-    assert.equal(hasNonDenialContent(logText), true);
+    const result = await scanBuildkitdLog(logText.split("\n"));
+    assert.equal(result.hasNonDenialContent, true);
   });
 
-  it("ignores blank lines when deciding", () => {
-    assert.equal(hasNonDenialContent("\n\n  \n"), false);
+  it("ignores blank lines when deciding", async () => {
+    const result = await scanBuildkitdLog("\n\n  \n".split("\n"));
+    assert.equal(result.hasNonDenialContent, false);
   });
 });
 
-// aggregate() itself is tested in core/lib/log/aggregate.test.ts.
+// aggregate()/createIncrementalAggregator() itself is tested in core/lib/log/aggregate.test.ts.
 // parseIdentifier() itself is tested in core/lib/log/parse-identifier.test.ts.
 
 reportResults();

--- a/core/lib/log/buildkitd-log-parser.ts
+++ b/core/lib/log/buildkitd-log-parser.ts
@@ -20,18 +20,21 @@
  * console output into this same log.
  */
 import { parseIdentifier } from "./parse-identifier.ts";
-
-export interface DenialEntry {
-  decision: string;
-  ruleType: string;
-  host: string;
-  port: string;
-  reason: string;
-}
+import { createIncrementalAggregator, type AggregatedEntry } from "./aggregate.ts";
 
 export interface DenialTimelineEntry {
   url: string;
   timestamp: string;
+}
+
+export interface BuildkitdLogScanResult {
+  blocked: AggregatedEntry[];
+  /** Chronological, per-event — not aggregated, since each entry's own
+   *  timestamp is what a timeline render needs. */
+  denied: DenialTimelineEntry[];
+  /** True iff a non-blank line wasn't a denial line — see the module doc
+   *  below for what this signals. */
+  hasNonDenialContent: boolean;
 }
 
 const deniedLinePattern = /msg="Evaluated source policy".*denied by policy/;
@@ -45,60 +48,43 @@ function unescapeLogrusValue(s: string): string {
 }
 
 /**
- * Scan for "Evaluated source policy" denial lines and return each one's raw
- * identifier and timestamp, in log order, with no host/port resolution or
- * aggregation. Shared by parseEntries() (host-aggregated) and
- * parseDenialTimeline() (chronological) below.
+ * Single forward pass over buildkitd's own debug log: denial lines fold
+ * into an incremental aggregator and also push onto a raw chronological
+ * `denied` list; non-denial, non-blank lines flip hasNonDenialContent.
+ *
+ * buildkitd emits copious debug output from the moment it starts,
+ * regardless of whether any denial ever occurred. A log consisting only of
+ * forged denial lines — or nothing at all — lacks that, which is a signal
+ * (not a guarantee) of tampering.
  */
-function parseDenialEntries(logText: string): DenialTimelineEntry[] {
-  const entries: DenialTimelineEntry[] = [];
-  for (const line of logText.split("\n")) {
-    if (!deniedLinePattern.test(line)) continue;
+export async function scanBuildkitdLog(
+  lines: AsyncIterable<string> | Iterable<string>,
+): Promise<BuildkitdLogScanResult> {
+  const blocked = createIncrementalAggregator();
+  const denied: DenialTimelineEntry[] = [];
+  let hasNonDenialContent = false;
+
+  for await (const line of lines) {
+    if (!deniedLinePattern.test(line)) {
+      if (line.trim() !== "") hasNonDenialContent = true;
+      continue;
+    }
     const refMatch = line.match(refFieldPattern);
     const timeMatch = line.match(timeFieldPattern);
     if (!refMatch || !timeMatch) continue;
-    entries.push({ url: unescapeLogrusValue(refMatch[1]), timestamp: timeMatch[1] });
-  }
-  return entries;
-}
 
-export function parseEntries(logText: string): DenialEntry[] {
-  const entries: DenialEntry[] = [];
-  for (const { url } of parseDenialEntries(logText)) {
+    const url = unescapeLogrusValue(refMatch[1]);
+    denied.push({ url, timestamp: timeMatch[1] });
+
     const parsed = parseIdentifier(url);
     if (!parsed) continue;
-    entries.push({
-      decision: "BLOCKED",
-      ruleType: parsed.scheme === "https" ? "HTTPS" : "HTTP",
+    blocked.add({
       host: parsed.host,
       port: parsed.port,
+      ruleType: parsed.scheme === "https" ? "HTTPS" : "HTTP",
       reason: "not-allowed",
     });
   }
-  return entries;
-}
 
-/**
- * Parse the chronological list of denied requests, each with its own
- * timestamp — unlike parseEntries(), this is neither aggregated by host nor
- * attributed to a RUN step (BuildKit's own denial log carries no vertex/span
- * identifier to attribute it with). Timestamps are whole-seconds only (no
- * sub-second precision), since that is all buildkitd's own logrus text
- * formatter records.
- */
-export function parseDenialTimeline(logText: string): DenialTimelineEntry[] {
-  return parseDenialEntries(logText);
-}
-
-/**
- * True iff logText contains at least one non-blank line that is not a
- * denial line. buildkitd emits copious startup/worker/gRPC debug output
- * (level = "debug" is set unconditionally) from the moment the process
- * starts, regardless of whether any build ever ran or any denial ever
- * occurred. A log consisting only of forged denial lines — or nothing at
- * all — lacks this, which is a signal (not a guarantee) that the log may
- * have been tampered with rather than reflecting a real run.
- */
-export function hasNonDenialContent(logText: string): boolean {
-  return logText.split("\n").some((line) => line.trim() !== "" && !deniedLinePattern.test(line));
+  return { blocked: blocked.toSortedArray(), denied, hasNonDenialContent };
 }

--- a/core/lib/log/haproxy-log-parser.property.test.ts
+++ b/core/lib/log/haproxy-log-parser.property.test.ts
@@ -7,17 +7,20 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 
-import { parseEntries } from "./haproxy-log-parser.ts";
+import { scanHaproxyLog } from "./haproxy-log-parser.ts";
 import { aggregate } from "./aggregate.ts";
 
 // ---------------------------------------------------------------------------
-// parseEntries
+// scanHaproxyLog
 // ---------------------------------------------------------------------------
 
-describe("parseEntries – properties", () => {
-  // A well-formed log line always round-trips: parseEntries recovers all five fields.
-  it("valid log line always parses to exactly one entry with matching fields", () => {
+describe("scanHaproxyLog – properties", () => {
+  // A well-formed log line always round-trips into the right bucket:
+  // BLOCKED always lands in `blocked`; ALLOWED/AUDIT lands in `passed` only
+  // if it matches the decision `isAudit` selects, otherwise it's dropped.
+  it("valid log line always aggregates to exactly one entry in the right bucket", async () => {
     const decision = fc.constantFrom("ALLOWED", "BLOCKED", "AUDIT");
+    const isAudit = fc.boolean();
     // ruleType must match \w+ in the log pattern
     const ruleType = fc.stringMatching(/^\w{1,10}$/);
     // host: no '"' or ':' to keep the lastIndexOf split unambiguous
@@ -26,31 +29,46 @@ describe("parseEntries – properties", () => {
     // reason: \S+ so the log pattern captures it in full
     const reason = fc.oneof(fc.constant("-"), fc.stringMatching(/^\S{1,15}$/));
 
-    fc.assert(
-      fc.property(decision, ruleType, host, port, reason, (d, rt, h, p, r) => {
+    await fc.assert(
+      fc.asyncProperty(decision, isAudit, ruleType, host, port, reason, async (d, audit, rt, h, p, r) => {
         const line = `[2024-01-01] buildcage [${d}] (${rt}) "${h}:${p}" ${r}`;
-        const entries = parseEntries(line);
-        assert.equal(entries.length, 1);
-        assert.equal(entries[0].decision, d);
-        assert.equal(entries[0].ruleType, rt);
-        assert.equal(entries[0].host, h);
-        assert.equal(entries[0].port, p);
-        assert.equal(entries[0].reason, r);
+        const result = await scanHaproxyLog([line], audit);
+        const passedDecision = audit ? "AUDIT" : "ALLOWED";
+
+        if (d === "BLOCKED") {
+          assert.equal(result.passed.length, 0);
+          assert.equal(result.blocked.length, 1);
+          assert.equal(result.blocked[0].ruleType, rt);
+          assert.equal(result.blocked[0].host, h);
+          assert.equal(result.blocked[0].port, p);
+          assert.equal(result.blocked[0].reason, r);
+        } else if (d === passedDecision) {
+          assert.equal(result.blocked.length, 0);
+          assert.equal(result.passed.length, 1);
+          assert.equal(result.passed[0].ruleType, rt);
+          assert.equal(result.passed[0].host, h);
+          assert.equal(result.passed[0].port, p);
+          assert.equal(result.passed[0].reason, r);
+        } else {
+          // The "other" of ALLOWED/AUDIT for this mode — dropped entirely.
+          assert.equal(result.passed.length, 0);
+          assert.equal(result.blocked.length, 0);
+        }
       }),
     );
   });
 
   // The log pattern captures reason as \S* (no whitespace). A reason string
   // containing an internal space is silently truncated to its first word.
-  it("reason with internal space is truncated to the first word", () => {
+  it("reason with internal space is truncated to the first word", async () => {
     const word = fc.stringMatching(/^\S{1,10}$/);
 
-    fc.assert(
-      fc.property(word, word, (w1, w2) => {
+    await fc.assert(
+      fc.asyncProperty(word, word, async (w1, w2) => {
         const line = `[ts] buildcage [ALLOWED] (HTTPS) "example.com:443" ${w1} ${w2}`;
-        const entries = parseEntries(line);
-        assert.equal(entries.length, 1);
-        assert.equal(entries[0].reason, w1);
+        const result = await scanHaproxyLog([line], false);
+        assert.equal(result.passed.length, 1);
+        assert.equal(result.passed[0].reason, w1);
       }),
     );
   });

--- a/core/lib/log/haproxy-log-parser.test.ts
+++ b/core/lib/log/haproxy-log-parser.test.ts
@@ -1,101 +1,118 @@
 import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { parseEntries, hasNonBuildcageContent } from "./haproxy-log-parser.ts";
+import { scanHaproxyLog } from "./haproxy-log-parser.ts";
 
 // ---------------------------------------------------------------------------
-// parseEntries
+// scanHaproxyLog
 // ---------------------------------------------------------------------------
-describe("parseEntries", () => {
-  it("parses ALLOWED log line", () => {
+describe("scanHaproxyLog", () => {
+  it("aggregates an ALLOWED log line as passed when isAudit is false", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "example.com:443" rule1';
-    const entries = parseEntries(log);
-    assert.equal(entries.length, 1);
-    assert.equal(entries[0].decision, "ALLOWED");
-    assert.equal(entries[0].ruleType, "HTTPS");
-    assert.equal(entries[0].host, "example.com");
-    assert.equal(entries[0].port, "443");
-    assert.equal(entries[0].reason, "rule1");
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.passed.length, 1);
+    assert.equal(result.passed[0].ruleType, "HTTPS");
+    assert.equal(result.passed[0].host, "example.com");
+    assert.equal(result.passed[0].port, "443");
+    assert.equal(result.passed[0].reason, "rule1");
+    assert.equal(result.blocked.length, 0);
   });
 
-  it("parses BLOCKED log line", () => {
+  it("aggregates a BLOCKED log line regardless of isAudit", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTP) "bad.com:80" not-allowed';
-    const entries = parseEntries(log);
-    assert.equal(entries.length, 1);
-    assert.equal(entries[0].decision, "BLOCKED");
-    assert.equal(entries[0].reason, "not-allowed");
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].reason, "not-allowed");
+    assert.equal(result.blockedCount, 1);
   });
 
-  it("parses AUDIT log line", () => {
+  it("aggregates an AUDIT log line as passed when isAudit is true", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "any.com:443"';
-    const entries = parseEntries(log);
-    assert.equal(entries.length, 1);
-    assert.equal(entries[0].decision, "AUDIT");
-    assert.equal(entries[0].reason, "-");
+    const result = await scanHaproxyLog(log.split("\n"), true);
+    assert.equal(result.passed.length, 1);
+    assert.equal(result.passed[0].reason, "-");
   });
 
-  it("ignores non-matching lines", () => {
+  it("drops an ALLOWED line when isAudit is true (not the decision this mode aggregates)", async () => {
+    const log = '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "example.com:443" rule1';
+    const result = await scanHaproxyLog(log.split("\n"), true);
+    assert.equal(result.passed.length, 0);
+  });
+
+  it("drops an AUDIT line when isAudit is false (not the decision this mode aggregates)", async () => {
+    const log = '[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "any.com:443"';
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.passed.length, 0);
+  });
+
+  it("ignores non-matching lines without counting them anywhere", async () => {
     const log = "some random log line\n[2024-01-01] other stuff";
-    const entries = parseEntries(log);
-    assert.equal(entries.length, 0);
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.passed.length, 0);
+    assert.equal(result.blocked.length, 0);
   });
 
-  it("parses multiple lines", () => {
+  it("aggregates repeated BLOCKED lines into one row, but keeps blockedCount raw", async () => {
+    const log = [
+      '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTPS) "bad.com:443" not-allowed',
+      '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTPS) "bad.com:443" not-allowed',
+    ].join("\n");
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blocked[0].count, 2);
+    assert.equal(result.blockedCount, 2);
+  });
+
+  it("keeps passed/blocked buckets independent across mixed lines", async () => {
     const log = [
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "a.com:443" r1',
       '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTP) "b.com:80" not-allowed',
-      'not a log line',
+      "not a log line",
       '[2024-01-01T00:00:02] buildcage [ALLOWED] (HTTPS) "a.com:443" r1',
     ].join("\n");
-    const entries = parseEntries(log);
-    assert.equal(entries.length, 3);
-  });
-});
-
-// aggregate() is tested in core/lib/log/aggregate.test.ts.
-
-// ---------------------------------------------------------------------------
-// mode detection
-// ---------------------------------------------------------------------------
-describe("mode detection", () => {
-  it("detects audit mode", () => {
-    const entries = parseEntries('[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "a.com:443"');
-    const isAudit = entries.some(e => e.decision === "AUDIT");
-    assert.ok(isAudit);
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.passed.length, 1);
+    assert.equal(result.passed[0].count, 2);
+    assert.equal(result.blocked.length, 1);
+    assert.equal(result.blockedCount, 1);
   });
 
-  it("detects restrict mode", () => {
-    const entries = parseEntries('[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "a.com:443" r1');
-    const isAudit = entries.some(e => e.decision === "AUDIT");
-    assert.ok(!isAudit);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// hasNonBuildcageContent
-// ---------------------------------------------------------------------------
-describe("hasNonBuildcageContent", () => {
-  it("returns false for empty log text", () => {
-    assert.equal(hasNonBuildcageContent(""), false);
+  it("accepts a real AsyncIterable, not just an array", async () => {
+    async function* lines(): AsyncGenerator<string> {
+      yield '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "async.com:443" r1';
+    }
+    const result = await scanHaproxyLog(lines(), false);
+    assert.equal(result.passed.length, 1);
+    assert.equal(result.passed[0].host, "async.com");
   });
 
-  it("returns false when the log has only buildcage-decision lines", () => {
+  // ---------------------------------------------------------------------
+  // hasNonBuildcageContent
+  // ---------------------------------------------------------------------
+  it("hasNonBuildcageContent is false for empty log text", async () => {
+    const result = await scanHaproxyLog("".split("\n"), false);
+    assert.equal(result.hasNonBuildcageContent, false);
+  });
+
+  it("hasNonBuildcageContent is false when the log has only buildcage-decision lines", async () => {
     const log = [
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "a.com:443" r1',
       '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTP) "b.com:80" not-allowed',
     ].join("\n");
-    assert.equal(hasNonBuildcageContent(log), false);
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.hasNonBuildcageContent, false);
   });
 
-  it("returns true when the log contains HAProxy's own non-decision output", () => {
+  it("hasNonBuildcageContent is true when the log contains HAProxy's own non-decision output", async () => {
     const log = [
       "[NOTICE]   (1) : haproxy version is 2.9.0",
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "a.com:443" r1',
     ].join("\n");
-    assert.equal(hasNonBuildcageContent(log), true);
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    assert.equal(result.hasNonBuildcageContent, true);
   });
 
-  it("ignores blank lines when deciding", () => {
-    const log = "\n\n  \n";
-    assert.equal(hasNonBuildcageContent(log), false);
+  it("hasNonBuildcageContent ignores blank lines when deciding", async () => {
+    const result = await scanHaproxyLog("\n\n  \n".split("\n"), false);
+    assert.equal(result.hasNonBuildcageContent, false);
   });
 });
 

--- a/core/lib/log/haproxy-log-parser.ts
+++ b/core/lib/log/haproxy-log-parser.ts
@@ -2,59 +2,77 @@
  * Log parsing library for HAProxy buildcage logs. aggregate() lives
  * separately in core/lib/log/aggregate.js and is not re-exported here.
  */
+import { createIncrementalAggregator, type AggregatedEntry } from "./aggregate.ts";
 
-export interface LogEntry {
-  decision: string;
-  ruleType: string;
-  host: string;
-  port: string;
-  reason: string;
+export interface HaproxyLogScanResult {
+  /** ALLOWED entries in restrict mode, AUDIT entries in audit mode — never
+   *  both (see `isAudit`). */
+  passed: AggregatedEntry[];
+  blocked: AggregatedEntry[];
+  /** Raw BLOCKED line count, pre-aggregation — distinct from blocked.length. */
+  blockedCount: number;
+  /** True iff a non-blank line didn't match the buildcage decision format —
+   *  see the module doc below for what this signals. */
+  hasNonBuildcageContent: boolean;
 }
 
 const logPattern =
   /^\[.*?\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+\((\w+)\)\s+"([^"]+)"\s*(\S*)/;
 
 /**
- * Parse log text into structured entries.
+ * Single forward pass over the log: matching lines fold directly into
+ * incremental aggregators (never collected into a flat array first), and
+ * non-matching, non-blank lines flip hasNonBuildcageContent.
+ *
+ * A genuine HAProxy process always emits some non-buildcage-format output
+ * of its own before any traffic occurs. A log with nothing but
+ * forged/replayed decision lines — or nothing at all — lacks that, which is
+ * a signal (not a guarantee) of tampering.
+ *
+ * `isAudit` picks which decision counts as "passed" (AUDIT vs ALLOWED); the
+ * other one, if it somehow appears, is dropped rather than aggregated.
  */
-export function parseEntries(logText: string): LogEntry[] {
-  const entries: LogEntry[] = [];
-  for (const line of logText.split("\n")) {
+export async function scanHaproxyLog(
+  lines: AsyncIterable<string> | Iterable<string>,
+  isAudit: boolean,
+): Promise<HaproxyLogScanResult> {
+  const passed = createIncrementalAggregator();
+  const blocked = createIncrementalAggregator();
+  const passedDecision = isAudit ? "AUDIT" : "ALLOWED";
+  let blockedCount = 0;
+  let hasNonBuildcageContent = false;
+
+  for await (const line of lines) {
     const m = line.match(logPattern);
-    if (m) {
-      const [, decision, ruleType, hostPort, reason] = m;
-      const colonIdx = hostPort.lastIndexOf(":");
-      let host: string;
-      let port: string;
-      if (colonIdx > 0) {
-        host = hostPort.substring(0, colonIdx);
-        port = hostPort.substring(colonIdx + 1);
-      } else {
-        host = hostPort;
-        port = "0";
-      }
-      entries.push({
-        decision,
-        ruleType,
-        host,
-        port,
-        reason: reason || "-",
-      });
+    if (!m) {
+      if (line.trim() !== "") hasNonBuildcageContent = true;
+      continue;
+    }
+    const [, decision, ruleType, hostPort, reason] = m;
+    const colonIdx = hostPort.lastIndexOf(":");
+    let host: string;
+    let port: string;
+    if (colonIdx > 0) {
+      host = hostPort.substring(0, colonIdx);
+      port = hostPort.substring(colonIdx + 1);
+    } else {
+      host = hostPort;
+      port = "0";
+    }
+    const entry = { host, port, ruleType, reason: reason || "-" };
+
+    if (decision === passedDecision) {
+      passed.add(entry);
+    } else if (decision === "BLOCKED") {
+      blocked.add(entry);
+      blockedCount++;
     }
   }
-  return entries;
-}
 
-/**
- * True iff logText contains at least one non-blank line that is not a
- * buildcage-decision line. A genuine HAProxy process always produces some
- * such content (its own startup/notice output, merged into this same log
- * via the s6 pipeline) before any traffic occurs, regardless of whether
- * any connection was ever blocked. A log consisting only of forged/replayed
- * decision lines — or nothing at all — lacks this, which is a signal (not
- * a guarantee) that the log may have been tampered with rather than
- * reflecting a real run.
- */
-export function hasNonBuildcageContent(logText: string): boolean {
-  return logText.split("\n").some((line) => line.trim() !== "" && !logPattern.test(line));
+  return {
+    passed: passed.toSortedArray(),
+    blocked: blocked.toSortedArray(),
+    blockedCount,
+    hasNonBuildcageContent,
+  };
 }

--- a/core/lib/report/build-explicit-report-data.test.ts
+++ b/core/lib/report/build-explicit-report-data.test.ts
@@ -32,8 +32,8 @@ const builds: VertexAllowedEntry[][] = [
 ];
 
 describe("buildExplicitReportData", () => {
-  it("aggregates passed from builds and blocked from the buildkitd log", () => {
-    const result = buildExplicitReportData(deniedLine, builds, params());
+  it("aggregates passed from builds and blocked from the buildkitd log", async () => {
+    const result = await buildExplicitReportData(deniedLine.split("\n"), builds, params());
     assert.equal(result.engine, "explicit");
     assert.equal(result.passed.length, 1);
     assert.equal(result.passed[0].host, "good.example.com");
@@ -42,41 +42,45 @@ describe("buildExplicitReportData", () => {
     assert.equal(result.blockedCount, 1);
   });
 
-  it("blockedCount equals blocked.length (aggregated, not raw event count)", () => {
+  it("blockedCount equals blocked.length (aggregated, not raw event count)", async () => {
     const twoDenials = [deniedLine, deniedLine].join("\n");
-    const result = buildExplicitReportData(twoDenials, [], params());
+    const result = await buildExplicitReportData(twoDenials.split("\n"), [], params());
     assert.equal(result.blocked.length, 1);
     assert.equal(result.blockedCount, 1);
   });
 
-  it("annotates blocked rows against knownBlockedRules", () => {
-    const result = buildExplicitReportData(deniedLine, [], params({ knownBlockedRules: ["blocked.example.com:443"] }));
+  it("annotates blocked rows against knownBlockedRules", async () => {
+    const result = await buildExplicitReportData(
+      deniedLine.split("\n"),
+      [],
+      params({ knownBlockedRules: ["blocked.example.com:443"] }),
+    );
     assert.equal(result.blocked[0].expected, true);
   });
 
-  it("populates proxyLogs.builds and proxyLogs.denied", () => {
-    const result = buildExplicitReportData(deniedLine, builds, params());
+  it("populates proxyLogs.builds and proxyLogs.denied", async () => {
+    const result = await buildExplicitReportData(deniedLine.split("\n"), builds, params());
     assert.equal(result.proxyLogs.builds, builds);
     assert.equal(result.proxyLogs.denied.length, 1);
     assert.equal(result.proxyLogs.denied[0].url, "https://blocked.example.com/");
   });
 
-  it("uses AUDIT decision for passed when mode is audit", () => {
-    const result = buildExplicitReportData("", builds, params({ mode: "audit" }));
+  it("uses AUDIT decision for passed when mode is audit", async () => {
+    const result = await buildExplicitReportData("".split("\n"), builds, params({ mode: "audit" }));
     assert.equal(result.passed.length, 1);
   });
 
-  it("returns empty passed/blocked and blockedCount 0 for empty inputs", () => {
-    const result = buildExplicitReportData("", [], params());
+  it("returns empty passed/blocked and blockedCount 0 for empty inputs", async () => {
+    const result = await buildExplicitReportData("".split("\n"), [], params());
     assert.deepEqual(result.passed, []);
     assert.deepEqual(result.blocked, []);
     assert.equal(result.blockedCount, 0);
     assert.equal(result.logLooksPlausible, false);
   });
 
-  it("logLooksPlausible is true for a genuinely quiet run (buildkitd's own startup noise, zero denials)", () => {
+  it("logLooksPlausible is true for a genuinely quiet run (buildkitd's own startup noise, zero denials)", async () => {
     const log = 'time="2026-01-01T00:00:00Z" level=info msg="found worker" builder=0';
-    const result = buildExplicitReportData(log, [], params());
+    const result = await buildExplicitReportData(log.split("\n"), [], params());
     assert.equal(result.blockedCount, 0);
     assert.equal(result.logLooksPlausible, true);
   });

--- a/core/lib/report/build-explicit-report-data.ts
+++ b/core/lib/report/build-explicit-report-data.ts
@@ -1,24 +1,20 @@
-import { parseEntries, parseDenialTimeline, hasNonDenialContent } from "../log/buildkitd-log-parser.ts";
-import { aggregate } from "../log/aggregate.ts";
+import { scanBuildkitdLog } from "../log/buildkitd-log-parser.ts";
 import { aggregateAllowedHosts, type VertexAllowedEntry } from "../log/vertex-log.ts";
 import { annotateKnownBlocked } from "./known-blocked.ts";
 import type { GenReportParameters, ExplicitReportData } from "./report-data.ts";
 
-/**
- * Pure — no I/O; `builds` is already fetched via buildctl by the caller.
- * blockedCount equals blocked.length here, unlike the transparent engine:
- * buildkitd's denial log has no finer per-event granularity to count.
- */
-export function buildExplicitReportData(
-  logText: string,
+/** Pure — no I/O; callers fetch lines/builds/parameters themselves. */
+export async function buildExplicitReportData(
+  lines: AsyncIterable<string> | Iterable<string>,
   builds: VertexAllowedEntry[][],
   parameters: GenReportParameters,
-): ExplicitReportData {
+): Promise<ExplicitReportData> {
   const isAudit = parameters.mode === "audit";
-
-  const blockedRawRows = aggregate(parseEntries(logText));
-  const blockedCount = blockedRawRows.length;
+  const { blocked: blockedRawRows, denied, hasNonDenialContent } = await scanBuildkitdLog(lines);
   const blocked = annotateKnownBlocked(blockedRawRows, parameters.knownBlockedRules);
+  // blockedCount equals blocked.length here, unlike the transparent engine:
+  // buildkitd's denial log has no finer per-event granularity to count.
+  const blockedCount = blocked.length;
 
   const passed = aggregateAllowedHosts(builds, isAudit ? "AUDIT" : "ALLOWED");
 
@@ -28,10 +24,10 @@ export function buildExplicitReportData(
     passed,
     blocked,
     blockedCount,
-    logLooksPlausible: hasNonDenialContent(logText),
+    logLooksPlausible: hasNonDenialContent,
     proxyLogs: {
       builds,
-      denied: parseDenialTimeline(logText),
+      denied,
     },
   };
 }

--- a/core/lib/report/build-transparent-report-data.test.ts
+++ b/core/lib/report/build-transparent-report-data.test.ts
@@ -14,12 +14,12 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
 }
 
 describe("buildTransparentReportData", () => {
-  it("aggregates allowed/blocked in restrict mode", () => {
+  it("aggregates allowed/blocked in restrict mode", async () => {
     const log = [
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "good.com:443" -',
       '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTP) "bad.com:80" not-allowed',
     ].join("\n");
-    const result = buildTransparentReportData(log, params());
+    const result = await buildTransparentReportData(log.split("\n"), params());
     assert.equal(result.engine, "transparent");
     assert.equal(result.passed.length, 1);
     assert.equal(result.passed[0].host, "good.com");
@@ -28,43 +28,46 @@ describe("buildTransparentReportData", () => {
     assert.equal(result.blockedCount, 1);
   });
 
-  it("aggregates audited traffic in audit mode instead of allowed", () => {
+  it("aggregates audited traffic in audit mode instead of allowed", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "any.com:443"';
-    const result = buildTransparentReportData(log, params({ mode: "audit" }));
+    const result = await buildTransparentReportData(log.split("\n"), params({ mode: "audit" }));
     assert.equal(result.passed.length, 1);
     assert.equal(result.passed[0].host, "any.com");
   });
 
-  it("annotates blocked rows against knownBlockedRules", () => {
+  it("annotates blocked rows against knownBlockedRules", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTPS) "noisy.example.com:443" not-allowed';
-    const result = buildTransparentReportData(log, params({ knownBlockedRules: ["noisy.example.com:443"] }));
+    const result = await buildTransparentReportData(
+      log.split("\n"),
+      params({ knownBlockedRules: ["noisy.example.com:443"] }),
+    );
     assert.equal(result.blocked[0].expected, true);
   });
 
-  it("returns empty passed/blocked and blockedCount 0 for empty log text", () => {
-    const result = buildTransparentReportData("", params());
+  it("returns empty passed/blocked and blockedCount 0 for empty log text", async () => {
+    const result = await buildTransparentReportData("".split("\n"), params());
     assert.deepEqual(result.passed, []);
     assert.deepEqual(result.blocked, []);
     assert.equal(result.blockedCount, 0);
     assert.equal(result.logLooksPlausible, false);
   });
 
-  it("logLooksPlausible is true for a genuinely quiet run (HAProxy's own startup noise, zero blocked)", () => {
+  it("logLooksPlausible is true for a genuinely quiet run (HAProxy's own startup noise, zero blocked)", async () => {
     const log = [
       "[NOTICE]   (1) : haproxy version is 2.9.0",
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "good.com:443" -',
     ].join("\n");
-    const result = buildTransparentReportData(log, params());
+    const result = await buildTransparentReportData(log.split("\n"), params());
     assert.equal(result.blockedCount, 0);
     assert.equal(result.logLooksPlausible, true);
   });
 
-  it("blockedCount counts raw events, not aggregated rows", () => {
+  it("blockedCount counts raw events, not aggregated rows", async () => {
     const log = [
       '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTPS) "bad.com:443" not-allowed',
       '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTPS) "bad.com:443" not-allowed',
     ].join("\n");
-    const result = buildTransparentReportData(log, params());
+    const result = await buildTransparentReportData(log.split("\n"), params());
     assert.equal(result.blockedCount, 2);
     assert.equal(result.blocked.length, 1);
     assert.equal(result.blocked[0].count, 2);

--- a/core/lib/report/build-transparent-report-data.ts
+++ b/core/lib/report/build-transparent-report-data.ts
@@ -1,24 +1,20 @@
-import { parseEntries, hasNonBuildcageContent } from "../log/haproxy-log-parser.ts";
-import { aggregate } from "../log/aggregate.ts";
+import { scanHaproxyLog } from "../log/haproxy-log-parser.ts";
 import { annotateKnownBlocked } from "./known-blocked.ts";
 import type { GenReportParameters, TransparentReportData } from "./report-data.ts";
 
 /**
  * Pure — no I/O; callers (report-action.node.ts, run/src/lib/report.ts)
- * fetch logText/parameters themselves. An empty logText naturally yields
+ * fetch lines/parameters themselves. An empty input naturally yields
  * passed:[]/blocked:[]/blockedCount:0, so no special-case branch is needed.
  */
-export function buildTransparentReportData(logText: string, parameters: GenReportParameters): TransparentReportData {
+export async function buildTransparentReportData(
+  lines: AsyncIterable<string> | Iterable<string>,
+  parameters: GenReportParameters,
+): Promise<TransparentReportData> {
   const isAudit = parameters.mode === "audit";
-  const entries = parseEntries(logText);
-
-  const blockedCount = entries.filter((e) => e.decision === "BLOCKED").length;
-  const blockedRawRows = aggregate(entries.filter((e) => e.decision === "BLOCKED"));
+  const { passed, blocked: blockedRawRows, blockedCount, hasNonBuildcageContent } =
+    await scanHaproxyLog(lines, isAudit);
   const blocked = annotateKnownBlocked(blockedRawRows, parameters.knownBlockedRules);
-
-  const passed = isAudit
-    ? aggregate(entries.filter((e) => e.decision === "AUDIT"))
-    : aggregate(entries.filter((e) => e.decision === "ALLOWED"));
 
   return {
     engine: "transparent",
@@ -26,6 +22,6 @@ export function buildTransparentReportData(logText: string, parameters: GenRepor
     passed,
     blocked,
     blockedCount,
-    logLooksPlausible: hasNonBuildcageContent(logText),
+    logLooksPlausible: hasNonBuildcageContent,
   };
 }

--- a/core/lib/test/test-shim.ts
+++ b/core/lib/test/test-shim.ts
@@ -18,6 +18,8 @@ interface Assert {
   ok(value: unknown): void;
   throws(fn: () => void, pattern?: RegExp): void;
   match(value: string, pattern: RegExp): void;
+  /** Node-only in practice; the QuickJS shim implements it just to satisfy this type. */
+  rejects(promise: Promise<unknown>, matcher?: (e: unknown) => boolean): Promise<void>;
 }
 
 interface Shim {
@@ -93,6 +95,17 @@ async function createQjsShim(): Promise<Shim> {
       if (!pattern.test(value)) {
         throw new Error(`Expected "${value}" to match ${pattern}`);
       }
+    },
+    async rejects(promise, matcher) {
+      try {
+        await promise;
+      } catch (e) {
+        if (matcher && !matcher(e)) {
+          throw new Error("Rejection did not match the expected condition");
+        }
+        return;
+      }
+      throw new Error("Expected promise to reject");
     },
   };
 

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -1,5 +1,5 @@
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_os = require("node:os"), node_path = require("node:path"), node_url = require("node:url"), node_crypto = require("node:crypto");
+let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_os = require("node:os"), node_path = require("node:path"), node_url = require("node:url"), node_crypto = require("node:crypto"), node_events = require("node:events"), node_readline = require("node:readline");
 /**
 * Turns a caught `docker` invocation error into an actionable message,
 * pointing at the runner requirement instead of surfacing execFileSync's
@@ -90,9 +90,59 @@ function defaultRunCommand(args) {
 		maxBuffer: 64 * 1024 * 1024
 	});
 }
-/** `run` is injectable so tests can assert on argv instead of mocking
-*  node:child_process directly. */
-function createDocker(run = defaultRunCommand) {
+function defaultSpawnCommand(args) {
+	return (0, node_child_process.spawn)("docker", args, { stdio: [
+		"ignore",
+		"pipe",
+		"pipe"
+	] });
+}
+/**
+* Drives a `docker <args>` child process and yields its stdout line by
+* line, never buffering more than the current line. Lazy — nothing spawns
+* until the caller starts iterating.
+*
+* Throws `{status, stderr}` on a non-zero exit and Node's own
+* `{code: "ENOENT", ...}` on a spawn failure, matching the shape
+* describeDockerFailure() (core/lib/actions/docker-error.ts) expects from
+* execFileSync elsewhere in this module.
+*/
+async function* streamDockerLines(spawnDocker, args, operation) {
+	let child = spawnDocker(args), spawnError;
+	child.on("error", (err) => {
+		spawnError = err;
+	});
+	let closed = (0, node_events.once)(child, "close").then(([code, signal]) => ({
+		code,
+		signal
+	}), () => ({
+		code: null,
+		signal: null
+	})), stderr = "";
+	child.stderr?.setEncoding("utf8"), child.stderr?.on("data", (chunk) => {
+		stderr += chunk;
+	});
+	let rl = (0, node_readline.createInterface)({
+		input: child.stdout,
+		crlfDelay: Infinity
+	}), exhausted = !1;
+	try {
+		for await (let line of rl) yield line;
+		exhausted = !0;
+	} finally {
+		rl.close(), !exhausted && child.exitCode === null && child.signalCode === null && child.kill();
+	}
+	if (!exhausted) return;
+	let { code, signal } = await closed;
+	if (spawnError) throw spawnError;
+	if (code !== 0) throw Object.assign(/* @__PURE__ */ Error(`${operation} exited with code ${code}${signal ? ` (signal ${signal})` : ""}: ${stderr.trim()}`), {
+		status: code ?? void 0,
+		stderr
+	});
+}
+/** `run`/`spawnDocker` are injectable so tests can assert on argv instead of
+*  mocking node:child_process directly. */
+function createDocker(run = defaultRunCommand, spawnDocker = defaultSpawnCommand) {
 	return {
 		findContainers(filters) {
 			let args = ["ps"];
@@ -106,13 +156,13 @@ function createDocker(run = defaultRunCommand) {
 				hostPath
 			}));
 		},
-		readFile(containerId, path) {
-			return run([
+		readFileLines(containerId, path) {
+			return streamDockerLines(spawnDocker, [
 				"exec",
 				containerId,
 				"cat",
 				path
-			]);
+			], `docker exec cat ${path}`);
 		},
 		readEnv(containerId) {
 			return parseDockerInspectEnv(run([

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -15,7 +15,7 @@ let node_child_process = require("node:child_process"), node_fs = require("node:
 node_path = __toESM(node_path, 1);
 let node_url = require("node:url"), node_os = require("node:os");
 node_os = __toESM(node_os, 1);
-let node_crypto = require("node:crypto");
+let node_crypto = require("node:crypto"), node_events = require("node:events"), node_readline = require("node:readline");
 //#region core/lib/provenance/image-ref.ts
 function resolveBuildcageImageRef({ imageDigest, actionRepository }) {
 	return `${`ghcr.io/${actionRepository}`.toLowerCase()}@${imageDigest}`;
@@ -7644,9 +7644,59 @@ function defaultRunCommand(args) {
 		maxBuffer: 64 * 1024 * 1024
 	});
 }
-/** `run` is injectable so tests can assert on argv instead of mocking
-*  node:child_process directly. */
-function createDocker(run = defaultRunCommand) {
+function defaultSpawnCommand(args) {
+	return (0, node_child_process.spawn)("docker", args, { stdio: [
+		"ignore",
+		"pipe",
+		"pipe"
+	] });
+}
+/**
+* Drives a `docker <args>` child process and yields its stdout line by
+* line, never buffering more than the current line. Lazy — nothing spawns
+* until the caller starts iterating.
+*
+* Throws `{status, stderr}` on a non-zero exit and Node's own
+* `{code: "ENOENT", ...}` on a spawn failure, matching the shape
+* describeDockerFailure() (core/lib/actions/docker-error.ts) expects from
+* execFileSync elsewhere in this module.
+*/
+async function* streamDockerLines(spawnDocker, args, operation) {
+	let child = spawnDocker(args), spawnError;
+	child.on("error", (err) => {
+		spawnError = err;
+	});
+	let closed = (0, node_events.once)(child, "close").then(([code, signal]) => ({
+		code,
+		signal
+	}), () => ({
+		code: null,
+		signal: null
+	})), stderr = "";
+	child.stderr?.setEncoding("utf8"), child.stderr?.on("data", (chunk) => {
+		stderr += chunk;
+	});
+	let rl = (0, node_readline.createInterface)({
+		input: child.stdout,
+		crlfDelay: Infinity
+	}), exhausted = !1;
+	try {
+		for await (let line of rl) yield line;
+		exhausted = !0;
+	} finally {
+		rl.close(), !exhausted && child.exitCode === null && child.signalCode === null && child.kill();
+	}
+	if (!exhausted) return;
+	let { code, signal } = await closed;
+	if (spawnError) throw spawnError;
+	if (code !== 0) throw Object.assign(/* @__PURE__ */ Error(`${operation} exited with code ${code}${signal ? ` (signal ${signal})` : ""}: ${stderr.trim()}`), {
+		status: code ?? void 0,
+		stderr
+	});
+}
+/** `run`/`spawnDocker` are injectable so tests can assert on argv instead of
+*  mocking node:child_process directly. */
+function createDocker(run = defaultRunCommand, spawnDocker = defaultSpawnCommand) {
 	return {
 		findContainers(filters) {
 			let args = ["ps"];
@@ -7660,13 +7710,13 @@ function createDocker(run = defaultRunCommand) {
 				hostPath
 			}));
 		},
-		readFile(containerId, path) {
-			return run([
+		readFileLines(containerId, path) {
+			return streamDockerLines(spawnDocker, [
 				"exec",
 				containerId,
 				"cat",
 				path
-			]);
+			], `docker exec cat ${path}`);
 		},
 		readEnv(containerId) {
 			return parseDockerInspectEnv(run([
@@ -7824,80 +7874,89 @@ function renderHostTable(rows, { showReason = !1, showExpected = !1 } = {}) {
 	})));
 }
 //#endregion
-//#region core/lib/log/haproxy-log-parser.ts
-const logPattern = /^\[.*?\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+\((\w+)\)\s+"([^"]+)"\s*(\S*)/;
-/**
-* Parse log text into structured entries.
-*/
-function parseEntries(logText) {
-	let entries = [];
-	for (let line of logText.split("\n")) {
-		let m = line.match(logPattern);
-		if (m) {
-			let [, decision, ruleType, hostPort, reason] = m, colonIdx = hostPort.lastIndexOf(":"), host, port;
-			colonIdx > 0 ? (host = hostPort.substring(0, colonIdx), port = hostPort.substring(colonIdx + 1)) : (host = hostPort, port = "0"), entries.push({
-				decision,
-				ruleType,
-				host,
-				port,
-				reason: reason || "-"
-			});
-		}
-	}
-	return entries;
+//#region core/lib/log/aggregate.ts
+function compareAggregated(a, b) {
+	return b.count - a.count || (a.host < b.host ? -1 : +(a.host > b.host)) || Number(a.port) - Number(b.port);
 }
-/**
-* True iff logText contains at least one non-blank line that is not a
-* buildcage-decision line. A genuine HAProxy process always produces some
-* such content (its own startup/notice output, merged into this same log
-* via the s6 pipeline) before any traffic occurs, regardless of whether
-* any connection was ever blocked. A log consisting only of forged/replayed
-* decision lines — or nothing at all — lacks this, which is a signal (not
-* a guarantee) that the log may have been tampered with rather than
-* reflecting a real run.
-*/
-function hasNonBuildcageContent(logText) {
-	return logText.split("\n").some((line) => line.trim() !== "" && !logPattern.test(line));
+/** Streaming counterpart to aggregate(): folds one entry at a time into a
+*  running Map, bounding memory by the number of unique combinations seen
+*  rather than by input length. */
+function createIncrementalAggregator() {
+	let map = /* @__PURE__ */ new Map();
+	return {
+		add(entry) {
+			let key = `${entry.host}\t${entry.port}\t${entry.ruleType}\t${entry.reason}`, existing = map.get(key);
+			existing ? existing.count++ : map.set(key, {
+				...entry,
+				count: 1
+			});
+		},
+		toSortedArray() {
+			return [...map.values()].sort(compareAggregated);
+		}
+	};
 }
 //#endregion
-//#region core/lib/log/aggregate.ts
+//#region core/lib/log/haproxy-log-parser.ts
 /**
-* Aggregate log entries by (host, port, ruleType, reason) with counts, sorted
-* descending.
+* Log parsing library for HAProxy buildcage logs. aggregate() lives
+* separately in core/lib/log/aggregate.js and is not re-exported here.
 */
-function aggregate(filtered) {
-	let map = {};
-	for (let e of filtered) {
-		let key = `${e.host}\t${e.port}\t${e.ruleType}\t${e.reason}`;
-		map[key] = (map[key] || 0) + 1;
-	}
-	return Object.keys(map).map((key) => {
-		let [host, portStr, ruleType, reason] = key.split("	");
-		return {
+const logPattern = /^\[.*?\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+\((\w+)\)\s+"([^"]+)"\s*(\S*)/;
+/**
+* Single forward pass over the log: matching lines fold directly into
+* incremental aggregators (never collected into a flat array first), and
+* non-matching, non-blank lines flip hasNonBuildcageContent.
+*
+* A genuine HAProxy process always emits some non-buildcage-format output
+* of its own before any traffic occurs. A log with nothing but
+* forged/replayed decision lines — or nothing at all — lacks that, which is
+* a signal (not a guarantee) of tampering.
+*
+* `isAudit` picks which decision counts as "passed" (AUDIT vs ALLOWED); the
+* other one, if it somehow appears, is dropped rather than aggregated.
+*/
+async function scanHaproxyLog(lines, isAudit) {
+	let passed = createIncrementalAggregator(), blocked = createIncrementalAggregator(), passedDecision = isAudit ? "AUDIT" : "ALLOWED", blockedCount = 0, hasNonBuildcageContent = !1;
+	for await (let line of lines) {
+		let m = line.match(logPattern);
+		if (!m) {
+			line.trim() !== "" && (hasNonBuildcageContent = !0);
+			continue;
+		}
+		let [, decision, ruleType, hostPort, reason] = m, colonIdx = hostPort.lastIndexOf(":"), host, port;
+		colonIdx > 0 ? (host = hostPort.substring(0, colonIdx), port = hostPort.substring(colonIdx + 1)) : (host = hostPort, port = "0");
+		let entry = {
 			host,
-			port: portStr,
+			port,
 			ruleType,
-			reason,
-			count: map[key]
+			reason: reason || "-"
 		};
-	}).sort((a, b) => b.count - a.count || (a.host < b.host ? -1 : +(a.host > b.host)) || Number(a.port) - Number(b.port));
+		decision === passedDecision ? passed.add(entry) : decision === "BLOCKED" && (blocked.add(entry), blockedCount++);
+	}
+	return {
+		passed: passed.toSortedArray(),
+		blocked: blocked.toSortedArray(),
+		blockedCount,
+		hasNonBuildcageContent
+	};
 }
 //#endregion
 //#region core/lib/report/build-transparent-report-data.ts
 /**
 * Pure — no I/O; callers (report-action.node.ts, run/src/lib/report.ts)
-* fetch logText/parameters themselves. An empty logText naturally yields
+* fetch lines/parameters themselves. An empty input naturally yields
 * passed:[]/blocked:[]/blockedCount:0, so no special-case branch is needed.
 */
-function buildTransparentReportData(logText, parameters) {
-	let isAudit = parameters.mode === "audit", entries = parseEntries(logText), blockedCount = entries.filter((e) => e.decision === "BLOCKED").length, blocked = annotateKnownBlocked(aggregate(entries.filter((e) => e.decision === "BLOCKED")), parameters.knownBlockedRules);
+async function buildTransparentReportData(lines, parameters) {
+	let { passed, blocked: blockedRawRows, blockedCount, hasNonBuildcageContent } = await scanHaproxyLog(lines, parameters.mode === "audit");
 	return {
 		engine: "transparent",
 		parameters,
-		passed: aggregate(isAudit ? entries.filter((e) => e.decision === "AUDIT") : entries.filter((e) => e.decision === "ALLOWED")),
-		blocked,
+		passed,
+		blocked: annotateKnownBlocked(blockedRawRows, parameters.knownBlockedRules),
 		blockedCount,
-		logLooksPlausible: hasNonBuildcageContent(logText)
+		logLooksPlausible: hasNonBuildcageContent
 	};
 }
 /**
@@ -7906,7 +7965,7 @@ function buildTransparentReportData(logText, parameters) {
 * so it fetches the raw log and calls the shared builder in-process.
 */
 function fetchReport(containerName, parameters) {
-	return buildTransparentReportData(createDocker().readFile(containerName, "/var/log/haproxy/current"), parameters);
+	return buildTransparentReportData(createDocker().readFileLines(containerName, "/var/log/haproxy/current"), parameters);
 }
 function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand } = {}) {
 	let heading = `Outbound Traffic Report${stepLabel ? ` — ${stepLabel}` : ""}`, isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, markdown = `## ${heading} (${report.parameters.mode} mode)\n\n`;
@@ -8073,7 +8132,7 @@ async function main() {
 		}, containerName);
 	} finally {
 		try {
-			writeReport(fetchReport(containerName, {
+			writeReport(await fetchReport(containerName, {
 				mode: env.INPUT_PROXY_MODE || "restrict",
 				allowedHttpsRules: rules.httpsRules,
 				allowedHttpRules: rules.httpRules,

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -16,9 +16,8 @@ const LOG_FILE = "/var/log/haproxy/current";
  * has no version-skew concern of its own (one pinned version end to end),
  * so it fetches the raw log and calls the shared builder in-process.
  */
-export function fetchReport(containerName: string, parameters: GenReportParameters): Report {
-  const logText = createDocker().readFile(containerName, LOG_FILE);
-  return buildTransparentReportData(logText, parameters);
+export function fetchReport(containerName: string, parameters: GenReportParameters): Promise<Report> {
+  return buildTransparentReportData(createDocker().readFileLines(containerName, LOG_FILE), parameters);
 }
 
 export interface ReportRenderContext {

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -249,7 +249,7 @@ async function main(): Promise<void> {
     }, containerName);
   } finally {
     try {
-      const report = fetchReport(containerName, {
+      const report = await fetchReport(containerName, {
         mode: env.INPUT_PROXY_MODE || "restrict",
         allowedHttpsRules: rules.httpsRules,
         allowedHttpRules: rules.httpRules,

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -37,7 +37,7 @@ function collectBuilds(docker: Docker, containerId: string): VertexAllowedEntry[
   }
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const containerId = process.argv[2];
   if (!containerId) {
     throw new Error("Usage: report-action.js <container-id>");
@@ -45,10 +45,8 @@ function main(): void {
 
   const docker = createDocker();
   const parameters = buildReportParameters(docker.readEnv(containerId));
-  const logText = docker.readFile(containerId, LOG_FILE);
   const builds = collectBuilds(docker, containerId);
-
-  const report = buildExplicitReportData(logText, builds, parameters);
+  const report = await buildExplicitReportData(docker.readFileLines(containerId, LOG_FILE), builds, parameters);
 
   for (const line of wrapLogGroup("HTTP Proxy communication logs", renderCommunicationDetails(report.proxyLogs.builds, report.proxyLogs.denied))) {
     console.log(line);
@@ -71,9 +69,7 @@ function main(): void {
   emitBlockedOutcome(report, { failOnBlocked, summaryFile });
 }
 
-try {
-  main();
-} catch (e) {
+main().catch((e) => {
   console.log(`::error::Unexpected error in report-action: ${errorMessage(e)}`);
   process.exit(1);
-}
+});

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -17,7 +17,7 @@ import { errorMessage } from "../../../../core/lib/general/error-message.ts";
 
 const LOG_FILE = "/var/log/haproxy/current";
 
-function main(): void {
+async function main(): Promise<void> {
   const containerId = process.argv[2];
   if (!containerId) {
     throw new Error("Usage: report-action.js <container-id>");
@@ -25,9 +25,7 @@ function main(): void {
 
   const docker = createDocker();
   const parameters = buildReportParameters(docker.readEnv(containerId));
-  const logText = docker.readFile(containerId, LOG_FILE);
-
-  const report = buildTransparentReportData(logText, parameters);
+  const report = await buildTransparentReportData(docker.readFileLines(containerId, LOG_FILE), parameters);
 
   const markdown = renderReportMarkdown(
     report,
@@ -46,9 +44,7 @@ function main(): void {
   emitBlockedOutcome(report, { failOnBlocked, summaryFile });
 }
 
-try {
-  main();
-} catch (e) {
+main().catch((e) => {
   console.log(`::error::Unexpected error in report-action: ${errorMessage(e)}`);
   process.exit(1);
-}
+});


### PR DESCRIPTION
## Summary

Reading a proxy's traffic log meant buffering the whole file into memory as one string, then re-scanning it multiple times (up to three separate passes across the two engines) to extract decision lines and check for signs of tampering. A build that hit the same blocked/allowed host many times — a realistic worst case, e.g. a dependency-install retry loop against one disallowed host — risked exceeding the buffer outright, and simply parsing into a flat list first wouldn't have fixed that either, since memory would still grow with the number of raw lines.

## Changes

- Read the proxy's traffic log as a stream instead of buffering the whole file into memory.
- Aggregate matching lines into their host/port/rule/reason counts as they're read, rather than collecting them into a list first — memory is now bounded by the number of unique combinations seen, not by line count.
- Compute the tamper-detection signal (whether the log shows any trace of a real proxy run) in the same pass, so the log only needs a single forward scan instead of several.
- Leave the explicit engine's per-build breakdown (sourced from `buildctl`, not the traffic log) as-is, since it's bounded by build structure rather than traffic volume and requires correlating data across the whole input in a way that doesn't fit a single forward pass.