### PR TITLE
docs: drop the unused step id and self-hosting cruft from setup examples

### DIFF
--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -10,20 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Uncomment when self-hosting under a private GHCR package; the public
-      # dash14/buildcage image is pulled anonymously and needs no login.
-      # - name: Login to GHCR
-      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Start Buildcage builder
-        # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>
         uses: dash14/buildcage/setup@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           proxy_mode: audit
@@ -55,5 +44,4 @@ jobs:
 
       - name: Show proxy report
         if: always()
-        # For self-hosting, replace with: <your-org>/buildcage/report@<SHA>
         uses: dash14/buildcage/report@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4

--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -38,9 +38,6 @@ jobs:
           context: /tmp/build-context
           push: false
           no-cache: true
-        env:
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: Show proxy report
         if: always()

--- a/.github/workflows/example-explicit.yml
+++ b/.github/workflows/example-explicit.yml
@@ -46,9 +46,6 @@ jobs:
           context: /tmp/build-context
           push: false
           no-cache: true
-        env:
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: Show proxy report
         if: always()

--- a/.github/workflows/example-explicit.yml
+++ b/.github/workflows/example-explicit.yml
@@ -10,20 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Uncomment when self-hosting under a private GHCR package; the public
-      # dash14/buildcage image is pulled anonymously and needs no login.
-      # - name: Login to GHCR
-      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Start Buildcage builder
-        # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>
         uses: dash14/buildcage/setup@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           proxy_mode: restrict
@@ -63,7 +52,6 @@ jobs:
 
       - name: Show proxy report
         if: always()
-        # For self-hosting, replace with: <your-org>/buildcage/report@<SHA>
         uses: dash14/buildcage/report@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           fail_on_blocked: false

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -42,9 +42,6 @@ jobs:
           context: /tmp/build-context
           push: false
           no-cache: true
-        env:
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: Show proxy report
         if: always()

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -10,20 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Uncomment when self-hosting under a private GHCR package; the public
-      # dash14/buildcage image is pulled anonymously and needs no login.
-      # - name: Login to GHCR
-      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Start Buildcage builder
-        # For self-hosting, replace with: <your-org>/buildcage/setup@<SHA>
         uses: dash14/buildcage/setup@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           proxy_mode: restrict
@@ -59,7 +48,6 @@ jobs:
 
       - name: Show proxy report
         if: always()
-        # For self-hosting, replace with: <your-org>/buildcage/report@<SHA>
         uses: dash14/buildcage/report@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           fail_on_blocked: false

--- a/.github/workflows/example-run-audit.yml
+++ b/.github/workflows/example-run-audit.yml
@@ -10,20 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Uncomment when self-hosting under a private GHCR package; the public
-      # dash14/buildcage image is pulled anonymously and needs no login.
-      # - name: Login to GHCR
-      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Discover required domains with the run action
-        # For self-hosting, replace with: <your-org>/buildcage/run@<SHA>
         uses: dash14/buildcage/run@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           proxy_mode: audit

--- a/.github/workflows/example-run-restrict.yml
+++ b/.github/workflows/example-run-restrict.yml
@@ -10,20 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # packages: read # Uncomment together with the login step below when self-hosting under a private GHCR package.
 
     steps:
-      # Uncomment when self-hosting under a private GHCR package; the public
-      # dash14/buildcage image is pulled anonymously and needs no login.
-      # - name: Login to GHCR
-      #   uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run tests with outbound network isolation
-        # For self-hosting, replace with: <your-org>/buildcage/run@<SHA>
         uses: dash14/buildcage/run@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
         with:
           proxy_mode: restrict

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ tool works the same way, including `docker/bake-action`: just point its `driver:
 
 ```yaml
 - name: Start Buildcage in audit mode
-  id: buildcage
   uses: dash14/buildcage/setup@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
   with:
     proxy_mode: audit  # Log every destination, block nothing
@@ -85,7 +84,6 @@ Copy these domain names into `allowed_https_rules` or `allowed_http_rules` for S
 
 ```yaml
 - name: Start Buildcage in restrict mode
-  id: buildcage
   uses: dash14/buildcage/setup@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
   with:
     proxy_mode: restrict  # Block every destination except the ones you allow

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,7 +6,6 @@ Starts the Buildcage builder container.
 
 ```yaml
 - name: Start Buildcage builder
-  id: buildcage
   uses: dash14/buildcage/setup@bdf40b4677db602b923c622f26ef09a210d2ebd7 # v2.2.4
   with:
     proxy_mode: restrict

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -85,7 +85,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Buildcage
-        id: buildcage
         uses: <your_org>/buildcage/setup@<40-char-sha> # vX.Y.Z
         with:
           proxy_mode: audit


### PR DESCRIPTION
## Summary

The Quick Start and reference examples had accumulated a few things that no longer served a purpose and made the snippets harder to read at a glance. `id: buildcage` on the setup step was never referenced anywhere — the setup action has no outputs, so it was dead weight left over from an earlier iteration. The example workflows also carried commented-out GHCR login steps and "For self-hosting, replace with..." notes inline, even though self-hosting already has its own dedicated guide; mixing that branch into the primary audit → restrict flow just added noise. Similarly, `DOCKER_BUILD_SUMMARY`/`DOCKER_BUILD_RECORD_UPLOAD` are deliberately set to suppress Docker's own build summary in the test/release workflows (so it doesn't crowd out Buildcage's own report), but in the example workflows — meant to be read as reference yml, not run for their Job Summary output — they were just unexplained clutter.

## Changes

- Remove the unused `id: buildcage` step id from the setup snippets in `README.md`, `docs/reference.md`, and `docs/self-hosting.md`.
- Drop the commented-out GHCR login step and "For self-hosting, replace with..." comments from all five `example-*.yml` workflows; self-hosting is already covered in `docs/self-hosting.md`.
- Drop the `DOCKER_BUILD_SUMMARY`/`DOCKER_BUILD_RECORD_UPLOAD` env vars from the three docker-build example workflows, keeping those snippets focused on what Buildcage itself needs.