### PR TITLE
feat: add ecapture-based HTTPS communication logs to the run action

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -401,8 +401,12 @@ jobs:
               fail_on_blocked: false
               run: |
                 sleep 5
-                wget -q -T 5 -O /dev/null http://example.com/
-                if wget -q -T 5 -O /dev/null http://example.net/ 2>&1; then
+                # HTTPS (not HTTP): exercises ecapture's HTTPS communication logs
+                # for a parallel step, so its report can be checked for
+                # cross-talk from step B's own traffic just as much as the
+                # network-level check below.
+                wget -q -T 5 -O /dev/null https://example.com/
+                if wget -q -T 5 -O /dev/null https://example.net/ 2>&1; then
                   echo "::error::cross-talk: example.net (step B's allowlist) was reachable from step A"; exit 1
                 fi
 
@@ -418,8 +422,8 @@ jobs:
               label: parallel-b
               fail_on_blocked: false
               run: |
-                wget -q -T 5 -O /dev/null http://example.net/
-                if wget -q -T 5 -O /dev/null http://example.com/ 2>&1; then
+                wget -q -T 5 -O /dev/null https://example.net/
+                if wget -q -T 5 -O /dev/null https://example.com/ 2>&1; then
                   echo "::error::cross-talk: example.com (step A's allowlist) was reachable from step B"; exit 1
                 fi
 

--- a/Makefile
+++ b/Makefile
@@ -244,8 +244,12 @@ test_integration_sandbox_linux: ## Run the run action's integration tests (needs
 	# TEMPORARY: diagnosing a CI-only cancellation right at this transition.
 	@echo "--- diagnostic: PID/process state before integration-test-concurrent.sh ---"
 	@cat /proc/sys/kernel/pid_max 2>&1 || true
-	@ps -eo pid,ppid,pgid,comm --sort=-pid 2>&1 | head -15 || true
+	@ps -eo pid,ppid,pgid,stat,wchan:32,comm --sort=-pid 2>&1 | head -15 || true
 	@ps -eo pid,ppid,pgid,comm 2>&1 | wc -l || true
+	@echo "--- ecapture process stacks (if accessible) ---"
+	@for p in $$(pgrep -x ecapture 2>/dev/null); do echo "== pid $$p =="; sudo -n cat /proc/$$p/stack 2>&1 || true; done
+	@echo "--- recent kernel log (dmesg, bpf/rcu/oom related) ---"
+	@sudo -n dmesg --time-format iso 2>&1 | tail -100 || true
 	@echo "--- end diagnostic ---"
 	@./run/test/integration-test-concurrent.sh
 	@./run/test/integration-test-known-blocked-rules.sh

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,11 @@ test_integration_sandbox_linux: ## Run the run action's integration tests (needs
 	@./run/test/integration-test-runner-temp.sh
 	@./run/test/integration-test-nested-mount-readonly.sh
 	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
+	@echo "--- diagnostic: resource usage before integration-test-concurrent.sh ---"
+	@df -h / /var/tmp 2>&1 || true
+	@free -h 2>&1 || true
+	@docker system df 2>&1 || true
+	@echo "--- end diagnostic ---"
 	@./run/test/integration-test-concurrent.sh
 	@./run/test/integration-test-known-blocked-rules.sh
 	@./run/test/integration-test-ecapture-terminates.sh

--- a/Makefile
+++ b/Makefile
@@ -232,24 +232,8 @@ clean_sandbox_dev: ## Stop and remove the sandbox dev-loop containers
 # Drives run/dist/main.cjs directly (a host command, not a Docker build).
 .PHONY: test_integration_sandbox_linux
 test_integration_sandbox_linux: ## Run the run action's integration tests (needs BUILDCAGE_LOCAL_IMAGE_REF and a test-hook build of run/dist/main.cjs)
-	@./run/test/integration-test-writable-dir.sh
-	@./run/test/integration-test-writable-disabled.sh
-	@./run/test/integration-test-defaults.sh
-	@./run/test/integration-test-seccomp.sh
-	@./run/test/integration-test-die-with-parent.sh
-	@./run/test/integration-test-fs-escape.sh
-	@./run/test/integration-test-runner-temp.sh
-	@./run/test/integration-test-nested-mount-readonly.sh
-	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
-	@echo "--- diagnostic: resource usage before integration-test-concurrent.sh ---"
-	@df -h / /var/tmp 2>&1 || true
-	@free -h 2>&1 || true
-	@docker system df 2>&1 || true
-	@echo "--- end diagnostic ---"
+	# TEMPORARY: isolated to just this one script to bisect a CI-only hang/cancellation -- restore the full list once resolved.
 	@./run/test/integration-test-concurrent.sh
-	@./run/test/integration-test-known-blocked-rules.sh
-	@./run/test/integration-test-ecapture-terminates.sh
-	@./run/test/integration-test-ecapture-hard-kill-recovery.sh
 
 # ---------------------------------------------------------------------------
 # example_{engine}_{mode} — smoke test against a plain Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,8 @@ test_integration_sandbox_linux: ## Run the run action's integration tests (needs
 	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
 	@./run/test/integration-test-concurrent.sh
 	@./run/test/integration-test-known-blocked-rules.sh
+	@./run/test/integration-test-ecapture-terminates.sh
+	@./run/test/integration-test-ecapture-hard-kill-recovery.sh
 
 # ---------------------------------------------------------------------------
 # example_{engine}_{mode} — smoke test against a plain Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,8 @@ test_integration_sandbox_linux: ## Run the run action's integration tests (needs
 	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
 	@./run/test/integration-test-concurrent.sh
 	@./run/test/integration-test-known-blocked-rules.sh
-	@./run/test/integration-test-ecapture-terminates.sh
-	@./run/test/integration-test-ecapture-hard-kill-recovery.sh
+	@timeout 120 ./run/test/integration-test-ecapture-terminates.sh
+	@timeout 180 ./run/test/integration-test-ecapture-hard-kill-recovery.sh
 
 # ---------------------------------------------------------------------------
 # example_{engine}_{mode} — smoke test against a plain Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -243,8 +243,8 @@ test_integration_sandbox_linux: ## Run the run action's integration tests (needs
 	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
 	@./run/test/integration-test-concurrent.sh
 	@./run/test/integration-test-known-blocked-rules.sh
-	@timeout 120 ./run/test/integration-test-ecapture-terminates.sh
-	@timeout 180 ./run/test/integration-test-ecapture-hard-kill-recovery.sh
+	@./run/test/integration-test-ecapture-terminates.sh
+	@./run/test/integration-test-ecapture-hard-kill-recovery.sh
 
 # ---------------------------------------------------------------------------
 # example_{engine}_{mode} — smoke test against a plain Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -232,8 +232,25 @@ clean_sandbox_dev: ## Stop and remove the sandbox dev-loop containers
 # Drives run/dist/main.cjs directly (a host command, not a Docker build).
 .PHONY: test_integration_sandbox_linux
 test_integration_sandbox_linux: ## Run the run action's integration tests (needs BUILDCAGE_LOCAL_IMAGE_REF and a test-hook build of run/dist/main.cjs)
-	# TEMPORARY: isolated to just this one script to bisect a CI-only hang/cancellation -- restore the full list once resolved.
+	@./run/test/integration-test-writable-dir.sh
+	@./run/test/integration-test-writable-disabled.sh
+	@./run/test/integration-test-defaults.sh
+	@./run/test/integration-test-seccomp.sh
+	@./run/test/integration-test-die-with-parent.sh
+	@./run/test/integration-test-fs-escape.sh
+	@./run/test/integration-test-runner-temp.sh
+	@./run/test/integration-test-nested-mount-readonly.sh
+	@./run/test/integration-test-non-runc-default-pseudofs-readonly.sh
+	# TEMPORARY: diagnosing a CI-only cancellation right at this transition.
+	@echo "--- diagnostic: PID/process state before integration-test-concurrent.sh ---"
+	@cat /proc/sys/kernel/pid_max 2>&1 || true
+	@ps -eo pid,ppid,pgid,comm --sort=-pid 2>&1 | head -15 || true
+	@ps -eo pid,ppid,pgid,comm 2>&1 | wc -l || true
+	@echo "--- end diagnostic ---"
 	@./run/test/integration-test-concurrent.sh
+	@./run/test/integration-test-known-blocked-rules.sh
+	@./run/test/integration-test-ecapture-terminates.sh
+	@./run/test/integration-test-ecapture-hard-kill-recovery.sh
 
 # ---------------------------------------------------------------------------
 # example_{engine}_{mode} — smoke test against a plain Dockerfile

--- a/core/lib/log/ecapture-log-parser.test.ts
+++ b/core/lib/log/ecapture-log-parser.test.ts
@@ -98,6 +98,32 @@ describe("scanEcaptureLog", () => {
     assert.equal(result[0].status, 200);
   });
 
+  it("flushes an earlier unresolved WRITE as unmatched when a second WRITE supersedes it (pipelining)", async () => {
+    const lines = [
+      ...block(100, 100, 4, "WRITE", ["GET /a HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(100, 100, 4, "WRITE", ["GET /b HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 200 OK\\r", "\\r"]),
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].url, "https://example.com/a");
+    assert.equal(result[0].status, undefined);
+    assert.equal(result[1].url, "https://example.com/b");
+    assert.equal(result[1].status, 200);
+  });
+
+  it("does not resolve the pending request on a 100 Continue, waiting for the real status instead", async () => {
+    const lines = [
+      ...block(100, 100, 4, "WRITE", ["PUT /upload HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 100 Continue\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 200 OK\\r", "\\r"]),
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].url, "https://example.com/upload");
+    assert.equal(result[0].status, 200);
+  });
+
   it("ignores non-matching lines outside any block", async () => {
     const result = await scanEcaptureLog(["some unrelated log line", ""]);
     assert.equal(result.length, 0);

--- a/core/lib/log/ecapture-log-parser.test.ts
+++ b/core/lib/log/ecapture-log-parser.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { scanEcaptureLog } from "./ecapture-log-parser.ts";
+
+function block(pid: number, tid: number, fd: number, direction: "WRITE" | "READ", lines: string[]): string[] {
+  return [
+    `2026-07-30T20:33:40Z INF [2026-07-30 20:33:40.359] PID:${pid} TID:${tid} Comm:curl FD:${fd} ${direction} (0 bytes):`,
+    ...lines,
+    " probe=OpenSSL",
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// scanEcaptureLog
+// ---------------------------------------------------------------------------
+describe("scanEcaptureLog", () => {
+  it("pairs a WRITE request with its following READ response", async () => {
+    const lines = [
+      ...block(100, 100, 4, "WRITE", ["GET / HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 200 OK\\r", "Content-Type: text/html\\r", "\\r"]),
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].method, "GET");
+    assert.equal(result[0].url, "https://example.com/");
+    assert.equal(result[0].status, 200);
+  });
+
+  it("keeps method/host/path/status only — headers and body never surface", async () => {
+    const lines = [
+      ...block(100, 100, 4, "WRITE", ["POST /login HTTP/1.1\\r", "Host: example.com\\r", "Authorization: Bearer secret-token\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 200 OK\\r", "\\r", "{\"token\":\"leaked-if-kept\"}"]),
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 1);
+    assert.deepEqual(Object.keys(result[0]).sort(), ["method", "status", "url"]);
+    assert.equal(JSON.stringify(result[0]).includes("secret-token"), false);
+    assert.equal(JSON.stringify(result[0]).includes("leaked-if-kept"), false);
+  });
+
+  it("separates two sequential keep-alive requests on the same connection", async () => {
+    const lines = [
+      ...block(100, 100, 4, "WRITE", ["GET /a HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 200 OK\\r", "\\r"]),
+      ...block(100, 100, 4, "WRITE", ["GET /b HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(100, 100, 4, "READ", ["HTTP/1.1 404 Not Found\\r", "\\r"]),
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].url, "https://example.com/a");
+    assert.equal(result[0].status, 200);
+    assert.equal(result[1].url, "https://example.com/b");
+    assert.equal(result[1].status, 404);
+  });
+
+  it("emits a WRITE with no matching READ, with status left undefined", async () => {
+    const lines = block(100, 100, 4, "WRITE", ["GET / HTTP/1.1\\r", "Host: example.com\\r", "\\r"]);
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].status, undefined);
+  });
+
+  it("ignores an HTTP/2 (HPACK-compressed) WRITE block instead of misparsing it", async () => {
+    const lines = block(100, 100, 4, "WRITE", ["PRI * HTTP/2.0\\r", "\\r", "SM\\r", "\\r", "\\x00\\x00\\x12\\x04\\x00\\x00garbage"]);
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 0);
+  });
+
+  it("ignores a WRITE block with a request line but no Host header", async () => {
+    const lines = block(100, 100, 4, "WRITE", ["GET / HTTP/1.1\\r", "User-Agent: curl\\r", "\\r"]);
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 0);
+  });
+
+  it("does not cross-match requests/responses from different PID/TID/FD", async () => {
+    const lines = [
+      ...block(100, 100, 4, "WRITE", ["GET /a HTTP/1.1\\r", "Host: example.com\\r", "\\r"]),
+      ...block(200, 200, 4, "READ", ["HTTP/1.1 200 OK\\r", "\\r"]),
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].status, undefined);
+  });
+
+  it("strips ANSI escape codes before matching", async () => {
+    const lines = [
+      "\x1b[90m2026-07-30T20:33:40Z\x1b[0m \x1b[32mINF\x1b[0m PID:100 TID:100 Comm:curl FD:4 WRITE (0 bytes):",
+      "GET / HTTP/1.1\\r",
+      "Host: example.com\\r",
+      "\\r",
+      " \x1b[36mprobe=\x1b[0mOpenSSL",
+      "PID:100 TID:100 Comm:curl FD:4 READ (0 bytes):",
+      "HTTP/1.1 200 OK\\r",
+      "\\r",
+      " probe=OpenSSL",
+    ];
+    const result = await scanEcaptureLog(lines);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].status, 200);
+  });
+
+  it("ignores non-matching lines outside any block", async () => {
+    const result = await scanEcaptureLog(["some unrelated log line", ""]);
+    assert.equal(result.length, 0);
+  });
+});
+
+reportResults();

--- a/core/lib/log/ecapture-log-parser.ts
+++ b/core/lib/log/ecapture-log-parser.ts
@@ -1,0 +1,104 @@
+/**
+ * Log parsing library for ecapture's `tls -m text` output (see
+ * docs/security.md's Run Action HTTPS communication logs section). Unlike
+ * haproxy-log-parser.ts's single-line-per-decision format, each captured
+ * event spans multiple lines: a "PID:.. TID:.. Comm:.. FD:.. WRITE|READ (N
+ * bytes):" header followed by the raw bytes ecapture observed, terminated by
+ * a "probe=..." annotation line. A WRITE block holds the request (an HTTP/1.x
+ * request line plus a Host header); the following READ block on the same
+ * PID+TID+FD holds the response (an HTTP/1.x status line). HTTP/2 traffic's
+ * HPACK-compressed headers don't match either pattern and are silently
+ * skipped — never emitted as (mis-)parsed data.
+ *
+ * Only method/host/path/status are ever extracted into AllowedRequest — the
+ * raw block content (which can include Authorization headers or response
+ * bodies) is discarded once matched against, never retained or exposed. This
+ * is the only point standing between ecapture's captured plaintext and
+ * anything this data is later rendered into (a GitHub Job Summary), so it
+ * must stay narrow.
+ */
+import type { AllowedRequest } from "./vertex-log.ts";
+
+const ansiEscapePattern = /\x1b\[[0-9;]*m/g;
+const blockHeaderPattern = /PID:(\d+)\s+TID:(\d+)\s+Comm:\S+\s+FD:(\d+)\s+(WRITE|READ)\s+\(\d+\s+bytes\):/;
+const blockTerminatorPattern = /^\s*probe=/i;
+const requestLinePattern = /^(\S+)\s+(\S+)\s+HTTP\/1\.[01]/;
+const hostHeaderPattern = /^Host:\s*([^\s\\]+)/i;
+const responseLinePattern = /^HTTP\/1\.[01]\s+(\d{3})/;
+
+interface PendingRequest {
+  method: string;
+  path: string;
+  host: string;
+}
+
+interface Block {
+  key: string;
+  direction: "WRITE" | "READ";
+  lines: string[];
+}
+
+/**
+ * Single forward pass over ecapture's text-mode output. Returns every
+ * request/response pair it could reconstruct, in the order captured. A WRITE
+ * block with no matching READ (connection reset, blocked before a response,
+ * end of log) is still emitted, with `status` left undefined — mirroring how
+ * the explicit engine's own AllowedRequest already treats a missing status.
+ *
+ * Synchronous (unlike haproxy-log-parser.ts's scanHaproxyLog): ecapture's log
+ * is always read directly off the runner host's own filesystem (see
+ * run/src/lib/isolated-exec.ts's readEcaptureLog), never streamed from a
+ * `docker exec`, so there's no AsyncIterable source to support here.
+ */
+export function scanEcaptureLog(lines: Iterable<string>): AllowedRequest[] {
+  const pending = new Map<string, PendingRequest>();
+  const entries: AllowedRequest[] = [];
+  let current: Block | null = null;
+
+  const finalizeCurrent = () => {
+    if (!current) return;
+    const block = current;
+    current = null;
+    if (block.direction === "WRITE") {
+      const reqMatch = block.lines[0]?.match(requestLinePattern);
+      if (!reqMatch) return;
+      const host = block.lines.slice(1).map((l) => l.match(hostHeaderPattern)?.[1]).find(Boolean);
+      if (!host) return;
+      pending.set(block.key, { method: reqMatch[1], path: reqMatch[2], host });
+    } else {
+      const resMatch = block.lines[0]?.match(responseLinePattern);
+      if (!resMatch) return;
+      const req = pending.get(block.key);
+      if (!req) return;
+      pending.delete(block.key);
+      entries.push({ method: req.method, url: `https://${req.host}${req.path}`, status: Number(resMatch[1]) });
+    }
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(ansiEscapePattern, "");
+    const headerMatch = line.match(blockHeaderPattern);
+    if (headerMatch) {
+      finalizeCurrent();
+      const [, pid, tid, fd, direction] = headerMatch;
+      current = { key: `${pid}:${tid}:${fd}`, direction: direction as "WRITE" | "READ", lines: [] };
+      continue;
+    }
+    if (!current) continue;
+    if (blockTerminatorPattern.test(line)) {
+      finalizeCurrent();
+      continue;
+    }
+    current.lines.push(line);
+  }
+  finalizeCurrent();
+
+  // Requests that never saw a matching response (still in `pending`) are
+  // surfaced too, rather than silently dropped, with no status — appended
+  // after every matched pair since insertion order (a Map) is chronological.
+  for (const { method, host, path } of pending.values()) {
+    entries.push({ method, url: `https://${host}${path}` });
+  }
+
+  return entries;
+}

--- a/core/lib/log/ecapture-log-parser.ts
+++ b/core/lib/log/ecapture-log-parser.ts
@@ -1,21 +1,13 @@
 /**
- * Log parsing library for ecapture's `tls -m text` output (see
- * docs/security.md's Run Action HTTPS communication logs section). Unlike
- * haproxy-log-parser.ts's single-line-per-decision format, each captured
- * event spans multiple lines: a "PID:.. TID:.. Comm:.. FD:.. WRITE|READ (N
- * bytes):" header followed by the raw bytes ecapture observed, terminated by
- * a "probe=..." annotation line. A WRITE block holds the request (an HTTP/1.x
- * request line plus a Host header); the following READ block on the same
- * PID+TID+FD holds the response (an HTTP/1.x status line). HTTP/2 traffic's
- * HPACK-compressed headers don't match either pattern and are silently
- * skipped — never emitted as (mis-)parsed data.
+ * Parses ecapture's `tls -m text` output (see docs/security.md's Run Action
+ * HTTPS communication logs section). Each event spans multiple lines: a
+ * "PID:.. TID:.. Comm:.. FD:.. WRITE|READ (N bytes):" header, the raw bytes,
+ * then a "probe=..." terminator. A WRITE block holds the request line + Host
+ * header; the matching READ (same PID+TID+FD) holds the response status
+ * line. Non-matching blocks (HTTP/2, etc.) are silently skipped.
  *
- * Only method/host/path/status are ever extracted into AllowedRequest — the
- * raw block content (which can include Authorization headers or response
- * bodies) is discarded once matched against, never retained or exposed. This
- * is the only point standing between ecapture's captured plaintext and
- * anything this data is later rendered into (a GitHub Job Summary), so it
- * must stay narrow.
+ * Only method/host/path/status ever leave the parser — the only point
+ * between ecapture's captured plaintext and the Job Summary.
  */
 import type { AllowedRequest } from "./vertex-log.ts";
 
@@ -39,16 +31,8 @@ interface Block {
 }
 
 /**
- * Single forward pass over ecapture's text-mode output. Returns every
- * request/response pair it could reconstruct, in the order captured. A WRITE
- * block with no matching READ (connection reset, blocked before a response,
- * end of log) is still emitted, with `status` left undefined — mirroring how
- * the explicit engine's own AllowedRequest already treats a missing status.
- *
- * Synchronous (unlike haproxy-log-parser.ts's scanHaproxyLog): ecapture's log
- * is always read directly off the runner host's own filesystem (see
- * run/src/lib/isolated-exec.ts's readEcaptureLog), never streamed from a
- * `docker exec`, so there's no AsyncIterable source to support here.
+ * One forward pass over ecapture's text-mode output, in capture order. A
+ * WRITE with no matching READ is still emitted, with `status` undefined.
  */
 export function scanEcaptureLog(lines: Iterable<string>): AllowedRequest[] {
   const pending = new Map<string, PendingRequest>();
@@ -93,9 +77,7 @@ export function scanEcaptureLog(lines: Iterable<string>): AllowedRequest[] {
   }
   finalizeCurrent();
 
-  // Requests that never saw a matching response (still in `pending`) are
-  // surfaced too, rather than silently dropped, with no status — appended
-  // after every matched pair since insertion order (a Map) is chronological.
+  // Unmatched requests still surface, with no status.
   for (const { method, host, path } of pending.values()) {
     entries.push({ method, url: `https://${host}${path}` });
   }

--- a/core/lib/log/ecapture-log-parser.ts
+++ b/core/lib/log/ecapture-log-parser.ts
@@ -48,14 +48,19 @@ export function scanEcaptureLog(lines: Iterable<string>): AllowedRequest[] {
       if (!reqMatch) return;
       const host = block.lines.slice(1).map((l) => l.match(hostHeaderPattern)?.[1]).find(Boolean);
       if (!host) return;
+      // Flush a pipelined, still-pending request as unmatched before it's superseded.
+      const superseded = pending.get(block.key);
+      if (superseded) entries.push({ method: superseded.method, url: `https://${superseded.host}${superseded.path}` });
       pending.set(block.key, { method: reqMatch[1], path: reqMatch[2], host });
     } else {
       const resMatch = block.lines[0]?.match(responseLinePattern);
       if (!resMatch) return;
+      const status = Number(resMatch[1]);
+      if (status >= 100 && status < 200) return; // interim (e.g. 100 Continue) — the real response is still to come
       const req = pending.get(block.key);
       if (!req) return;
       pending.delete(block.key);
-      entries.push({ method: req.method, url: `https://${req.host}${req.path}`, status: Number(resMatch[1]) });
+      entries.push({ method: req.method, url: `https://${req.host}${req.path}`, status });
     }
   };
 

--- a/core/lib/report/command-log.test.ts
+++ b/core/lib/report/command-log.test.ts
@@ -192,12 +192,21 @@ describe("renderHttpLogList", () => {
     assert.equal(
       renderHttpLogList(entries),
       "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n" +
+        "<sub>*Note: captured only for HTTPS traffic that was allowed, from processes linked against " +
+        "OpenSSL/BoringSSL/GnuTLS/NSS — other TLS stacks (e.g. Rust's rustls, Go's crypto/tls) and " +
+        "blocked connections never appear here.*</sub>\n\n" +
         "```\n" +
         "- GET https://example.com/a -> 200\n" +
         "- POST https://example.com/b -> 404\n" +
         "```\n" +
         "</details>\n"
     );
+  });
+
+  it("includes a caveat note about OpenSSL-only coverage and allowed-only traffic", () => {
+    const md = renderHttpLogList([{ method: "GET", url: "https://example.com/", status: 200 }]);
+    assert.match(md, /OpenSSL\/BoringSSL\/GnuTLS\/NSS/);
+    assert.match(md, /blocked connections\s+never appear here/);
   });
 
   it("an entry with no status omits the arrow", () => {

--- a/core/lib/report/command-log.test.ts
+++ b/core/lib/report/command-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { renderCommunicationDetails } from "./command-log.ts";
+import { renderCommunicationDetails, renderHttpLogList } from "./command-log.ts";
 
 function wrap(body: string) {
   return "\n<details>\n<summary>💬 Communication details</summary>\n\n" + body + "</details>\n";
@@ -174,6 +174,40 @@ describe("renderCommunicationDetails", () => {
       const md = renderCommunicationDetails([[vertex]], []);
       assert.match(md, /\* RUN echo hello-world\.txt\n/);
     });
+  });
+});
+
+describe("renderHttpLogList", () => {
+  it("null/undefined/empty → empty string", () => {
+    assert.equal(renderHttpLogList(null), "");
+    assert.equal(renderHttpLogList(undefined), "");
+    assert.equal(renderHttpLogList([]), "");
+  });
+
+  it("renders a flat, time-ordered list with no per-vertex grouping", () => {
+    const entries = [
+      { method: "GET", url: "https://example.com/a", status: 200 },
+      { method: "POST", url: "https://example.com/b", status: 404 },
+    ];
+    assert.equal(
+      renderHttpLogList(entries),
+      "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n" +
+        "```\n" +
+        "- GET https://example.com/a -> 200\n" +
+        "- POST https://example.com/b -> 404\n" +
+        "```\n" +
+        "</details>\n"
+    );
+  });
+
+  it("an entry with no status omits the arrow", () => {
+    const md = renderHttpLogList([{ method: "GET", url: "https://example.com/" }]);
+    assert.match(md, /- GET https:\/\/example\.com\/\n/);
+  });
+
+  it("escapes markdown-significant characters in the URL", () => {
+    const md = renderHttpLogList([{ method: "GET", url: "https://example.com/[id]", status: 200 }]);
+    assert.match(md, /- GET https:\/\/example\.com\/\\\[id\\\] -> 200/);
   });
 });
 

--- a/core/lib/report/command-log.ts
+++ b/core/lib/report/command-log.ts
@@ -76,6 +76,10 @@ export function renderHttpLogList(entries: AllowedRequest[] | null | undefined):
   if (!entries || entries.length === 0) return "";
 
   let md = "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n";
+  md +=
+    "<sub>*Note: captured only for HTTPS traffic that was allowed, from processes linked against " +
+    "OpenSSL/BoringSSL/GnuTLS/NSS — other TLS stacks (e.g. Rust's rustls, Go's crypto/tls) and " +
+    "blocked connections never appear here.*</sub>\n\n";
   md += "```\n";
   for (const entry of entries) md += `${renderRequestLine(entry)}\n`;
   md += "```\n";

--- a/core/lib/report/command-log.ts
+++ b/core/lib/report/command-log.ts
@@ -69,13 +69,9 @@ function renderRequestLine({ method, url, status }: AllowedRequest): string {
   return status === undefined ? line : `${line} -> ${status}`;
 }
 
-/**
- * Render the `run` action's ecapture-derived HTTPS communication logs as a
- * collapsed markdown section, or "" if there's nothing to show. Unlike
- * renderCommunicationDetails above, entries aren't grouped per RUN
- * step/vertex — ecapture's log carries no such attribution, so this is a
- * flat, time-ordered list of every request it could reconstruct.
- */
+/** Renders the `run` action's ecapture-derived HTTPS communication logs as a
+ *  collapsed section, or "" if empty. Flat, time-ordered — unlike
+ *  renderCommunicationDetails, there's no per-vertex attribution here. */
 export function renderHttpLogList(entries: AllowedRequest[] | null | undefined): string {
   if (!entries || entries.length === 0) return "";
 

--- a/core/lib/report/command-log.ts
+++ b/core/lib/report/command-log.ts
@@ -69,6 +69,24 @@ function renderRequestLine({ method, url, status }: AllowedRequest): string {
   return status === undefined ? line : `${line} -> ${status}`;
 }
 
+/**
+ * Render the `run` action's ecapture-derived HTTPS communication logs as a
+ * collapsed markdown section, or "" if there's nothing to show. Unlike
+ * renderCommunicationDetails above, entries aren't grouped per RUN
+ * step/vertex — ecapture's log carries no such attribution, so this is a
+ * flat, time-ordered list of every request it could reconstruct.
+ */
+export function renderHttpLogList(entries: AllowedRequest[] | null | undefined): string {
+  if (!entries || entries.length === 0) return "";
+
+  let md = "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n";
+  md += "```\n";
+  for (const entry of entries) md += `${renderRequestLine(entry)}\n`;
+  md += "```\n";
+  md += "</details>\n";
+  return md;
+}
+
 // Escapes the markdown syntax characters that could actually alter rendering
 // in the contexts this module embeds text into (bold headers, list items,
 // italic captions): backslash (escaped first, so it can't double-escape the

--- a/core/lib/report/report-data.ts
+++ b/core/lib/report/report-data.ts
@@ -1,6 +1,6 @@
 import type { HostTableRow } from "./host-table.ts";
 import type { AnnotatedBlockedRow } from "./known-blocked.ts";
-import type { VertexAllowedEntry } from "../log/vertex-log.ts";
+import type { AllowedRequest, VertexAllowedEntry } from "../log/vertex-log.ts";
 
 /** Echoed back verbatim rather than re-derived — only the container's own
  *  env (or, for run, its own action input) reflects what was configured. */
@@ -38,6 +38,13 @@ export interface ReportDataCommon {
 
 export interface TransparentReportData extends ReportDataCommon {
   engine: "transparent";
+  /** Best-effort HTTPS communication logs from ecapture (`run` action only,
+   *  as of now — see docs/security.md's Run Action section). A flat,
+   *  chronological list rather than per-RUN-step-grouped like explicit's
+   *  proxyLogs.builds: there's no vertex/span identifier to attribute
+   *  entries with here. Undefined (not just empty) when ecapture wasn't run
+   *  at all, distinguishing "no HTTPS traffic observed" from "not captured". */
+  httpLogs?: AllowedRequest[];
 }
 
 /** Discriminated union (keyed on `engine`) rather than an optional field,

--- a/core/lib/report/report-data.ts
+++ b/core/lib/report/report-data.ts
@@ -38,12 +38,8 @@ export interface ReportDataCommon {
 
 export interface TransparentReportData extends ReportDataCommon {
   engine: "transparent";
-  /** Best-effort HTTPS communication logs from ecapture (`run` action only,
-   *  as of now — see docs/security.md's Run Action section). A flat,
-   *  chronological list rather than per-RUN-step-grouped like explicit's
-   *  proxyLogs.builds: there's no vertex/span identifier to attribute
-   *  entries with here. Undefined (not just empty) when ecapture wasn't run
-   *  at all, distinguishing "no HTTPS traffic observed" from "not captured". */
+  /** Best-effort HTTPS communication logs from ecapture (`run` action only —
+   *  see docs/security.md). Undefined when ecapture wasn't run at all. */
   httpLogs?: AllowedRequest[];
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -152,7 +152,16 @@ order it actually happens. For the user-facing behavior and threat model, see
    - Extracted fresh into this step's own scratch directory on every invocation (no shared,
      cross-step/cross-job cache), so each `run:` step is fully independent and everything extracted
      is torn down with the scratch directory afterward.
-4. Build an OCI runtime bundle (`config.json`) describing the sandbox (`isolated-exec.ts`).
+4. Pre-create the cgroup runc will use for the isolated command (`isolated-exec.ts`).
+   - The path (`cgroupInnerPath`/`cgroupFsPath`) is derived purely from the container name, not
+     runc's own default cgroup placement (which depends on whatever cgroup the invoking process
+     happens to be in at the time, and isn't reliably knowable in advance). Created via `sudo mkdir
+     -p` since ecapture's own `--cgroup_path` validation (step 7) needs it to already exist.
+   - Recorded to GITHUB_STATE (`ecapture_cgroup_path`) so `post.ts` can remove it if the step is
+     killed outright before reaching its own cleanup (step 10).
+   - Best-effort: a failure here is a warning, and both the OCI config below and ecapture (step 7)
+     fall back to runc's own default cgroup placement / unscoped capture instead.
+5. Build an OCI runtime bundle (`config.json`) describing the sandbox (`isolated-exec.ts`).
    - Starts from `runc`'s own default spec, then patches in: a root filesystem pointing at a
      not-yet-created bind-mount directory, made read-only (every real host mount point is forced
      individually read-only outside workdir/home/tmp/RUNNER_TEMP/writable, since the top-level
@@ -167,7 +176,9 @@ order it actually happens. For the user-facing behavior and threat model, see
      that directory (or an ancestor of it) is rejected outright rather than silently accepted. The
      sandbox's real host view (its own `/` and every nested mount) is untouched and stays read-only
      outside the writable set.
-5. Stage the sandbox's network and filesystem as root, via `sudo -n` (`run-isolated.sh`).
+   - `linux.cgroupsPath` is set to step 4's cgroup path when that step succeeded, telling runc
+     exactly where to place the container's cgroup instead of leaving it to runc's own default.
+6. Stage the sandbox's network and filesystem as root, via `sudo -n` (`run-isolated.sh`).
    - Re-execs itself into a fresh, private mount namespace before touching anything else, so the
      mount work below is invisible to every other `run:` step running concurrently on the same
      host.
@@ -181,39 +192,45 @@ order it actually happens. For the user-facing behavior and threat model, see
      proxy's fixed gateway address directly — no bridge, since this is always a 1:1 connection
      (one sandbox, one proxy) and a plain named interface is enough for `init-iptables`'s
      `-i sandbox0` rule (added at container startup) to match once this device appears later.
-6. Start ecapture in the background, just before running the sandboxed command (`isolated-exec.ts`).
+7. Start ecapture in the background, just before running the sandboxed command (`isolated-exec.ts`).
    - Extracted onto the runner host the same way as `runc`/`gen-seccomp-profile` in step 3 (`docker
-     cp` from the proxy image, run natively there). Its capture window is exactly the isolated
-     command's lifetime: started here, stopped right after step 7 below returns.
+     cp` from the proxy image, run natively there). Scoped to step 4's cgroup (`--cgroup_path`) when
+     that step succeeded. Its capture window is exactly the isolated command's lifetime: started
+     here, stopped right after step 8 below returns.
+   - Its pid is recorded to GITHUB_STATE (`ecapture_pid`) so `post.ts` can find and stop it if the
+     step is killed outright before reaching its own cleanup (step 10).
    - Best-effort only — a failure to extract or start it is reported as a warning annotation, never
      a `SandboxError` that would abort the step itself. See [HTTPS Communication Logs
      (ecapture)](./security.md#https-communication-logs-ecapture) in Security Details for what this
      does and doesn't capture.
-7. Run the sandboxed command via `runc`.
+8. Run the sandboxed command via `runc`.
    - runc creates its own further-nested namespaces per `config.json` and enforces every
      isolation guarantee declared there — capability drop, seccomp filter, read-only filesystem,
-     network namespace.
+     network namespace — including placing it in step 4's cgroup when `linux.cgroupsPath` was set.
    - A two-hop process-supervision chain ties the sandboxed process's life to the staging step
      above: the process that starts `runc` and, separately, the sandboxed command itself both
      die if their immediate parent does, so killing the staging step tears down the whole chain
      instead of leaving the sandboxed command running as an orphan.
-   - Once this returns, ecapture (step 6) is stopped and its log parsed
-     (`core/lib/log/ecapture-log-parser.ts`) into the step's HTTPS communication logs, before the
-     scratch directory holding that log is torn down in the next step.
-8. Clean up once the command exits (`run-isolated.sh`).
+   - Once this returns, ecapture (step 7) is stopped — via `sudo`, since it runs as root — and its
+     log parsed (`core/lib/log/ecapture-log-parser.ts`) into the step's HTTPS communication logs,
+     before the scratch directory holding that log is torn down in the next step. Step 4's cgroup
+     directory is then removed too (best-effort; normally already gone via runc's own teardown).
+9. Clean up once the command exits (`run-isolated.sh`).
    - An exit trap tears the container down, unmounts the rootfs bind-mount, removes the veth, and
      deletes the network namespace.
    - As a second layer of defense, anything still mounted under the run's own scratch directory
      is force-detached before that directory is deleted, in case the trap above didn't run to
      completion.
-9. Append this step's report to the Job Summary and stop the proxy container (`main.ts`).
-   - The report is built in-process on the runner: `report.ts` reads the container's own
-     communication log via `docker exec ... cat`, then the container is stopped. The HTTPS
-     communication logs parsed in step 7 are merged into this same report object before rendering.
-   - If the whole process is killed before reaching this point, a fallback step reads the
-     container's identity back from job state and stops it anyway, and reclaims the step's scratch
-     directory — whose path it reconstructs deterministically from that same identity, then
-     force-detaches any surviving mount before deleting (`post.ts`).
+10. Append this step's report to the Job Summary and stop the proxy container (`main.ts`).
+    - The report is built in-process on the runner: `report.ts` reads the container's own
+      communication log via `docker exec ... cat`, then the container is stopped. The HTTPS
+      communication logs parsed in step 8 are merged into this same report object before rendering.
+    - If the whole process is killed before reaching this point, a fallback step reads the
+      container's identity back from job state and stops it anyway, and reclaims the step's scratch
+      directory — whose path it reconstructs deterministically from that same identity, then
+      force-detaches any surviving mount before deleting. It applies the same recovery to ecapture
+      (`STATE_ecapture_pid`, checked against `/proc/<pid>/comm` before signaling in case the pid was
+      recycled) and step 4's cgroup directory (`STATE_ecapture_cgroup_path`) (`post.ts`).
 
 ## Local Development
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -181,7 +181,15 @@ order it actually happens. For the user-facing behavior and threat model, see
      proxy's fixed gateway address directly — no bridge, since this is always a 1:1 connection
      (one sandbox, one proxy) and a plain named interface is enough for `init-iptables`'s
      `-i sandbox0` rule (added at container startup) to match once this device appears later.
-6. Run the sandboxed command via `runc`.
+6. Start ecapture in the background, just before running the sandboxed command (`isolated-exec.ts`).
+   - Extracted onto the runner host the same way as `runc`/`gen-seccomp-profile` in step 3 (`docker
+     cp` from the proxy image, run natively there). Its capture window is exactly the isolated
+     command's lifetime: started here, stopped right after step 7 below returns.
+   - Best-effort only — a failure to extract or start it is reported as a warning annotation, never
+     a `SandboxError` that would abort the step itself. See [HTTPS Communication Logs
+     (ecapture)](./security.md#https-communication-logs-ecapture) in Security Details for what this
+     does and doesn't capture.
+7. Run the sandboxed command via `runc`.
    - runc creates its own further-nested namespaces per `config.json` and enforces every
      isolation guarantee declared there — capability drop, seccomp filter, read-only filesystem,
      network namespace.
@@ -189,15 +197,19 @@ order it actually happens. For the user-facing behavior and threat model, see
      above: the process that starts `runc` and, separately, the sandboxed command itself both
      die if their immediate parent does, so killing the staging step tears down the whole chain
      instead of leaving the sandboxed command running as an orphan.
-7. Clean up once the command exits (`run-isolated.sh`).
+   - Once this returns, ecapture (step 6) is stopped and its log parsed
+     (`core/lib/log/ecapture-log-parser.ts`) into the step's HTTPS communication logs, before the
+     scratch directory holding that log is torn down in the next step.
+8. Clean up once the command exits (`run-isolated.sh`).
    - An exit trap tears the container down, unmounts the rootfs bind-mount, removes the veth, and
      deletes the network namespace.
    - As a second layer of defense, anything still mounted under the run's own scratch directory
      is force-detached before that directory is deleted, in case the trap above didn't run to
      completion.
-8. Append this step's report to the Job Summary and stop the proxy container (`main.ts`).
+9. Append this step's report to the Job Summary and stop the proxy container (`main.ts`).
    - The report is built in-process on the runner: `report.ts` reads the container's own
-     communication log via `docker exec ... cat`, then the container is stopped.
+     communication log via `docker exec ... cat`, then the container is stopped. The HTTPS
+     communication logs parsed in step 7 are merged into this same report object before rendering.
    - If the whole process is killed before reaching this point, a fallback step reads the
      container's identity back from job state and stops it anyway, and reclaims the step's scratch
      directory — whose path it reconstructs deterministically from that same identity, then

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -239,6 +239,13 @@ In `audit` mode, the Job Summary also includes a ready-to-paste `restrict` mode 
 during the audited run — mirroring the same example the `report` action generates for
 `setup`/`report` workflows.
 
+When the isolated command makes HTTPS requests through an OpenSSL-family library, the Job Summary
+also includes a "💬 HTTPS communication logs" section showing method/path detail, not just the
+domain-level allow/block decision — this is best-effort observability with real coverage gaps (no
+effect on enforcement); see [HTTPS Communication Logs
+(ecapture)](./security.md#https-communication-logs-ecapture) in Security Details for exactly what
+it does and doesn't capture.
+
 See the [restrict mode](../.github/workflows/example-run-restrict.yml) and
 [audit mode](../.github/workflows/example-run-audit.yml) example workflows for each in full.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -317,6 +317,13 @@ that's the only point standing between decrypted traffic and a GitHub Job Summar
 
 **Coverage is deliberately narrow, and known to have gaps:**
 
+- **Blocked HTTPS connections never appear here, only allowed ones.** The allow/block decision above
+  is made from the SNI in the TLS `ClientHello`, before the handshake completes — a blocked
+  connection is torn down right there, so the encrypted session `SSL_write`/`SSL_read` operate on
+  never actually gets established, and there's no application-layer request for ecapture to capture
+  in the first place. This is expected, not a coverage gap to fix: the "🚫 Blocked Hosts" table above
+  is (and stays) the authoritative record of what was blocked; this section only ever supplements the
+  "✅ Allowed Hosts" side with method/path detail.
 - **OpenSSL/BoringSSL/GnuTLS/NSS-linked tools only.** A tool statically using its own TLS stack —
   Rust's `rustls`, the JVM's default `SunJSSE` provider, .NET's own implementation — isn't hooked by
   this mechanism at all and simply won't appear in this section, same as if it made no HTTPS calls.

--- a/docs/security.md
+++ b/docs/security.md
@@ -294,6 +294,50 @@ an OCI `config.json` and enforced by runc natively.
   `run-isolated.sh` is killed outright (e.g. an out-of-memory kill lands on it specifically), the
   whole sandboxed process tree is killed with it rather than surviving as an orphan.
 
+### HTTPS Communication Logs (ecapture)
+
+`run` optionally shows *method and path* detail for the isolated command's HTTPS traffic, not just
+the domain-level allow/block decision the tables above already show — a "💬 HTTPS communication
+logs" section in the report, when there's anything to show. This is purely observability layered on
+top of the network isolation above; it has no effect on what's allowed or blocked.
+
+It's implemented with [ecapture](https://github.com/gojue/ecapture), an eBPF-based tool that hooks
+OpenSSL's own read/write functions (`uprobe`s on `libssl.so`) to read the plaintext on either side of
+encryption, directly in the traced process's memory — no CA certificate or MITM proxying involved,
+unlike `explicit`'s own path-level visibility (see [Coverage and
+Visibility](#coverage-and-visibility)). ecapture is extracted onto the runner host alongside
+`runc`/`gen-seccomp-profile` (see [Isolation Mechanisms](#isolation-mechanisms) above) and started
+just before, stopped just after, the isolated command runs — its capture window covers exactly one
+`run:` step. It works here specifically because the sandbox's rootfs is a bind-mount of the host's
+own `/` (see above): the isolated command's `libssl.so` is the exact same file ecapture itself
+resolves, with no cross-mount-namespace path resolution needed. Only `method`, `host`, `path`, and
+`status` are ever extracted from what ecapture captures — every other byte (headers, including
+`Authorization`, and request/response bodies) is discarded before this data reaches the report, since
+that's the only point standing between decrypted traffic and a GitHub Job Summary.
+
+**Coverage is deliberately narrow, and known to have gaps:**
+
+- **OpenSSL/BoringSSL/GnuTLS/NSS-linked tools only.** A tool statically using its own TLS stack —
+  Rust's `rustls`, the JVM's default `SunJSSE` provider, .NET's own implementation — isn't hooked by
+  this mechanism at all and simply won't appear in this section, same as if it made no HTTPS calls.
+  This is narrower than the "works with any language or package manager" guarantee the domain-level
+  allow/block decision itself carries (see the [README](../README.md)) — that guarantee is untouched;
+  it's specifically this supplementary detail that doesn't extend to every stack.
+- **HTTP/1.x request lines only.** ecapture's text-mode output doesn't decompress HTTP/2's
+  HPACK-compressed headers, so a client that negotiates `h2` (many modern HTTP libraries do, when the
+  server supports it) won't have its method/path recovered — the request simply doesn't appear here,
+  rather than showing up malformed.
+- **Sees the whole runner host, not just this step.** ecapture is started without `--pid`/`--cgroup_path`
+  scoping, so — for the duration of one `run:` step — it observes every OpenSSL-linked process on the
+  runner host, not only the isolated command's own. On a GitHub-hosted runner (a dedicated, ephemeral
+  VM for one job) this has no practical effect. On a shared, concurrently-used self-hosted runner, it
+  means this step's report could in principle pick up HTTPS traffic from an unrelated process running
+  on the same host at the same time. Both PID-based and cgroup-based scoping were evaluated and
+  rejected for now: a single `--pid` match doesn't cover the child processes a `run:` script's own
+  commands spawn under different PIDs, and `--cgroup_path` — despite working correctly against a
+  plain container's own cgroup in testing — failed to capture anything at all when pointed at the
+  cgroup runc creates for the isolated command specifically, for a reason not yet root-caused.
+
 ### Known Limitations
 
 - **No AppArmor/SELinux/Landlock policy**: these would add path-level MAC restrictions on top of

--- a/docs/security.md
+++ b/docs/security.md
@@ -334,17 +334,17 @@ that's the only point standing between decrypted traffic and a GitHub Job Summar
   HPACK-compressed headers, so a client that negotiates `h2` (many modern HTTP libraries do, when the
   server supports it) won't have its method/path recovered — the request simply doesn't appear here,
   rather than showing up malformed.
-- **Scoped to this step's own cgroup, on a best-effort basis.** ecapture is normally started with
-  `--cgroup_path` pointed at the cgroup runc will create for the isolated command — predicted from
-  the invoking process's own `/proc/self/cgroup` (see `predictCgroupPath` in
-  `run/src/lib/isolated-exec.ts`) and pre-created with `sudo mkdir -p` before ecapture starts (its
-  own `--cgroup_path` validation needs the directory to already exist; runc's cgroup setup already
-  tolerates reusing a directory it didn't create itself, and its normal container teardown removes it
-  afterward). If this preparation fails for any reason (not a cgroup v2 host, `sudo` can't create the
-  directory, etc.), it falls back to unscoped capture rather than skipping ecapture entirely — in that
-  fallback case, for the duration of one `run:` step, it observes every OpenSSL-linked process on the
-  runner host, not only the isolated command's own. On a GitHub-hosted runner (a dedicated, ephemeral
-  VM for one job) an unscoped fallback has no practical effect either way. On a shared,
+- **Scoped to this step's own cgroup.** ecapture is started with `--cgroup_path` pointed at the
+  cgroup runc will create for the isolated command — predicted from the invoking process's own
+  `/proc/self/cgroup` (see `predictCgroupPath` in `run/src/lib/isolated-exec.ts`) and pre-created
+  with `sudo mkdir -p` before ecapture starts (its own `--cgroup_path` validation needs the directory
+  to already exist; runc's cgroup setup already tolerates reusing a directory it didn't create
+  itself, and its normal container teardown removes it afterward). Confirmed on GitHub-hosted
+  runners: two concurrent `run:` steps with different allowlists each show only their own step's
+  HTTPS requests, never each other's. If this preparation fails for any reason (not a cgroup v2 host,
+  `sudo` can't create the directory, etc.), it falls back to unscoped capture rather than skipping
+  ecapture entirely — in that fallback case, for the duration of one `run:` step, it observes every
+  OpenSSL-linked process on the runner host, not only the isolated command's own. On a shared,
   concurrently-used self-hosted runner, an unscoped fallback means this step's report could in
   principle pick up HTTPS traffic from an unrelated process running on the same host at the same time.
   PID-based scoping was evaluated and rejected as an alternative: a single `--pid` match doesn't cover

--- a/docs/security.md
+++ b/docs/security.md
@@ -325,8 +325,9 @@ that's the only point standing between decrypted traffic and a GitHub Job Summar
   is (and stays) the authoritative record of what was blocked; this section only ever supplements the
   "✅ Allowed Hosts" side with method/path detail.
 - **OpenSSL/BoringSSL/GnuTLS/NSS-linked tools only.** A tool statically using its own TLS stack —
-  Rust's `rustls`, the JVM's default `SunJSSE` provider, .NET's own implementation — isn't hooked by
-  this mechanism at all and simply won't appear in this section, same as if it made no HTTPS calls.
+  Rust's `rustls`, Go's `crypto/tls`, the JVM's default `SunJSSE` provider, .NET's own implementation
+  — isn't hooked by this mechanism at all and simply won't appear in this section, same as if it made
+  no HTTPS calls.
   This is narrower than the "works with any language or package manager" guarantee the domain-level
   allow/block decision itself carries (see the [README](../README.md)) — that guarantee is untouched;
   it's specifically this supplementary detail that doesn't extend to every stack.
@@ -334,12 +335,15 @@ that's the only point standing between decrypted traffic and a GitHub Job Summar
   HPACK-compressed headers, so a client that negotiates `h2` (many modern HTTP libraries do, when the
   server supports it) won't have its method/path recovered — the request simply doesn't appear here,
   rather than showing up malformed.
-- **Scoped to this step's own cgroup.** ecapture is started with `--cgroup_path` pointed at the
-  cgroup runc will create for the isolated command — predicted from the invoking process's own
-  `/proc/self/cgroup` (see `predictCgroupPath` in `run/src/lib/isolated-exec.ts`) and pre-created
-  with `sudo mkdir -p` before ecapture starts (its own `--cgroup_path` validation needs the directory
-  to already exist; runc's cgroup setup already tolerates reusing a directory it didn't create
-  itself, and its normal container teardown removes it afterward). Confirmed on GitHub-hosted
+- **Scoped to this step's own cgroup.** ecapture is started with `--cgroup_path` pointed at a cgroup
+  path (`cgroupFsPath` in `run/src/lib/isolated-exec.ts`) derived deterministically from the
+  container name, with no dependence on runc's own implicit defaults or on parsing
+  `/proc/self/cgroup`. The same path is passed to runc explicitly as `linux.cgroupsPath` in the OCI
+  config, so runc places the isolated command's own cgroup exactly there rather than somewhere
+  ecapture would have to guess. The directory is pre-created with `sudo mkdir -p` before ecapture
+  starts (its own `--cgroup_path` validation needs the directory to already exist; runc's cgroup
+  setup tolerates reusing a directory it didn't create itself) and removed again after the step
+  finishes. Confirmed on GitHub-hosted
   runners: two concurrent `run:` steps with different allowlists each show only their own step's
   HTTPS requests, never each other's. If this preparation fails for any reason (not a cgroup v2 host,
   `sudo` can't create the directory, etc.), it falls back to unscoped capture rather than skipping

--- a/docs/security.md
+++ b/docs/security.md
@@ -334,16 +334,22 @@ that's the only point standing between decrypted traffic and a GitHub Job Summar
   HPACK-compressed headers, so a client that negotiates `h2` (many modern HTTP libraries do, when the
   server supports it) won't have its method/path recovered — the request simply doesn't appear here,
   rather than showing up malformed.
-- **Sees the whole runner host, not just this step.** ecapture is started without `--pid`/`--cgroup_path`
-  scoping, so — for the duration of one `run:` step — it observes every OpenSSL-linked process on the
+- **Scoped to this step's own cgroup, on a best-effort basis.** ecapture is normally started with
+  `--cgroup_path` pointed at the cgroup runc will create for the isolated command — predicted from
+  the invoking process's own `/proc/self/cgroup` (see `predictCgroupPath` in
+  `run/src/lib/isolated-exec.ts`) and pre-created with `sudo mkdir -p` before ecapture starts (its
+  own `--cgroup_path` validation needs the directory to already exist; runc's cgroup setup already
+  tolerates reusing a directory it didn't create itself, and its normal container teardown removes it
+  afterward). If this preparation fails for any reason (not a cgroup v2 host, `sudo` can't create the
+  directory, etc.), it falls back to unscoped capture rather than skipping ecapture entirely — in that
+  fallback case, for the duration of one `run:` step, it observes every OpenSSL-linked process on the
   runner host, not only the isolated command's own. On a GitHub-hosted runner (a dedicated, ephemeral
-  VM for one job) this has no practical effect. On a shared, concurrently-used self-hosted runner, it
-  means this step's report could in principle pick up HTTPS traffic from an unrelated process running
-  on the same host at the same time. Both PID-based and cgroup-based scoping were evaluated and
-  rejected for now: a single `--pid` match doesn't cover the child processes a `run:` script's own
-  commands spawn under different PIDs, and `--cgroup_path` — despite working correctly against a
-  plain container's own cgroup in testing — failed to capture anything at all when pointed at the
-  cgroup runc creates for the isolated command specifically, for a reason not yet root-caused.
+  VM for one job) an unscoped fallback has no practical effect either way. On a shared,
+  concurrently-used self-hosted runner, an unscoped fallback means this step's report could in
+  principle pick up HTTPS traffic from an unrelated process running on the same host at the same time.
+  PID-based scoping was evaluated and rejected as an alternative: a single `--pid` match doesn't cover
+  the child processes a `run:` script's own commands spawn under different PIDs, unlike cgroup
+  membership, which they inherit.
 
 ### Known Limitations
 

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7430,7 +7430,7 @@ function stopEcapture(proc) {
 				"kill",
 				"-TERM",
 				`-${proc.pid}`
-			]);
+			], { stdio: "ignore" });
 		} catch {
 			return;
 		}
@@ -7474,7 +7474,7 @@ function removeCgroupDirIfEmpty(cgroupPath) {
 			"--",
 			"rmdir",
 			cgroupPath
-		]);
+		], { stdio: "ignore" });
 	} catch {}
 }
 /**

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7418,24 +7418,46 @@ function waitForEcaptureReady(logPath, timeoutMs = 5e3) {
 * Stop a process started by startEcapture, with a brief grace period to
 * flush and exit before the caller reads its log file. Killed via `sudo`
 * since ecapture runs as root -- an unprivileged `process.kill()` would just
-* fail with EPERM. Not a wait-until-exited poll: the blocking sleep here
-* starves the event loop, so `proc.exitCode`/`kill(pid, 0)` can't be trusted.
+* fail with EPERM. Escalates to SIGKILL if it's still alive after the grace
+* period: ecapture doesn't always honor SIGTERM promptly (detaching its eBPF
+* uprobes can be slow, or get stuck), and a stopEcapture that only ever sends
+* SIGTERM leaves it running as a leaked root process indefinitely -- these
+* accumulate silently across many `run:` steps until enough are alive at
+* once to destabilize the runner. Liveness is checked via a fresh `sudo kill
+* -0`, not Node's own `proc.exitCode`/`kill(pid, 0)`: the blocking sleep here
+* starves the event loop, so Node can't have reaped this child by now either
+* way, making its own view of the process unreliable.
 */
 function stopEcapture(proc) {
-	if (proc.pid) {
-		try {
-			(0, node_child_process.execFileSync)("sudo", [
-				"-n",
-				"--",
-				"kill",
-				"-TERM",
-				`-${proc.pid}`
-			], { stdio: "ignore" });
-		} catch {
-			return;
-		}
-		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+	if (!proc.pid) return;
+	let pgid = `-${proc.pid}`;
+	try {
+		(0, node_child_process.execFileSync)("sudo", [
+			"-n",
+			"--",
+			"kill",
+			"-TERM",
+			pgid
+		], { stdio: "ignore" });
+	} catch {
+		return;
 	}
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+	try {
+		(0, node_child_process.execFileSync)("sudo", [
+			"-n",
+			"--",
+			"kill",
+			"-0",
+			pgid
+		], { stdio: "ignore" }), (0, node_child_process.execFileSync)("sudo", [
+			"-n",
+			"--",
+			"kill",
+			"-KILL",
+			pgid
+		], { stdio: "ignore" });
+	} catch {}
 }
 /** Parse ecapture's captured log into this step's HTTPS communication logs.
 *  Undefined (not empty) if the log doesn't exist at all. */

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7426,6 +7426,26 @@ function startEcapture(ecapturePath, logPath, cgroupPath) {
 	});
 	return (0, node_fs.closeSync)(logFd), proc;
 }
+const ECAPTURE_READY_PATTERN = /started successfully/;
+/**
+* Block (synchronously — see withScratchDir) until ecapture's own log shows
+* it has finished loading and attaching its eBPF probes, or `timeoutMs`
+* elapses, whichever comes first. Loading/verifying the eBPF bytecode and
+* attaching probes isn't instant, and its exact duration varies with the
+* kernel; without this, a short-lived isolated command (a handful of quick
+* `wget`/`curl` calls, done in well under a second) can run to completion
+* before ecapture is actually capturing anything, silently yielding an empty
+* (rather than merely absent) httpLogs. Best-effort: on timeout this simply
+* gives up and lets the caller proceed anyway — missing the capture window
+* is preferable to hanging the whole step indefinitely.
+*/
+function waitForEcaptureReady(logPath, timeoutMs = 5e3) {
+	let deadline = Date.now() + timeoutMs;
+	for (; Date.now() < deadline;) {
+		if ((0, node_fs.existsSync)(logPath) && ECAPTURE_READY_PATTERN.test((0, node_fs.readFileSync)(logPath, "utf8"))) return;
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+	}
+}
 /**
 * Stop a process started by startEcapture, giving it a brief, fixed grace
 * period (blocking — see withScratchDir, whose callback must stay
@@ -8310,7 +8330,7 @@ async function main() {
 				ecaptureProc = startEcapture(extractEcapture({
 					containerName,
 					destDir: dir
-				}), ecaptureLogPath);
+				}), ecaptureLogPath), waitForEcaptureReady(ecaptureLogPath);
 			} catch (e) {
 				annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
 			}

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7399,7 +7399,7 @@ function startEcapture(ecapturePath, logPath, cgroupPath) {
 		],
 		detached: !0
 	});
-	return (0, node_fs.closeSync)(logFd), proc.on("error", () => {}), proc;
+	return (0, node_fs.closeSync)(logFd), proc.on("error", () => {}), proc.unref(), proc;
 }
 const ECAPTURE_READY_PATTERN = /started successfully/;
 /**

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8351,7 +8351,7 @@ async function main() {
 				ecaptureProc = startEcapture(extractEcapture({
 					containerName,
 					destDir: dir
-				}), ecaptureLogPath, void 0), waitForEcaptureReady(ecaptureLogPath), ecaptureProc.pid && stateFile && (0, node_fs.appendFileSync)(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);
+				}), ecaptureLogPath, cgroupReady ? cgroupFs : void 0), waitForEcaptureReady(ecaptureLogPath), ecaptureProc.pid && stateFile && (0, node_fs.appendFileSync)(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);
 			} catch (e) {
 				annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
 			}

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7396,15 +7396,16 @@ function extractEcapture({ containerName, destDir }) {
 * runIsolated() and stopped (stopEcapture) right after it returns, so its
 * capture window covers exactly one `run:` step.
 *
-* No `--pid`/`--cgroup_path` scoping is applied by default: as of now,
-* ecapture observes every OpenSSL-linked process on the runner host for the
-* duration of this step, not just the isolated command's own (see
-* docs/security.md's known limitations). `cgroupPath`, when a caller
-* eventually has one to pass, would narrow that — see the TODO on this
-* repo's own dev-loop investigation notes; every attempt to resolve a
-* runc-nested sandbox's own auto-generated cgroup failed in local testing
-* for a reason not yet root-caused, so this parameter is unused for now,
-* pending re-verification on a real Linux CI host.
+* `cgroupPath` (see predictCgroupPath/ensureCgroupDir), when given, scopes
+* ecapture to just the isolated command's own cgroup rather than every
+* OpenSSL-linked process on the runner host for the step's duration — see
+* docs/security.md's known limitations for why this matters (cross-talk
+* between concurrent `run:` steps, or with an unrelated process, on a
+* shared/self-hosted runner). Earlier attempts to resolve a runc-nested
+* sandbox's own cgroup failed in Mac dev-loop testing for a reason
+* eventually traced to that testing environment specifically (see
+* predictCgroupPath's own doc) — real Linux CI is what determines whether
+* this actually narrows capture as intended.
 */
 function startEcapture(ecapturePath, logPath, cgroupPath) {
 	let args = [
@@ -7485,6 +7486,75 @@ function stopEcapture(proc) {
 */
 function readEcaptureLog(logPath) {
 	if ((0, node_fs.existsSync)(logPath)) return scanEcaptureLog((0, node_fs.readFileSync)(logPath, "utf8").split("\n"));
+}
+/**
+* Predict the cgroup v2 path runc will create for a container named
+* `containerName`, given no explicit `linux.cgroupsPath` in the OCI config
+* (buildOciConfig doesn't set one). Confirmed against runc's own source
+* (opencontainers/cgroups' fs2.defaultDirPath): with no cgroupsPath and no
+* systemd cgroup driver, the path is `/sys/fs/cgroup/<parent-of-runc's-own-
+* current-cgroup>/<containerName>` — i.e. a sibling of whatever cgroup the
+* process invoking `runc run` (this Node process, via `sudo`, which doesn't
+* itself move cgroups) is currently in. This is NOT a fixed prefix like
+* `/docker/<id>` — that was only ever true in Mac dev-loop testing because
+* the dev-loop container's own cgroup happened to be under `/docker/...`,
+* confirmed by reading runc's actual path-computation logic instead of
+* assuming the earlier observation generalized.
+*
+* The predicted path doesn't exist yet at this point (runc only creates it
+* once the container actually starts) — see ensureCgroupDir, which must run
+* before ecapture's own `--cgroup_path` validation (a plain stat check) can
+* succeed.
+*/
+function predictCgroupPath(containerName) {
+	return computeCgroupPath((0, node_fs.readFileSync)("/proc/self/cgroup", "utf8"), containerName);
+}
+/** Pure half of predictCgroupPath, split out so it's testable without a real
+*  /proc/self/cgroup (not present on macOS, where these tests also run). */
+function computeCgroupPath(selfCgroupContent, containerName) {
+	let line = selfCgroupContent.split("\n").find((l) => l.startsWith("0::"));
+	if (!line) throw Error(`could not find a cgroup v2 (unified) entry in /proc/self/cgroup: ${selfCgroupContent}`);
+	return (0, node_path.join)("/sys/fs/cgroup", (0, node_path.dirname)(line.slice(3).trim()), containerName);
+}
+/**
+* Create the cgroup v2 directory runc will later reuse for the isolated
+* command (see predictCgroupPath), so ecapture's `--cgroup_path` validation
+* has something real to stat before the container itself exists. Run via
+* `sudo` since `/sys/fs/cgroup` isn't writable by the runner's own
+* unprivileged user. Safe to pre-create: runc's own cgroup setup
+* (opencontainers/cgroups' fs2.CreateCgroupPath) already tolerates the
+* directory existing (os.Mkdir + os.IsExist check), and its normal container
+* teardown (`runc delete -f` in run-isolated.sh's cleanup trap) removes it
+* regardless of who created it.
+*/
+function ensureCgroupDir(cgroupPath) {
+	(0, node_child_process.execFileSync)("sudo", [
+		"-n",
+		"--",
+		"mkdir",
+		"-p",
+		cgroupPath
+	]);
+}
+/**
+* Best-effort cleanup for the directory ensureCgroupDir created. Normally
+* already removed by runc's own container teardown (`runc delete -f` in
+* run-isolated.sh's cleanup trap, which removes the cgroup it manages
+* regardless of who created the directory) — this is a safety net for the
+* case where that didn't happen (e.g. runIsolated itself failed before ever
+* creating a container). `rmdir` only removes an *empty* directory, so this
+* silently no-ops rather than forcing anything if the cgroup is still in use
+* or already gone.
+*/
+function removeCgroupDirIfEmpty(cgroupPath) {
+	try {
+		(0, node_child_process.execFileSync)("sudo", [
+			"-n",
+			"--",
+			"rmdir",
+			cgroupPath
+		]);
+	} catch {}
 }
 /**
 * Pure: extract {mountPoint, fsType} for every line of raw
@@ -8325,12 +8395,17 @@ async function main() {
 				throw new SandboxError(`Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`, "OCI_CONFIG_BUILD_FAILED");
 			}
 			writeOciConfig(config, dir);
-			let ecaptureProc, ecaptureLogPath = (0, node_path.join)(dir, "ecapture.log");
+			let ecaptureProc, ecaptureLogPath = (0, node_path.join)(dir, "ecapture.log"), cgroupPath;
+			try {
+				cgroupPath = predictCgroupPath(containerName), ensureCgroupDir(cgroupPath);
+			} catch (e) {
+				annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`), cgroupPath = void 0;
+			}
 			try {
 				ecaptureProc = startEcapture(extractEcapture({
 					containerName,
 					destDir: dir
-				}), ecaptureLogPath), waitForEcaptureReady(ecaptureLogPath);
+				}), ecaptureLogPath, cgroupPath), waitForEcaptureReady(ecaptureLogPath);
 			} catch (e) {
 				annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
 			}
@@ -8350,7 +8425,7 @@ async function main() {
 			} catch (e) {
 				annotation.warning(`Failed to read ecapture's HTTPS communication logs: ${errorMessage(e)}`);
 			}
-			return isolatedExitCode;
+			return cgroupPath && removeCgroupDirIfEmpty(cgroupPath), isolatedExitCode;
 		}, containerName);
 	} finally {
 		try {

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7255,6 +7255,74 @@ function buildComposeDownArgs({ composeFile, projectName }) {
 	];
 }
 //#endregion
+//#region core/lib/log/ecapture-log-parser.ts
+const ansiEscapePattern = /\x1b\[[0-9;]*m/g, blockHeaderPattern = /PID:(\d+)\s+TID:(\d+)\s+Comm:\S+\s+FD:(\d+)\s+(WRITE|READ)\s+\(\d+\s+bytes\):/, blockTerminatorPattern = /^\s*probe=/i, requestLinePattern = /^(\S+)\s+(\S+)\s+HTTP\/1\.[01]/, hostHeaderPattern = /^Host:\s*([^\s\\]+)/i, responseLinePattern = /^HTTP\/1\.[01]\s+(\d{3})/;
+/**
+* Single forward pass over ecapture's text-mode output. Returns every
+* request/response pair it could reconstruct, in the order captured. A WRITE
+* block with no matching READ (connection reset, blocked before a response,
+* end of log) is still emitted, with `status` left undefined — mirroring how
+* the explicit engine's own AllowedRequest already treats a missing status.
+*
+* Synchronous (unlike haproxy-log-parser.ts's scanHaproxyLog): ecapture's log
+* is always read directly off the runner host's own filesystem (see
+* run/src/lib/isolated-exec.ts's readEcaptureLog), never streamed from a
+* `docker exec`, so there's no AsyncIterable source to support here.
+*/
+function scanEcaptureLog(lines) {
+	let pending = /* @__PURE__ */ new Map(), entries = [], current = null, finalizeCurrent = () => {
+		if (!current) return;
+		let block = current;
+		if (current = null, block.direction === "WRITE") {
+			let reqMatch = block.lines[0]?.match(requestLinePattern);
+			if (!reqMatch) return;
+			let host = block.lines.slice(1).map((l) => l.match(hostHeaderPattern)?.[1]).find(Boolean);
+			if (!host) return;
+			pending.set(block.key, {
+				method: reqMatch[1],
+				path: reqMatch[2],
+				host
+			});
+		} else {
+			let resMatch = block.lines[0]?.match(responseLinePattern);
+			if (!resMatch) return;
+			let req = pending.get(block.key);
+			if (!req) return;
+			pending.delete(block.key), entries.push({
+				method: req.method,
+				url: `https://${req.host}${req.path}`,
+				status: Number(resMatch[1])
+			});
+		}
+	};
+	for (let rawLine of lines) {
+		let line = rawLine.replace(ansiEscapePattern, ""), headerMatch = line.match(blockHeaderPattern);
+		if (headerMatch) {
+			finalizeCurrent();
+			let [, pid, tid, fd, direction] = headerMatch;
+			current = {
+				key: `${pid}:${tid}:${fd}`,
+				direction,
+				lines: []
+			};
+			continue;
+		}
+		if (current) {
+			if (blockTerminatorPattern.test(line)) {
+				finalizeCurrent();
+				continue;
+			}
+			current.lines.push(line);
+		}
+	}
+	finalizeCurrent();
+	for (let { method, host, path } of pending.values()) entries.push({
+		method,
+		url: `https://${host}${path}`
+	});
+	return entries;
+}
+//#endregion
 //#region run/scripts/extra-masked-proc-paths.json
 var extra_masked_proc_paths_default = [
 	"/proc/kallsyms",
@@ -7302,6 +7370,101 @@ function extractRuncBootstrap({ containerName, destDir }) {
 		seccompProfile,
 		baseSpec
 	};
+}
+/**
+* Extract ecapture (eBPF-based TLS plaintext capture, no CA certificate
+* needed) from the proxy image onto the runner host, alongside runc/
+* gen-seccomp-profile above. Run natively on the host (not `docker exec`)
+* for the same reason those are: it needs to observe the isolated command
+* directly, and the sandbox's rootfs is a bind-mount of the host's own `/`
+* (see run-isolated.sh), so a host-native ecapture process resolves the
+* exact same libssl.so the sandboxed command loads — no cross-mount-
+* namespace path resolution needed. See docs/security.md's Run Action HTTPS
+* communication logs section for what this does and doesn't capture.
+*/
+function extractEcapture({ containerName, destDir }) {
+	let ecapturePath = (0, node_path.join)(destDir, "ecapture");
+	return (0, node_child_process.execFileSync)("docker", buildDockerCpArgs({
+		containerName,
+		containerPath: "/opt/buildcage/bin/ecapture",
+		hostPath: ecapturePath
+	})), (0, node_fs.chmodSync)(ecapturePath, 493), ecapturePath;
+}
+/**
+* Start ecapture in the background, writing its captured events to `logPath`
+* (inside this run's own scratch dir). Meant to be started just before
+* runIsolated() and stopped (stopEcapture) right after it returns, so its
+* capture window covers exactly one `run:` step.
+*
+* No `--pid`/`--cgroup_path` scoping is applied by default: as of now,
+* ecapture observes every OpenSSL-linked process on the runner host for the
+* duration of this step, not just the isolated command's own (see
+* docs/security.md's known limitations). `cgroupPath`, when a caller
+* eventually has one to pass, would narrow that — see the TODO on this
+* repo's own dev-loop investigation notes; every attempt to resolve a
+* runc-nested sandbox's own auto-generated cgroup failed in local testing
+* for a reason not yet root-caused, so this parameter is unused for now,
+* pending re-verification on a real Linux CI host.
+*/
+function startEcapture(ecapturePath, logPath, cgroupPath) {
+	let args = [
+		"-n",
+		"--",
+		ecapturePath,
+		"tls",
+		"-m",
+		"text"
+	];
+	cgroupPath && args.push(`--cgroup_path=${cgroupPath}`);
+	let logFd = (0, node_fs.openSync)(logPath, "w"), proc = (0, node_child_process.spawn)("sudo", args, {
+		stdio: [
+			"ignore",
+			logFd,
+			logFd
+		],
+		detached: !0
+	});
+	return (0, node_fs.closeSync)(logFd), proc;
+}
+/**
+* Stop a process started by startEcapture, giving it a brief, fixed grace
+* period (blocking — see withScratchDir, whose callback must stay
+* synchronous) to flush and exit before the caller reads its log file.
+*
+* Not a wait-until-actually-exited poll: the `Atomics.wait`-based blocking
+* sleep below (same pattern as removeScratchDir's retry loop) starves the
+* event loop, so Node can never process this child's own exit notification
+* while we're in it — `proc.exitCode` would never update. A raw
+* `process.kill(pid, 0)` liveness probe doesn't work as a substitute either:
+* it still succeeds against a zombie (exited but not yet reaped) process,
+* which is exactly the state this child sits in for as long as we keep
+* starving the event loop, so a loop built on that check would always run
+* to its full timeout. Distinguishing zombie from running requires an
+* OS-specific mechanism (e.g. /proc/<pid>/stat's state field on Linux) this
+* function deliberately avoids needing. ecapture's own writes are
+* unbuffered per captured event, so anything already written to the log by
+* the time SIGTERM lands is already on disk regardless of exactly when the
+* process finishes exiting.
+*/
+function stopEcapture(proc) {
+	if (proc.pid) {
+		try {
+			process.kill(-proc.pid, "SIGTERM");
+		} catch {
+			return;
+		}
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+	}
+}
+/**
+* Read and parse ecapture's captured log (see startEcapture), returning the
+* HTTPS communication logs to attach to this step's report. Returns
+* undefined (not an empty array) if the log doesn't exist at all — e.g.
+* ecapture failed to start — distinguishing "not captured" from "captured,
+* saw nothing".
+*/
+function readEcaptureLog(logPath) {
+	if ((0, node_fs.existsSync)(logPath)) return scanEcaptureLog((0, node_fs.readFileSync)(logPath, "utf8").split("\n"));
 }
 /**
 * Pure: extract {mountPoint, fsType} for every line of raw
@@ -7874,6 +8037,29 @@ function renderHostTable(rows, { showReason = !1, showExpected = !1 } = {}) {
 	})));
 }
 //#endregion
+//#region core/lib/report/command-log.ts
+function renderRequestLine({ method, url, status }) {
+	let line = `- ${escapeMarkdown(method)} ${escapeMarkdown(url)}`;
+	return status === void 0 ? line : `${line} -> ${status}`;
+}
+/**
+* Render the `run` action's ecapture-derived HTTPS communication logs as a
+* collapsed markdown section, or "" if there's nothing to show. Unlike
+* renderCommunicationDetails above, entries aren't grouped per RUN
+* step/vertex — ecapture's log carries no such attribution, so this is a
+* flat, time-ordered list of every request it could reconstruct.
+*/
+function renderHttpLogList(entries) {
+	if (!entries || entries.length === 0) return "";
+	let md = "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n";
+	md += "```\n";
+	for (let entry of entries) md += `${renderRequestLine(entry)}\n`;
+	return md += "```\n", md += "</details>\n", md;
+}
+function escapeMarkdown(text) {
+	return text.replace(/([\\`*_[\]<>])/g, "\\$1");
+}
+//#endregion
 //#region core/lib/log/aggregate.ts
 function compareAggregated(a, b) {
 	return b.count - a.count || (a.host < b.host ? -1 : +(a.host > b.host)) || Number(a.port) - Number(b.port);
@@ -7978,7 +8164,7 @@ function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runComm
 	}) + "\n\n")) : (report.passed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(report.passed) + "\n\n"), report.blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(report.blocked, {
 		showReason: !0,
 		showExpected
-	}) + "\n\n")), markdown;
+	}) + "\n\n")), markdown += renderHttpLogList(report.httpLogs), markdown;
 }
 function writeReport(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand } = {}) {
 	let isAudit = report.parameters.mode === "audit", outcome = determineBlockedOutcome({
@@ -8082,7 +8268,7 @@ async function main() {
 	} catch (e) {
 		throw new SandboxError(describeDockerFailure(e, { operation: "docker compose up" }), "DOCKER_UNAVAILABLE");
 	}
-	let exitCode = 1;
+	let exitCode = 1, httpLogs;
 	try {
 		let proxyPid = getContainerPid(containerName);
 		if (proxyPid === null) throw new SandboxError(`Sandbox proxy container ${containerName} is not running.`, "PROXY_NOT_RUNNING");
@@ -8118,7 +8304,17 @@ async function main() {
 			} catch (e) {
 				throw new SandboxError(`Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`, "OCI_CONFIG_BUILD_FAILED");
 			}
-			return writeOciConfig(config, dir), runIsolated({
+			writeOciConfig(config, dir);
+			let ecaptureProc, ecaptureLogPath = (0, node_path.join)(dir, "ecapture.log");
+			try {
+				ecaptureProc = startEcapture(extractEcapture({
+					containerName,
+					destDir: dir
+				}), ecaptureLogPath);
+			} catch (e) {
+				annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
+			}
+			let isolatedExitCode = runIsolated({
 				runcPath,
 				proxyPid,
 				bundleDir: dir,
@@ -8129,16 +8325,23 @@ async function main() {
 				dns,
 				targetIp: "172.20.0.101"
 			});
+			if (ecaptureProc) try {
+				stopEcapture(ecaptureProc), httpLogs = readEcaptureLog(ecaptureLogPath);
+			} catch (e) {
+				annotation.warning(`Failed to read ecapture's HTTPS communication logs: ${errorMessage(e)}`);
+			}
+			return isolatedExitCode;
 		}, containerName);
 	} finally {
 		try {
-			writeReport(await fetchReport(containerName, {
+			let report = await fetchReport(containerName, {
 				mode: env.INPUT_PROXY_MODE || "restrict",
 				allowedHttpsRules: rules.httpsRules,
 				allowedHttpRules: rules.httpRules,
 				allowedIpRules: rules.ipRules,
 				knownBlockedRules
-			}), {
+			});
+			report.httpLogs = httpLogs, writeReport(report, {
 				actionRepo,
 				actionRef,
 				runCommand: runInput,

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7439,7 +7439,8 @@ function stopEcapture(proc) {
 			"-TERM",
 			pgid
 		], { stdio: "ignore" });
-	} catch {
+	} catch (e) {
+		console.error(`DEBUG stopEcapture: initial TERM to ${pgid} threw: ${errorMessage(e)}`);
 		return;
 	}
 	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
@@ -7450,14 +7451,16 @@ function stopEcapture(proc) {
 			"kill",
 			"-0",
 			pgid
-		], { stdio: "ignore" }), (0, node_child_process.execFileSync)("sudo", [
+		], { stdio: "ignore" }), console.error(`DEBUG stopEcapture: ${pgid} still alive after TERM+500ms, escalating to KILL`), (0, node_child_process.execFileSync)("sudo", [
 			"-n",
 			"--",
 			"kill",
 			"-KILL",
 			pgid
-		], { stdio: "ignore" });
-	} catch {}
+		], { stdio: "ignore" }), console.error(`DEBUG stopEcapture: KILL sent to ${pgid}`);
+	} catch (e) {
+		console.error(`DEBUG stopEcapture: ${pgid} liveness check/escalation ended: ${errorMessage(e)}`);
+	}
 }
 /** Parse ecapture's captured log into this step's HTTPS communication logs.
 *  Undefined (not empty) if the log doesn't exist at all. */

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7270,7 +7270,11 @@ function scanEcaptureLog(lines) {
 			if (!reqMatch) return;
 			let host = block.lines.slice(1).map((l) => l.match(hostHeaderPattern)?.[1]).find(Boolean);
 			if (!host) return;
-			pending.set(block.key, {
+			let superseded = pending.get(block.key);
+			superseded && entries.push({
+				method: superseded.method,
+				url: `https://${superseded.host}${superseded.path}`
+			}), pending.set(block.key, {
 				method: reqMatch[1],
 				path: reqMatch[2],
 				host
@@ -7278,12 +7282,14 @@ function scanEcaptureLog(lines) {
 		} else {
 			let resMatch = block.lines[0]?.match(responseLinePattern);
 			if (!resMatch) return;
+			let status = Number(resMatch[1]);
+			if (status >= 100 && status < 200) return;
 			let req = pending.get(block.key);
 			if (!req) return;
 			pending.delete(block.key), entries.push({
 				method: req.method,
 				url: `https://${req.host}${req.path}`,
-				status: Number(resMatch[1])
+				status
 			});
 		}
 	};
@@ -7345,18 +7351,19 @@ function writeRunScript(runInput, dir) {
 function generateBaseOciSpec(runcPath, bundleDir) {
 	return (0, node_child_process.execFileSync)(runcPath, ["spec"], { cwd: bundleDir }), JSON.parse((0, node_fs.readFileSync)((0, node_path.join)(bundleDir, "config.json"), "utf8"));
 }
+/** Extract one binary from the proxy image's `/opt/buildcage/bin/` into `destDir`
+*  via `docker cp` (not `docker exec` -- some callers run natively on the host,
+*  see gen-seccomp-profile/main.go). Torn down with the scratch dir. */
+function extractBinaryFromProxyImage(containerName, destDir, name) {
+	let path = (0, node_path.join)(destDir, name);
+	return (0, node_child_process.execFileSync)("docker", buildDockerCpArgs({
+		containerName,
+		containerPath: `/opt/buildcage/bin/${name}`,
+		hostPath: path
+	})), (0, node_fs.chmodSync)(path, 493), path;
+}
 function extractRuncBootstrap({ containerName, destDir }) {
-	let runcPath = (0, node_path.join)(destDir, "runc"), genSeccompProfilePath = (0, node_path.join)(destDir, "gen-seccomp-profile");
-	(0, node_child_process.execFileSync)("docker", buildDockerCpArgs({
-		containerName,
-		containerPath: "/opt/buildcage/bin/runc",
-		hostPath: runcPath
-	})), (0, node_child_process.execFileSync)("docker", buildDockerCpArgs({
-		containerName,
-		containerPath: "/opt/buildcage/bin/gen-seccomp-profile",
-		hostPath: genSeccompProfilePath
-	})), (0, node_fs.chmodSync)(runcPath, 493), (0, node_fs.chmodSync)(genSeccompProfilePath, 493);
-	let seccompProfile = JSON.parse((0, node_child_process.execFileSync)(genSeccompProfilePath, { encoding: "utf8" })), baseSpec = generateBaseOciSpec(runcPath, destDir);
+	let runcPath = extractBinaryFromProxyImage(containerName, destDir, "runc"), genSeccompProfilePath = extractBinaryFromProxyImage(containerName, destDir, "gen-seccomp-profile"), seccompProfile = JSON.parse((0, node_child_process.execFileSync)(genSeccompProfilePath, { encoding: "utf8" })), baseSpec = generateBaseOciSpec(runcPath, destDir);
 	return (0, node_fs.rmSync)(genSeccompProfilePath), {
 		runcPath,
 		seccompProfile,
@@ -7366,17 +7373,12 @@ function extractRuncBootstrap({ containerName, destDir }) {
 /** Extract ecapture onto the runner host, same as extractRuncBootstrap above.
 *  See docs/security.md's Run Action HTTPS communication logs section. */
 function extractEcapture({ containerName, destDir }) {
-	let ecapturePath = (0, node_path.join)(destDir, "ecapture");
-	return (0, node_child_process.execFileSync)("docker", buildDockerCpArgs({
-		containerName,
-		containerPath: "/opt/buildcage/bin/ecapture",
-		hostPath: ecapturePath
-	})), (0, node_fs.chmodSync)(ecapturePath, 493), ecapturePath;
+	return extractBinaryFromProxyImage(containerName, destDir, "ecapture");
 }
 /**
 * Start ecapture in the background. Meant to run for exactly one `run:`
 * step: start before runIsolated(), stop (stopEcapture) right after.
-* `cgroupPath` (see predictCgroupPath), when given, scopes capture to the
+* `cgroupPath` (see cgroupFsPath), when given, scopes capture to the
 * isolated command's own cgroup instead of the whole runner host.
 */
 function startEcapture(ecapturePath, logPath, cgroupPath) {
@@ -7397,7 +7399,7 @@ function startEcapture(ecapturePath, logPath, cgroupPath) {
 		],
 		detached: !0
 	});
-	return (0, node_fs.closeSync)(logFd), proc;
+	return (0, node_fs.closeSync)(logFd), proc.on("error", () => {}), proc;
 }
 const ECAPTURE_READY_PATTERN = /started successfully/;
 /**
@@ -7414,15 +7416,21 @@ function waitForEcaptureReady(logPath, timeoutMs = 5e3) {
 }
 /**
 * Stop a process started by startEcapture, with a brief grace period to
-* flush and exit before the caller reads its log file. Not a wait-until-
-* exited poll: the blocking sleep here starves the event loop, so
-* `proc.exitCode` never updates, and `process.kill(pid, 0)` would still
-* succeed against a zombie either way.
+* flush and exit before the caller reads its log file. Killed via `sudo`
+* since ecapture runs as root -- an unprivileged `process.kill()` would just
+* fail with EPERM. Not a wait-until-exited poll: the blocking sleep here
+* starves the event loop, so `proc.exitCode`/`kill(pid, 0)` can't be trusted.
 */
 function stopEcapture(proc) {
 	if (proc.pid) {
 		try {
-			process.kill(-proc.pid, "SIGTERM");
+			(0, node_child_process.execFileSync)("sudo", [
+				"-n",
+				"--",
+				"kill",
+				"-TERM",
+				`-${proc.pid}`
+			]);
 		} catch {
 			return;
 		}
@@ -7434,25 +7442,15 @@ function stopEcapture(proc) {
 function readEcaptureLog(logPath) {
 	if ((0, node_fs.existsSync)(logPath)) return scanEcaptureLog((0, node_fs.readFileSync)(logPath, "utf8").split("\n"));
 }
-/**
-* Predict the cgroup v2 path runc will create for `containerName` (no
-* explicit `linux.cgroupsPath` is set in the OCI config). Per runc's own
-* source (opencontainers/cgroups' fs2.defaultDirPath), that's
-* `/sys/fs/cgroup/<parent of the caller's own cgroup>/<containerName>` — not
-* a fixed prefix like `/docker/<id>`, which was only ever an artifact of the
-* Mac dev-loop's own container living under `/docker/...`.
-*
-* The path doesn't exist yet here (runc creates it once the container
-* starts) — see ensureCgroupDir.
-*/
-function predictCgroupPath(containerName) {
-	return computeCgroupPath((0, node_fs.readFileSync)("/proc/self/cgroup", "utf8"), containerName);
+/** The `linux.cgroupsPath` value for `containerName`'s OCI config, relative
+*  to the cgroup v2 mount root. */
+function cgroupInnerPath(containerName) {
+	return `/buildcage-run/${containerName}`;
 }
-/** Pure half of predictCgroupPath (no real /proc/self/cgroup on macOS, where these tests also run). */
-function computeCgroupPath(selfCgroupContent, containerName) {
-	let line = selfCgroupContent.split("\n").find((l) => l.startsWith("0::"));
-	if (!line) throw Error(`could not find a cgroup v2 (unified) entry in /proc/self/cgroup: ${selfCgroupContent}`);
-	return (0, node_path.join)("/sys/fs/cgroup", (0, node_path.dirname)(line.slice(3).trim()), containerName);
+/** The real filesystem path of `cgroupInnerPath`'s cgroup, for
+*  ensureCgroupDir/removeCgroupDirIfEmpty and ecapture's own `--cgroup_path`. */
+function cgroupFsPath(containerName) {
+	return (0, node_path.join)("/sys/fs/cgroup", cgroupInnerPath(containerName));
 }
 /** Pre-create the cgroup so ecapture's own `--cgroup_path` validation (a
 *  stat check) succeeds before the container exists. runc's cgroup setup
@@ -7567,7 +7565,7 @@ function assertScratchBaseNotWritable(writableDirs) {
 	let overlapping = writableDirs.find((p) => pathsOverlap(p, SANDBOX_SCRATCH_BASE));
 	if (overlapping) throw Error(`writable path ${JSON.stringify(overlapping)} overlaps the sandbox's own scratch directory (${SANDBOX_SCRATCH_BASE}); this would re-expose the sandboxed host filesystem read-write inside the sandbox itself. Choose a writable path outside ${SANDBOX_SCRATCH_BASE}.`);
 }
-function buildOciConfig(baseSpec, { uid, gid, workdir, home, runnerTemp, writablePaths = [], env, netnsPath, rootfsBindDir, resolvConfPath, seccompProfile, scriptPath, hostMounts = [] }) {
+function buildOciConfig(baseSpec, { uid, gid, workdir, home, runnerTemp, writablePaths = [], env, netnsPath, rootfsBindDir, cgroupsPath, resolvConfPath, seccompProfile, scriptPath, hostMounts = [] }) {
 	let disableReadonly = writablePaths.includes("/"), mounts = [...baseSpec.mounts, {
 		destination: "/etc/resolv.conf",
 		type: "none",
@@ -7629,7 +7627,8 @@ function buildOciConfig(baseSpec, { uid, gid, workdir, home, runnerTemp, writabl
 			namespaces,
 			seccomp: seccompProfile,
 			maskedPaths,
-			readonlyPaths
+			readonlyPaths,
+			...cgroupsPath ? { cgroupsPath } : {}
 		}
 	};
 }
@@ -8061,7 +8060,7 @@ function renderRequestLine({ method, url, status }) {
 function renderHttpLogList(entries) {
 	if (!entries || entries.length === 0) return "";
 	let md = "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n";
-	md += "```\n";
+	md += "<sub>*Note: captured only for HTTPS traffic that was allowed, from processes linked against OpenSSL/BoringSSL/GnuTLS/NSS — other TLS stacks (e.g. Rust's rustls, Go's crypto/tls) and blocked connections never appear here.*</sub>\n\n", md += "```\n";
 	for (let entry of entries) md += `${renderRequestLine(entry)}\n`;
 	return md += "```\n", md += "</details>\n", md;
 }
@@ -8292,7 +8291,14 @@ async function main() {
 			} catch (e) {
 				throw new SandboxError(`Failed to extract runc/gen-seccomp-profile from the proxy image: ${errorMessage(e)}`, "RUNC_EXTRACT_FAILED");
 			}
-			let workdir = env.GITHUB_WORKSPACE || "", home = env.HOME || "", netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-"), rootfsBindDir = (0, node_path.join)(dir, "rootfs"), config;
+			let workdir = env.GITHUB_WORKSPACE || "", home = env.HOME || "", netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-"), rootfsBindDir = (0, node_path.join)(dir, "rootfs"), cgroupFs = cgroupFsPath(containerName), cgroupReady = !1;
+			try {
+				ensureCgroupDir(cgroupFs), cgroupReady = !0;
+			} catch (e) {
+				annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`);
+			}
+			cgroupReady && stateFile && (0, node_fs.appendFileSync)(stateFile, `ecapture_cgroup_path=${cgroupFs}\n`);
+			let config;
 			try {
 				let resolvConfPath = writeResolvConf(dns, dir), scriptPath = writeRunScript(runInput, dir), hostMounts = listHostMounts();
 				config = buildOciConfig(baseSpec, {
@@ -8308,23 +8314,19 @@ async function main() {
 					resolvConfPath,
 					seccompProfile,
 					scriptPath,
-					hostMounts
+					hostMounts,
+					cgroupsPath: cgroupReady ? cgroupInnerPath(containerName) : void 0
 				});
 			} catch (e) {
 				throw new SandboxError(`Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`, "OCI_CONFIG_BUILD_FAILED");
 			}
 			writeOciConfig(config, dir);
-			let ecaptureProc, ecaptureLogPath = (0, node_path.join)(dir, "ecapture.log"), cgroupPath;
-			try {
-				cgroupPath = predictCgroupPath(containerName), ensureCgroupDir(cgroupPath);
-			} catch (e) {
-				annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`), cgroupPath = void 0;
-			}
+			let ecaptureProc, ecaptureLogPath = (0, node_path.join)(dir, "ecapture.log");
 			try {
 				ecaptureProc = startEcapture(extractEcapture({
 					containerName,
 					destDir: dir
-				}), ecaptureLogPath, cgroupPath), waitForEcaptureReady(ecaptureLogPath);
+				}), ecaptureLogPath, cgroupReady ? cgroupFs : void 0), waitForEcaptureReady(ecaptureLogPath), ecaptureProc.pid && stateFile && (0, node_fs.appendFileSync)(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);
 			} catch (e) {
 				annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
 			}
@@ -8344,7 +8346,7 @@ async function main() {
 			} catch (e) {
 				annotation.warning(`Failed to read ecapture's HTTPS communication logs: ${errorMessage(e)}`);
 			}
-			return cgroupPath && removeCgroupDirIfEmpty(cgroupPath), isolatedExitCode;
+			return cgroupReady && removeCgroupDirIfEmpty(cgroupFs), isolatedExitCode;
 		}, containerName);
 	} finally {
 		try {

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7258,16 +7258,8 @@ function buildComposeDownArgs({ composeFile, projectName }) {
 //#region core/lib/log/ecapture-log-parser.ts
 const ansiEscapePattern = /\x1b\[[0-9;]*m/g, blockHeaderPattern = /PID:(\d+)\s+TID:(\d+)\s+Comm:\S+\s+FD:(\d+)\s+(WRITE|READ)\s+\(\d+\s+bytes\):/, blockTerminatorPattern = /^\s*probe=/i, requestLinePattern = /^(\S+)\s+(\S+)\s+HTTP\/1\.[01]/, hostHeaderPattern = /^Host:\s*([^\s\\]+)/i, responseLinePattern = /^HTTP\/1\.[01]\s+(\d{3})/;
 /**
-* Single forward pass over ecapture's text-mode output. Returns every
-* request/response pair it could reconstruct, in the order captured. A WRITE
-* block with no matching READ (connection reset, blocked before a response,
-* end of log) is still emitted, with `status` left undefined — mirroring how
-* the explicit engine's own AllowedRequest already treats a missing status.
-*
-* Synchronous (unlike haproxy-log-parser.ts's scanHaproxyLog): ecapture's log
-* is always read directly off the runner host's own filesystem (see
-* run/src/lib/isolated-exec.ts's readEcaptureLog), never streamed from a
-* `docker exec`, so there's no AsyncIterable source to support here.
+* One forward pass over ecapture's text-mode output, in capture order. A
+* WRITE with no matching READ is still emitted, with `status` undefined.
 */
 function scanEcaptureLog(lines) {
 	let pending = /* @__PURE__ */ new Map(), entries = [], current = null, finalizeCurrent = () => {
@@ -7371,17 +7363,8 @@ function extractRuncBootstrap({ containerName, destDir }) {
 		baseSpec
 	};
 }
-/**
-* Extract ecapture (eBPF-based TLS plaintext capture, no CA certificate
-* needed) from the proxy image onto the runner host, alongside runc/
-* gen-seccomp-profile above. Run natively on the host (not `docker exec`)
-* for the same reason those are: it needs to observe the isolated command
-* directly, and the sandbox's rootfs is a bind-mount of the host's own `/`
-* (see run-isolated.sh), so a host-native ecapture process resolves the
-* exact same libssl.so the sandboxed command loads — no cross-mount-
-* namespace path resolution needed. See docs/security.md's Run Action HTTPS
-* communication logs section for what this does and doesn't capture.
-*/
+/** Extract ecapture onto the runner host, same as extractRuncBootstrap above.
+*  See docs/security.md's Run Action HTTPS communication logs section. */
 function extractEcapture({ containerName, destDir }) {
 	let ecapturePath = (0, node_path.join)(destDir, "ecapture");
 	return (0, node_child_process.execFileSync)("docker", buildDockerCpArgs({
@@ -7391,21 +7374,10 @@ function extractEcapture({ containerName, destDir }) {
 	})), (0, node_fs.chmodSync)(ecapturePath, 493), ecapturePath;
 }
 /**
-* Start ecapture in the background, writing its captured events to `logPath`
-* (inside this run's own scratch dir). Meant to be started just before
-* runIsolated() and stopped (stopEcapture) right after it returns, so its
-* capture window covers exactly one `run:` step.
-*
-* `cgroupPath` (see predictCgroupPath/ensureCgroupDir), when given, scopes
-* ecapture to just the isolated command's own cgroup rather than every
-* OpenSSL-linked process on the runner host for the step's duration — see
-* docs/security.md's known limitations for why this matters (cross-talk
-* between concurrent `run:` steps, or with an unrelated process, on a
-* shared/self-hosted runner). Earlier attempts to resolve a runc-nested
-* sandbox's own cgroup failed in Mac dev-loop testing for a reason
-* eventually traced to that testing environment specifically (see
-* predictCgroupPath's own doc) — real Linux CI is what determines whether
-* this actually narrows capture as intended.
+* Start ecapture in the background. Meant to run for exactly one `run:`
+* step: start before runIsolated(), stop (stopEcapture) right after.
+* `cgroupPath` (see predictCgroupPath), when given, scopes capture to the
+* isolated command's own cgroup instead of the whole runner host.
 */
 function startEcapture(ecapturePath, logPath, cgroupPath) {
 	let args = [
@@ -7429,16 +7401,9 @@ function startEcapture(ecapturePath, logPath, cgroupPath) {
 }
 const ECAPTURE_READY_PATTERN = /started successfully/;
 /**
-* Block (synchronously — see withScratchDir) until ecapture's own log shows
-* it has finished loading and attaching its eBPF probes, or `timeoutMs`
-* elapses, whichever comes first. Loading/verifying the eBPF bytecode and
-* attaching probes isn't instant, and its exact duration varies with the
-* kernel; without this, a short-lived isolated command (a handful of quick
-* `wget`/`curl` calls, done in well under a second) can run to completion
-* before ecapture is actually capturing anything, silently yielding an empty
-* (rather than merely absent) httpLogs. Best-effort: on timeout this simply
-* gives up and lets the caller proceed anyway — missing the capture window
-* is preferable to hanging the whole step indefinitely.
+* Block until ecapture's log shows its eBPF probes are attached, or
+* `timeoutMs` elapses. Needed because a short isolated command can finish
+* before ecapture is actually capturing anything.
 */
 function waitForEcaptureReady(logPath, timeoutMs = 5e3) {
 	let deadline = Date.now() + timeoutMs;
@@ -7448,24 +7413,11 @@ function waitForEcaptureReady(logPath, timeoutMs = 5e3) {
 	}
 }
 /**
-* Stop a process started by startEcapture, giving it a brief, fixed grace
-* period (blocking — see withScratchDir, whose callback must stay
-* synchronous) to flush and exit before the caller reads its log file.
-*
-* Not a wait-until-actually-exited poll: the `Atomics.wait`-based blocking
-* sleep below (same pattern as removeScratchDir's retry loop) starves the
-* event loop, so Node can never process this child's own exit notification
-* while we're in it — `proc.exitCode` would never update. A raw
-* `process.kill(pid, 0)` liveness probe doesn't work as a substitute either:
-* it still succeeds against a zombie (exited but not yet reaped) process,
-* which is exactly the state this child sits in for as long as we keep
-* starving the event loop, so a loop built on that check would always run
-* to its full timeout. Distinguishing zombie from running requires an
-* OS-specific mechanism (e.g. /proc/<pid>/stat's state field on Linux) this
-* function deliberately avoids needing. ecapture's own writes are
-* unbuffered per captured event, so anything already written to the log by
-* the time SIGTERM lands is already on disk regardless of exactly when the
-* process finishes exiting.
+* Stop a process started by startEcapture, with a brief grace period to
+* flush and exit before the caller reads its log file. Not a wait-until-
+* exited poll: the blocking sleep here starves the event loop, so
+* `proc.exitCode` never updates, and `process.kill(pid, 0)` would still
+* succeed against a zombie either way.
 */
 function stopEcapture(proc) {
 	if (proc.pid) {
@@ -7477,56 +7429,35 @@ function stopEcapture(proc) {
 		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
 	}
 }
-/**
-* Read and parse ecapture's captured log (see startEcapture), returning the
-* HTTPS communication logs to attach to this step's report. Returns
-* undefined (not an empty array) if the log doesn't exist at all — e.g.
-* ecapture failed to start — distinguishing "not captured" from "captured,
-* saw nothing".
-*/
+/** Parse ecapture's captured log into this step's HTTPS communication logs.
+*  Undefined (not empty) if the log doesn't exist at all. */
 function readEcaptureLog(logPath) {
 	if ((0, node_fs.existsSync)(logPath)) return scanEcaptureLog((0, node_fs.readFileSync)(logPath, "utf8").split("\n"));
 }
 /**
-* Predict the cgroup v2 path runc will create for a container named
-* `containerName`, given no explicit `linux.cgroupsPath` in the OCI config
-* (buildOciConfig doesn't set one). Confirmed against runc's own source
-* (opencontainers/cgroups' fs2.defaultDirPath): with no cgroupsPath and no
-* systemd cgroup driver, the path is `/sys/fs/cgroup/<parent-of-runc's-own-
-* current-cgroup>/<containerName>` — i.e. a sibling of whatever cgroup the
-* process invoking `runc run` (this Node process, via `sudo`, which doesn't
-* itself move cgroups) is currently in. This is NOT a fixed prefix like
-* `/docker/<id>` — that was only ever true in Mac dev-loop testing because
-* the dev-loop container's own cgroup happened to be under `/docker/...`,
-* confirmed by reading runc's actual path-computation logic instead of
-* assuming the earlier observation generalized.
+* Predict the cgroup v2 path runc will create for `containerName` (no
+* explicit `linux.cgroupsPath` is set in the OCI config). Per runc's own
+* source (opencontainers/cgroups' fs2.defaultDirPath), that's
+* `/sys/fs/cgroup/<parent of the caller's own cgroup>/<containerName>` — not
+* a fixed prefix like `/docker/<id>`, which was only ever an artifact of the
+* Mac dev-loop's own container living under `/docker/...`.
 *
-* The predicted path doesn't exist yet at this point (runc only creates it
-* once the container actually starts) — see ensureCgroupDir, which must run
-* before ecapture's own `--cgroup_path` validation (a plain stat check) can
-* succeed.
+* The path doesn't exist yet here (runc creates it once the container
+* starts) — see ensureCgroupDir.
 */
 function predictCgroupPath(containerName) {
 	return computeCgroupPath((0, node_fs.readFileSync)("/proc/self/cgroup", "utf8"), containerName);
 }
-/** Pure half of predictCgroupPath, split out so it's testable without a real
-*  /proc/self/cgroup (not present on macOS, where these tests also run). */
+/** Pure half of predictCgroupPath (no real /proc/self/cgroup on macOS, where these tests also run). */
 function computeCgroupPath(selfCgroupContent, containerName) {
 	let line = selfCgroupContent.split("\n").find((l) => l.startsWith("0::"));
 	if (!line) throw Error(`could not find a cgroup v2 (unified) entry in /proc/self/cgroup: ${selfCgroupContent}`);
 	return (0, node_path.join)("/sys/fs/cgroup", (0, node_path.dirname)(line.slice(3).trim()), containerName);
 }
-/**
-* Create the cgroup v2 directory runc will later reuse for the isolated
-* command (see predictCgroupPath), so ecapture's `--cgroup_path` validation
-* has something real to stat before the container itself exists. Run via
-* `sudo` since `/sys/fs/cgroup` isn't writable by the runner's own
-* unprivileged user. Safe to pre-create: runc's own cgroup setup
-* (opencontainers/cgroups' fs2.CreateCgroupPath) already tolerates the
-* directory existing (os.Mkdir + os.IsExist check), and its normal container
-* teardown (`runc delete -f` in run-isolated.sh's cleanup trap) removes it
-* regardless of who created it.
-*/
+/** Pre-create the cgroup so ecapture's own `--cgroup_path` validation (a
+*  stat check) succeeds before the container exists. runc's cgroup setup
+*  tolerates the directory already existing, and removes it on teardown
+*  regardless of who created it. */
 function ensureCgroupDir(cgroupPath) {
 	(0, node_child_process.execFileSync)("sudo", [
 		"-n",
@@ -7536,16 +7467,8 @@ function ensureCgroupDir(cgroupPath) {
 		cgroupPath
 	]);
 }
-/**
-* Best-effort cleanup for the directory ensureCgroupDir created. Normally
-* already removed by runc's own container teardown (`runc delete -f` in
-* run-isolated.sh's cleanup trap, which removes the cgroup it manages
-* regardless of who created the directory) — this is a safety net for the
-* case where that didn't happen (e.g. runIsolated itself failed before ever
-* creating a container). `rmdir` only removes an *empty* directory, so this
-* silently no-ops rather than forcing anything if the cgroup is still in use
-* or already gone.
-*/
+/** Best-effort cleanup in case runc's own teardown didn't run. `rmdir`
+*  no-ops if the cgroup is still in use or already gone. */
 function removeCgroupDirIfEmpty(cgroupPath) {
 	try {
 		(0, node_child_process.execFileSync)("sudo", [
@@ -8132,13 +8055,9 @@ function renderRequestLine({ method, url, status }) {
 	let line = `- ${escapeMarkdown(method)} ${escapeMarkdown(url)}`;
 	return status === void 0 ? line : `${line} -> ${status}`;
 }
-/**
-* Render the `run` action's ecapture-derived HTTPS communication logs as a
-* collapsed markdown section, or "" if there's nothing to show. Unlike
-* renderCommunicationDetails above, entries aren't grouped per RUN
-* step/vertex — ecapture's log carries no such attribution, so this is a
-* flat, time-ordered list of every request it could reconstruct.
-*/
+/** Renders the `run` action's ecapture-derived HTTPS communication logs as a
+*  collapsed section, or "" if empty. Flat, time-ordered — unlike
+*  renderCommunicationDetails, there's no per-vertex attribution here. */
 function renderHttpLogList(entries) {
 	if (!entries || entries.length === 0) return "";
 	let md = "\n<details>\n<summary>💬 HTTPS communication logs</summary>\n\n";

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7414,6 +7414,24 @@ function waitForEcaptureReady(logPath, timeoutMs = 5e3) {
 		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
 	}
 }
+function waitUntilGone(pgid, timeoutMs) {
+	let deadline = Date.now() + timeoutMs;
+	for (; Date.now() < deadline;) {
+		try {
+			(0, node_child_process.execFileSync)("sudo", [
+				"-n",
+				"--",
+				"kill",
+				"-0",
+				pgid
+			], { stdio: "ignore" });
+		} catch {
+			return !0;
+		}
+		Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+	}
+	return !1;
+}
 /**
 * Stop a process started by startEcapture, with a brief grace period to
 * flush and exit before the caller reads its log file. Killed via `sudo`
@@ -7443,24 +7461,24 @@ function stopEcapture(proc) {
 		console.error(`DEBUG stopEcapture: initial TERM to ${pgid} threw: ${errorMessage(e)}`);
 		return;
 	}
-	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+	if (waitUntilGone(pgid, 8e3)) {
+		console.error(`DEBUG stopEcapture: ${pgid} exited on its own within 8s of TERM`);
+		return;
+	}
+	console.error(`DEBUG stopEcapture: ${pgid} still alive after TERM+8s, escalating to KILL`);
 	try {
 		(0, node_child_process.execFileSync)("sudo", [
 			"-n",
 			"--",
 			"kill",
-			"-0",
-			pgid
-		], { stdio: "ignore" }), console.error(`DEBUG stopEcapture: ${pgid} still alive after TERM+500ms, escalating to KILL`), (0, node_child_process.execFileSync)("sudo", [
-			"-n",
-			"--",
-			"kill",
 			"-KILL",
 			pgid
-		], { stdio: "ignore" }), console.error(`DEBUG stopEcapture: KILL sent to ${pgid}`);
+		], { stdio: "ignore" });
 	} catch (e) {
-		console.error(`DEBUG stopEcapture: ${pgid} liveness check/escalation ended: ${errorMessage(e)}`);
+		console.error(`DEBUG stopEcapture: KILL to ${pgid} threw: ${errorMessage(e)}`);
+		return;
 	}
+	waitUntilGone(pgid, 5e3) ? console.error(`DEBUG stopEcapture: ${pgid} gone within 5s of KILL`) : console.error(`DEBUG stopEcapture: ${pgid} STILL ALIVE 5s after KILL`);
 }
 /** Parse ecapture's captured log into this step's HTTPS communication logs.
 *  Undefined (not empty) if the log doesn't exist at all. */

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8351,7 +8351,7 @@ async function main() {
 				ecaptureProc = startEcapture(extractEcapture({
 					containerName,
 					destDir: dir
-				}), ecaptureLogPath, cgroupReady ? cgroupFs : void 0), waitForEcaptureReady(ecaptureLogPath), ecaptureProc.pid && stateFile && (0, node_fs.appendFileSync)(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);
+				}), ecaptureLogPath, void 0), waitForEcaptureReady(ecaptureLogPath), ecaptureProc.pid && stateFile && (0, node_fs.appendFileSync)(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);
 			} catch (e) {
 				annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
 			}

--- a/run/dist/post.cjs
+++ b/run/dist/post.cjs
@@ -125,7 +125,25 @@ function scratchDirFor(containerName) {
 }
 //#endregion
 //#region run/src/post.ts
-const __dirname$1 = (0, node_path.dirname)((0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href)), containerName = process.env.STATE_container_name, projectName = process.env.STATE_project_name;
+const __dirname$1 = (0, node_path.dirname)((0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href)), containerName = process.env.STATE_container_name, projectName = process.env.STATE_project_name, ecapturePid = process.env.STATE_ecapture_pid;
+if (ecapturePid) try {
+	(0, node_fs.readFileSync)(`/proc/${ecapturePid}/comm`, "utf8").trim() === "ecapture" && (0, node_child_process.execFileSync)("sudo", [
+		"-n",
+		"--",
+		"kill",
+		"-TERM",
+		`-${ecapturePid}`
+	]);
+} catch {}
+const ecaptureCgroupPath = process.env.STATE_ecapture_cgroup_path;
+if (ecaptureCgroupPath) try {
+	(0, node_child_process.execFileSync)("sudo", [
+		"-n",
+		"--",
+		"rmdir",
+		ecaptureCgroupPath
+	]);
+} catch {}
 if (containerName?.startsWith("buildcage-proxy-")) try {
 	let scratchDir = scratchDirFor(containerName);
 	(0, node_fs.existsSync)(scratchDir) && cleanupScratchDir(scratchDir);

--- a/run/dist/post.cjs
+++ b/run/dist/post.cjs
@@ -133,7 +133,7 @@ if (ecapturePid) try {
 		"kill",
 		"-TERM",
 		`-${ecapturePid}`
-	]);
+	], { stdio: "ignore" });
 } catch {}
 const ecaptureCgroupPath = process.env.STATE_ecapture_cgroup_path;
 if (ecaptureCgroupPath) try {
@@ -142,7 +142,7 @@ if (ecaptureCgroupPath) try {
 		"--",
 		"rmdir",
 		ecaptureCgroupPath
-	]);
+	], { stdio: "ignore" });
 } catch {}
 if (containerName?.startsWith("buildcage-proxy-")) try {
 	let scratchDir = scratchDirFor(containerName);

--- a/run/docker/Dockerfile
+++ b/run/docker/Dockerfile
@@ -3,13 +3,24 @@ ARG RUNC_VERSION=v1.5.1
 ARG RUNC_SHA256_AMD64=177df879d50c913eb205e898d5c1c05a18f574053c0ce5524c471208eaf06f6f
 ARG RUNC_SHA256_ARM64=ca70e7dbd6616ca782a59b5d3ac86909123fdaa9fa3f89dcf29051c70eee7ce9
 
+# renovate: datasource=github-releases depName=gojue/ecapture
+ARG ECAPTURE_VERSION=v2.5.2
+ARG ECAPTURE_SHA256_AMD64=96d960536a8bfba3cbd6218fa01358886a9dce744891a00dd0e323cd85f26038
+ARG ECAPTURE_SHA256_ARM64=fca78b5963be0a7e882181a92e23d9281b4db0ccedca949656b6cf8557709f99
+
 # Prepare dependencies — runc's official release binaries are already
 # statically linked (including libseccomp), so no compilation is needed,
-# only a checksum-pinned download (see docs/development.md).
+# only a checksum-pinned download (see docs/development.md). ecapture's
+# release tarball is fetched the same way — its binary is also statically
+# linked (no libc dependency), confirmed to run unmodified on this same
+# Alpine/musl base during development.
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS deps
 ARG RUNC_VERSION
 ARG RUNC_SHA256_AMD64
 ARG RUNC_SHA256_ARM64
+ARG ECAPTURE_VERSION
+ARG ECAPTURE_SHA256_AMD64
+ARG ECAPTURE_SHA256_ARM64
 RUN apk add --no-cache curl && \
     mkdir -p /opt/buildcage/bin && \
     ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') && \
@@ -17,7 +28,13 @@ RUN apk add --no-cache curl && \
     curl -fsSL "https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.${ARCH}" \
       -o /opt/buildcage/bin/runc && \
     echo "${EXPECTED_SHA256}  /opt/buildcage/bin/runc" | sha256sum -c && \
-    chmod +x /opt/buildcage/bin/runc
+    chmod +x /opt/buildcage/bin/runc && \
+    ECAPTURE_EXPECTED_SHA256=$([ "$ARCH" = "amd64" ] && echo "$ECAPTURE_SHA256_AMD64" || echo "$ECAPTURE_SHA256_ARM64") && \
+    curl -fsSL "https://github.com/gojue/ecapture/releases/download/${ECAPTURE_VERSION}/ecapture-${ECAPTURE_VERSION}-linux-${ARCH}.tar.gz" \
+      -o /tmp/ecapture.tar.gz && \
+    echo "${ECAPTURE_EXPECTED_SHA256}  /tmp/ecapture.tar.gz" | sha256sum -c && \
+    tar -C /opt/buildcage/bin --strip-components=1 -xzf /tmp/ecapture.tar.gz "ecapture-${ECAPTURE_VERSION}-linux-${ARCH}/ecapture" && \
+    chmod +x /opt/buildcage/bin/ecapture
 
 # Building gen-seccomp-profile here only compiles the binary — it's
 # extracted onto the runner host and run natively there, not at image
@@ -87,6 +104,12 @@ COPY --from=qjs-build /build/dist/qjs/core/scripts/convert-rule.js /opt/buildcag
 # runc — extracted onto the runner host at `run` action startup and used by
 # run-isolated.sh to execute the isolated command (see docs/development.md)
 COPY --from=deps /opt/buildcage/bin/runc /opt/buildcage/bin/runc
+
+# ecapture — extracted onto the runner host at `run` action startup and run
+# natively there (not inside this container), alongside the isolated command,
+# so it observes the same host filesystem the sandbox's rootfs is bind-mounted
+# from (see docs/security.md's Run Action HTTPS communication logs section).
+COPY --from=deps /opt/buildcage/bin/ecapture /opt/buildcage/bin/ecapture
 
 # gen-seccomp-profile — extracted onto the runner host and run natively
 # there (not inside this container) to produce the seccomp filter embedded

--- a/run/docker/files/THIRD_PARTY_LICENSES
+++ b/run/docker/files/THIRD_PARTY_LICENSES
@@ -46,6 +46,17 @@ runc
 
 ------------------------------------------------------------------------------
 
+ecapture
+  Website : https://ecapture.cc/
+  License : Apache License 2.0 (Apache-2.0)
+  Source  : https://github.com/gojue/ecapture
+  Note    : Official pre-built release binary, checksum-pinned in
+            run/docker/Dockerfile. Extracted onto the runner host at `run`
+            action startup and run natively there alongside the isolated
+            command, to capture HTTPS communication logs (see docs/security.md).
+
+------------------------------------------------------------------------------
+
 Note on GPL components (HAProxy, dnsmasq):
 
 These components are installed from the Alpine Linux official package

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync, statSync } from "node:fs";
+import { readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { spawn } from "node:child_process";
 
 import {
   writeRunScript,
@@ -14,6 +15,8 @@ import {
   computeReadonlyHostMounts,
   freshMountDestinationsFrom,
   parseMountsUnder,
+  stopEcapture,
+  readEcaptureLog,
 } from "./isolated-exec.ts";
 
 describe("writeRunScript", () => {
@@ -392,5 +395,71 @@ describe("withScratchDir", () => {
       });
     });
     assert.throws(() => readFileSync(join(capturedDir, "run-script.sh")));
+  });
+});
+
+describe("readEcaptureLog", () => {
+  it("returns undefined when the log file doesn't exist at all", () => {
+    withScratchDir((dir) => {
+      assert.equal(readEcaptureLog(join(dir, "does-not-exist.log")), undefined);
+    });
+  });
+
+  it("returns an empty array when the log exists but has no matching content", () => {
+    withScratchDir((dir) => {
+      const logPath = join(dir, "ecapture.log");
+      writeFileSync(logPath, "some unrelated startup log line\n");
+      assert.deepEqual(readEcaptureLog(logPath), []);
+    });
+  });
+
+  it("parses a real WRITE/READ pair from the log file", () => {
+    withScratchDir((dir) => {
+      const logPath = join(dir, "ecapture.log");
+      const content = [
+        "PID:100 TID:100 Comm:curl FD:4 WRITE (0 bytes):",
+        "GET / HTTP/1.1\\r",
+        "Host: example.com\\r",
+        "\\r",
+        " probe=OpenSSL",
+        "PID:100 TID:100 Comm:curl FD:4 READ (0 bytes):",
+        "HTTP/1.1 200 OK\\r",
+        "\\r",
+        " probe=OpenSSL",
+      ].join("\n");
+      writeFileSync(logPath, content);
+      const result = readEcaptureLog(logPath);
+      assert.deepEqual(result, [{ method: "GET", url: "https://example.com/", status: 200 }]);
+    });
+  });
+});
+
+describe("stopEcapture", () => {
+  it("delivers SIGTERM to the whole process group, not just the immediate child", () => {
+    withScratchDir((dir) => {
+      // A trap-and-touch script, rather than checking kill(pid, 0) after
+      // the fact: that check would succeed against a zombie (exited but not
+      // yet reaped) process regardless of whether the signal was actually
+      // delivered, since stopEcapture's own blocking sleep prevents Node
+      // from reaping it during the call — see stopEcapture's own comment.
+      const markerPath = join(dir, "signaled");
+      const proc = spawn("sh", ["-c", `trap 'touch ${markerPath}; exit 0' TERM; sleep 30`], {
+        detached: true,
+        stdio: "ignore",
+      });
+      // Give the shell a moment to actually start and register its trap
+      // handler before signaling it -- sending SIGTERM in the same instant
+      // as spawn() would hit it before the trap exists, falling back to the
+      // signal's default (silent) termination instead of running it. Real
+      // usage never races this: ecapture runs for the isolated command's
+      // whole duration, not a few milliseconds.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+      stopEcapture(proc);
+      assert.equal(statSync(markerPath).isFile(), true);
+    });
+  });
+
+  it("does nothing (doesn't throw) when the process has no pid", () => {
+    assert.doesNotThrow(() => stopEcapture({ pid: undefined } as never));
   });
 });

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -17,6 +17,7 @@ import {
   parseMountsUnder,
   stopEcapture,
   readEcaptureLog,
+  waitForEcaptureReady,
 } from "./isolated-exec.ts";
 
 describe("writeRunScript", () => {
@@ -430,6 +431,39 @@ describe("readEcaptureLog", () => {
       writeFileSync(logPath, content);
       const result = readEcaptureLog(logPath);
       assert.deepEqual(result, [{ method: "GET", url: "https://example.com/", status: 200 }]);
+    });
+  });
+});
+
+describe("waitForEcaptureReady", () => {
+  it("returns as soon as the log already contains the readiness marker", () => {
+    withScratchDir((dir) => {
+      const logPath = join(dir, "ecapture.log");
+      writeFileSync(logPath, "INF OpenSSL probe started successfully probe=OpenSSL\n");
+      const start = Date.now();
+      waitForEcaptureReady(logPath, 5000);
+      assert.ok(Date.now() - start < 200, "should not wait once the marker is already present");
+    });
+  });
+
+  it("gives up after timeoutMs when the log never shows the marker", () => {
+    withScratchDir((dir) => {
+      const logPath = join(dir, "ecapture.log");
+      writeFileSync(logPath, "INF some unrelated startup line\n");
+      const start = Date.now();
+      waitForEcaptureReady(logPath, 300);
+      const elapsed = Date.now() - start;
+      assert.ok(elapsed >= 300, "should wait out the full timeout");
+      assert.ok(elapsed < 2000, "should not wait meaningfully longer than the timeout");
+    });
+  });
+
+  it("gives up after timeoutMs when the log file never appears at all", () => {
+    withScratchDir((dir) => {
+      const logPath = join(dir, "does-not-exist.log");
+      const start = Date.now();
+      waitForEcaptureReady(logPath, 300);
+      assert.ok(Date.now() - start >= 300);
     });
   });
 });

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -14,6 +14,7 @@ import {
   computeReadonlyHostMounts,
   freshMountDestinationsFrom,
   parseMountsUnder,
+  startEcapture,
   stopEcapture,
   readEcaptureLog,
   waitForEcaptureReady,
@@ -491,6 +492,16 @@ describe("waitForEcaptureReady", () => {
       const start = Date.now();
       waitForEcaptureReady(logPath, 300);
       assert.ok(Date.now() - start >= 300);
+    });
+  });
+});
+
+describe("startEcapture", () => {
+  it("attaches an 'error' listener so an async spawn failure can't crash the process", () => {
+    withScratchDir((dir) => {
+      const proc = startEcapture(join(dir, "nonexistent-ecapture-binary"), join(dir, "ecapture.log"));
+      assert.ok(proc.listenerCount("error") > 0);
+      stopEcapture(proc);
     });
   });
 });

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { spawn } from "node:child_process";
 
 import {
   writeRunScript,
@@ -497,30 +496,11 @@ describe("waitForEcaptureReady", () => {
 });
 
 describe("stopEcapture", () => {
-  it("delivers SIGTERM to the whole process group, not just the immediate child", () => {
-    withScratchDir((dir) => {
-      // A trap-and-touch script, rather than checking kill(pid, 0) after
-      // the fact: that check would succeed against a zombie (exited but not
-      // yet reaped) process regardless of whether the signal was actually
-      // delivered, since stopEcapture's own blocking sleep prevents Node
-      // from reaping it during the call — see stopEcapture's own comment.
-      const markerPath = join(dir, "signaled");
-      const proc = spawn("sh", ["-c", `trap 'touch ${markerPath}; exit 0' TERM; sleep 30`], {
-        detached: true,
-        stdio: "ignore",
-      });
-      // Give the shell a moment to actually start and register its trap
-      // handler before signaling it -- sending SIGTERM in the same instant
-      // as spawn() would hit it before the trap exists, falling back to the
-      // signal's default (silent) termination instead of running it. Real
-      // usage never races this: ecapture runs for the isolated command's
-      // whole duration, not a few milliseconds.
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
-      stopEcapture(proc);
-      assert.equal(statSync(markerPath).isFile(), true);
-    });
-  });
-
+  // stopEcapture kills via `sudo` (ecapture itself runs as root), so a
+  // meaningful "does it actually terminate the process" test needs a real
+  // passwordless-sudo host, not a unit test -- see
+  // run/test/integration-test-ecapture-terminates.sh, which drives the real
+  // run/dist/main.cjs and checks with `pgrep` afterward.
   it("does nothing (doesn't throw) when the process has no pid", () => {
     assert.doesNotThrow(() => stopEcapture({ pid: undefined } as never));
   });

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -18,6 +18,7 @@ import {
   stopEcapture,
   readEcaptureLog,
   waitForEcaptureReady,
+  computeCgroupPath,
 } from "./isolated-exec.ts";
 
 describe("writeRunScript", () => {
@@ -432,6 +433,33 @@ describe("readEcaptureLog", () => {
       const result = readEcaptureLog(logPath);
       assert.deepEqual(result, [{ method: "GET", url: "https://example.com/", status: 200 }]);
     });
+  });
+});
+
+describe("computeCgroupPath", () => {
+  it("joins the parent of the caller's own cgroup with the container name", () => {
+    const result = computeCgroupPath("0::/actions_job/1234\n", "buildcage-proxy-abc");
+    assert.equal(result, "/sys/fs/cgroup/actions_job/buildcage-proxy-abc");
+  });
+
+  it("handles the caller already being at the cgroup v2 root", () => {
+    const result = computeCgroupPath("0::/\n", "buildcage-proxy-abc");
+    assert.equal(result, "/sys/fs/cgroup/buildcage-proxy-abc");
+  });
+
+  it("matches the Mac dev-loop's own observed /docker/<id> shape, as one possible case", () => {
+    const result = computeCgroupPath("0::/docker/65385640f4b2bac1f5c422ab29e3bba9d0be8d4d9c3a161530dc59a9d05a6bfe\n", "buildcage-proxy-abc");
+    assert.equal(result, "/sys/fs/cgroup/docker/buildcage-proxy-abc");
+  });
+
+  it("finds the 0:: line among other (cgroup v1 hybrid) lines", () => {
+    const content = "12:pids:/user.slice\n1:name=systemd:/user.slice\n0::/user.slice/session-1.scope\n";
+    const result = computeCgroupPath(content, "buildcage-proxy-abc");
+    assert.equal(result, "/sys/fs/cgroup/user.slice/buildcage-proxy-abc");
+  });
+
+  it("throws when there is no 0:: (cgroup v2 unified) entry at all", () => {
+    assert.throws(() => computeCgroupPath("12:pids:/user.slice\n1:name=systemd:/user.slice\n", "x"), /cgroup v2/);
   });
 });
 

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -18,7 +18,8 @@ import {
   stopEcapture,
   readEcaptureLog,
   waitForEcaptureReady,
-  computeCgroupPath,
+  cgroupInnerPath,
+  cgroupFsPath,
 } from "./isolated-exec.ts";
 
 describe("writeRunScript", () => {
@@ -242,6 +243,16 @@ describe("buildOciConfig", () => {
     assert.equal(config.linux.namespaces.length, 6);
   });
 
+  it("sets linux.cgroupsPath when given", () => {
+    const config = buildOciConfig(fakeBaseSpec(), { ...baseArgs, writablePaths: [], cgroupsPath: "/buildcage-run/buildcage-proxy-abc" });
+    assert.equal(config.linux.cgroupsPath, "/buildcage-run/buildcage-proxy-abc");
+  });
+
+  it("omits linux.cgroupsPath when not given, leaving runc's own default in effect", () => {
+    const config = buildOciConfig(fakeBaseSpec(), { ...baseArgs, writablePaths: [] });
+    assert.equal("cgroupsPath" in config.linux, false);
+  });
+
   it("extends maskedPaths with kallsyms/kmsg/sysrq-trigger and moves sysrq-trigger out of readonlyPaths", () => {
     const config = buildOciConfig(fakeBaseSpec(), { ...baseArgs, writablePaths: [] });
     for (const p of ["/proc/kallsyms", "/proc/kmsg", "/proc/sysrq-trigger", "/proc/kcore", "/proc/keys", "/proc/timer_list"]) {
@@ -436,30 +447,15 @@ describe("readEcaptureLog", () => {
   });
 });
 
-describe("computeCgroupPath", () => {
-  it("joins the parent of the caller's own cgroup with the container name", () => {
-    const result = computeCgroupPath("0::/actions_job/1234\n", "buildcage-proxy-abc");
-    assert.equal(result, "/sys/fs/cgroup/actions_job/buildcage-proxy-abc");
+describe("cgroupInnerPath / cgroupFsPath", () => {
+  it("derives a path from the container name alone, with no host-specific input", () => {
+    assert.equal(cgroupInnerPath("buildcage-proxy-abc"), "/buildcage-run/buildcage-proxy-abc");
+    assert.equal(cgroupFsPath("buildcage-proxy-abc"), "/sys/fs/cgroup/buildcage-run/buildcage-proxy-abc");
   });
 
-  it("handles the caller already being at the cgroup v2 root", () => {
-    const result = computeCgroupPath("0::/\n", "buildcage-proxy-abc");
-    assert.equal(result, "/sys/fs/cgroup/buildcage-proxy-abc");
-  });
-
-  it("matches the Mac dev-loop's own observed /docker/<id> shape, as one possible case", () => {
-    const result = computeCgroupPath("0::/docker/65385640f4b2bac1f5c422ab29e3bba9d0be8d4d9c3a161530dc59a9d05a6bfe\n", "buildcage-proxy-abc");
-    assert.equal(result, "/sys/fs/cgroup/docker/buildcage-proxy-abc");
-  });
-
-  it("finds the 0:: line among other (cgroup v1 hybrid) lines", () => {
-    const content = "12:pids:/user.slice\n1:name=systemd:/user.slice\n0::/user.slice/session-1.scope\n";
-    const result = computeCgroupPath(content, "buildcage-proxy-abc");
-    assert.equal(result, "/sys/fs/cgroup/user.slice/buildcage-proxy-abc");
-  });
-
-  it("throws when there is no 0:: (cgroup v2 unified) entry at all", () => {
-    assert.throws(() => computeCgroupPath("12:pids:/user.slice\n1:name=systemd:/user.slice\n", "x"), /cgroup v2/);
+  it("keeps cgroupFsPath consistent with cgroupInnerPath (the same value passed to both runc and ecapture)", () => {
+    const name = "buildcage-proxy-xyz";
+    assert.equal(cgroupFsPath(name), `/sys/fs/cgroup${cgroupInnerPath(name)}`);
   });
 });
 
@@ -509,7 +505,7 @@ describe("startEcapture", () => {
 describe("stopEcapture", () => {
   // stopEcapture kills via `sudo` (ecapture itself runs as root), so a
   // meaningful "does it actually terminate the process" test needs a real
-  // passwordless-sudo host, not a unit test -- see
+  // passwordless-sudo host, not a unit test — see
   // run/test/integration-test-ecapture-terminates.sh, which drives the real
   // run/dist/main.cjs and checks with `pgrep` afterward.
   it("does nothing (doesn't throw) when the process has no pid", () => {

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -208,6 +208,30 @@ export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?
   return proc;
 }
 
+const ECAPTURE_READY_PATTERN = /started successfully/;
+
+/**
+ * Block (synchronously — see withScratchDir) until ecapture's own log shows
+ * it has finished loading and attaching its eBPF probes, or `timeoutMs`
+ * elapses, whichever comes first. Loading/verifying the eBPF bytecode and
+ * attaching probes isn't instant, and its exact duration varies with the
+ * kernel; without this, a short-lived isolated command (a handful of quick
+ * `wget`/`curl` calls, done in well under a second) can run to completion
+ * before ecapture is actually capturing anything, silently yielding an empty
+ * (rather than merely absent) httpLogs. Best-effort: on timeout this simply
+ * gives up and lets the caller proceed anyway — missing the capture window
+ * is preferable to hanging the whole step indefinitely.
+ */
+export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(logPath) && ECAPTURE_READY_PATTERN.test(readFileSync(logPath, "utf8"))) {
+      return;
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+}
+
 /**
  * Stop a process started by startEcapture, giving it a brief, fixed grace
  * period (blocking — see withScratchDir, whose callback must stay

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -207,20 +207,34 @@ export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
  * Stop a process started by startEcapture, with a brief grace period to
  * flush and exit before the caller reads its log file. Killed via `sudo`
  * since ecapture runs as root -- an unprivileged `process.kill()` would just
- * fail with EPERM. Not a wait-until-exited poll: the blocking sleep here
- * starves the event loop, so `proc.exitCode`/`kill(pid, 0)` can't be trusted.
+ * fail with EPERM. Escalates to SIGKILL if it's still alive after the grace
+ * period: ecapture doesn't always honor SIGTERM promptly (detaching its eBPF
+ * uprobes can be slow, or get stuck), and a stopEcapture that only ever sends
+ * SIGTERM leaves it running as a leaked root process indefinitely -- these
+ * accumulate silently across many `run:` steps until enough are alive at
+ * once to destabilize the runner. Liveness is checked via a fresh `sudo kill
+ * -0`, not Node's own `proc.exitCode`/`kill(pid, 0)`: the blocking sleep here
+ * starves the event loop, so Node can't have reaped this child by now either
+ * way, making its own view of the process unreliable.
  */
 export function stopEcapture(proc: ChildProcess): void {
   if (!proc.pid) return;
+  const pgid = `-${proc.pid}`;
   try {
     // stdio: "ignore" -- execFileSync passes a failing child's stderr straight
     // through even when the thrown error is caught, and "already exited" is
     // an expected, not a warning-worthy, outcome here.
-    execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${proc.pid}`], { stdio: "ignore" });
+    execFileSync("sudo", ["-n", "--", "kill", "-TERM", pgid], { stdio: "ignore" });
   } catch {
     return; // already exited, or sudo itself failed
   }
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+  try {
+    execFileSync("sudo", ["-n", "--", "kill", "-0", pgid], { stdio: "ignore" }); // throws (ESRCH) if already gone
+    execFileSync("sudo", ["-n", "--", "kill", "-KILL", pgid], { stdio: "ignore" });
+  } catch {
+    // Already gone (kill -0 failed), or sudo itself failed.
+  }
 }
 
 /** Parse ecapture's captured log into this step's HTTPS communication logs.

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -206,7 +206,10 @@ export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
 export function stopEcapture(proc: ChildProcess): void {
   if (!proc.pid) return;
   try {
-    execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${proc.pid}`]);
+    // stdio: "ignore" -- execFileSync passes a failing child's stderr straight
+    // through even when the thrown error is caught, and "already exited" is
+    // an expected, not a warning-worthy, outcome here.
+    execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${proc.pid}`], { stdio: "ignore" });
   } catch {
     return; // already exited, or sudo itself failed
   }
@@ -250,7 +253,10 @@ export function ensureCgroupDir(cgroupPath: string): void {
  *  no-ops if the cgroup is still in use or already gone. */
 export function removeCgroupDirIfEmpty(cgroupPath: string): void {
   try {
-    execFileSync("sudo", ["-n", "--", "rmdir", cgroupPath]);
+    // stdio: "ignore" -- suppresses the expected "No such file or directory"/
+    // "Device or busy" stderr that execFileSync would otherwise print even
+    // though the error below is caught and intentionally not surfaced.
+    execFileSync("sudo", ["-n", "--", "rmdir", cgroupPath], { stdio: "ignore" });
   } catch {
     // Already removed by runc, or still non-empty -- not our job to force it.
   }

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -176,6 +176,13 @@ export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?
   // Swallow spawn failures (async 'error' event) so they can't crash the
   // process -- waitForEcaptureReady's own timeout already covers this as a no-op.
   proc.on("error", () => {});
+  // Without this, Node keeps the event loop alive until this child actually
+  // exits -- by default true even for a detached child (see Node's own
+  // child_process docs). stopEcapture only sends SIGTERM and waits a fixed
+  // 500ms with no confirmation, so if ecapture is slow to tear down its eBPF
+  // probes, the whole run action step would otherwise hang well past the
+  // point where its own work (report, docker compose down) is already done.
+  proc.unref();
   return proc;
 }
 

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -204,17 +204,17 @@ export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
 
 /**
  * Stop a process started by startEcapture, with a brief grace period to
- * flush and exit before the caller reads its log file. Not a wait-until-
- * exited poll: the blocking sleep here starves the event loop, so
- * `proc.exitCode` never updates, and `process.kill(pid, 0)` would still
- * succeed against a zombie either way.
+ * flush and exit before the caller reads its log file. Killed via `sudo`
+ * since ecapture runs as root -- an unprivileged `process.kill()` would just
+ * fail with EPERM. Not a wait-until-exited poll: the blocking sleep here
+ * starves the event loop, so `proc.exitCode`/`kill(pid, 0)` can't be trusted.
  */
 export function stopEcapture(proc: ChildProcess): void {
   if (!proc.pid) return;
   try {
-    process.kill(-proc.pid, "SIGTERM");
+    execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${proc.pid}`]);
   } catch {
-    return; // already exited
+    return; // already exited, or sudo itself failed
   }
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
 }

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -113,18 +113,21 @@ export function generateBaseOciSpec(runcPath: string, bundleDir: string): OciSpe
   return JSON.parse(readFileSync(join(bundleDir, "config.json"), "utf8"));
 }
 
+/** Extract one binary from the proxy image's `/opt/buildcage/bin/` into `destDir`
+ *  via `docker cp` (not `docker exec` -- some callers run natively on the host,
+ *  see gen-seccomp-profile/main.go). Torn down with the scratch dir. */
+function extractBinaryFromProxyImage(containerName: string, destDir: string, name: string): string {
+  const path = join(destDir, name);
+  execFileSync("docker", buildDockerCpArgs({ containerName, containerPath: `/opt/buildcage/bin/${name}`, hostPath: path }));
+  chmodSync(path, 0o755);
+  return path;
+}
+
 /**
- * Extract runc and gen-seccomp-profile from the proxy image into this run's
- * own `destDir` (its per-step scratch dir), then resolve the base OCI spec
- * and the seccomp profile from them. Run once per `run:` step; each
- * invocation is independent, and everything written here is torn down with
- * the scratch dir (see withScratchDir / cleanupScratchDir).
- *
- * Both binaries ship inside the proxy image and are pulled onto the host via
- * `docker cp`, then run natively there (not `docker exec`) since the seccomp
- * profile's content depends on the real host kernel/arch -- see
- * gen-seccomp-profile/main.go. gen-seccomp-profile is only needed transiently
- * to resolve the profile, so it's removed once read; runc stays for `runc run`.
+ * Extract runc and gen-seccomp-profile, then resolve the base OCI spec and
+ * the seccomp profile from them. Run once per `run:` step; each invocation
+ * is independent. gen-seccomp-profile is only needed transiently to resolve
+ * the profile, so it's removed once read; runc stays for `runc run`.
  */
 export interface ExtractRuncBootstrapOptions {
   containerName: string;
@@ -141,15 +144,8 @@ export function extractRuncBootstrap({
   containerName,
   destDir,
 }: ExtractRuncBootstrapOptions): RuncBootstrap {
-  const runcPath = join(destDir, "runc");
-  const genSeccompProfilePath = join(destDir, "gen-seccomp-profile");
-  execFileSync("docker", buildDockerCpArgs({ containerName, containerPath: "/opt/buildcage/bin/runc", hostPath: runcPath }));
-  execFileSync(
-    "docker",
-    buildDockerCpArgs({ containerName, containerPath: "/opt/buildcage/bin/gen-seccomp-profile", hostPath: genSeccompProfilePath }),
-  );
-  chmodSync(runcPath, 0o755);
-  chmodSync(genSeccompProfilePath, 0o755);
+  const runcPath = extractBinaryFromProxyImage(containerName, destDir, "runc");
+  const genSeccompProfilePath = extractBinaryFromProxyImage(containerName, destDir, "gen-seccomp-profile");
   const seccompProfile = JSON.parse(execFileSync(genSeccompProfilePath, { encoding: "utf8" }));
   const baseSpec = generateBaseOciSpec(runcPath, destDir); // writes config.json into destDir (overwritten later by writeOciConfig)
   rmSync(genSeccompProfilePath); // only needed to resolve seccompProfile above
@@ -160,19 +156,13 @@ export function extractRuncBootstrap({
 /** Extract ecapture onto the runner host, same as extractRuncBootstrap above.
  *  See docs/security.md's Run Action HTTPS communication logs section. */
 export function extractEcapture({ containerName, destDir }: ExtractRuncBootstrapOptions): string {
-  const ecapturePath = join(destDir, "ecapture");
-  execFileSync(
-    "docker",
-    buildDockerCpArgs({ containerName, containerPath: "/opt/buildcage/bin/ecapture", hostPath: ecapturePath }),
-  );
-  chmodSync(ecapturePath, 0o755);
-  return ecapturePath;
+  return extractBinaryFromProxyImage(containerName, destDir, "ecapture");
 }
 
 /**
  * Start ecapture in the background. Meant to run for exactly one `run:`
  * step: start before runIsolated(), stop (stopEcapture) right after.
- * `cgroupPath` (see predictCgroupPath), when given, scopes capture to the
+ * `cgroupPath` (see cgroupFsPath), when given, scopes capture to the
  * isolated command's own cgroup instead of the whole runner host.
  */
 export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?: string): ChildProcess {

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -1,9 +1,21 @@
-import { execFileSync } from "node:child_process";
-import { writeFileSync, mkdtempSync, rmSync, readFileSync, mkdirSync, chmodSync, existsSync } from "node:fs";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import {
+  writeFileSync,
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  mkdirSync,
+  chmodSync,
+  existsSync,
+  openSync,
+  closeSync,
+} from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildDockerCpArgs } from "../../../core/lib/docker/container.ts";
 import { errorMessage } from "../../../core/lib/general/error-message.ts";
+import { scanEcaptureLog } from "../../../core/lib/log/ecapture-log-parser.ts";
+import type { AllowedRequest } from "../../../core/lib/log/vertex-log.ts";
 // Sensitive /proc paths masked with /dev/null. runc's own `runc spec`
 // default already masks /proc/kcore, /proc/keys, and /proc/timer_list
 // (among others) and leaves /proc/sysrq-trigger merely read-only —
@@ -142,6 +154,101 @@ export function extractRuncBootstrap({
   rmSync(genSeccompProfilePath); // only needed to resolve seccompProfile above
 
   return { runcPath, seccompProfile, baseSpec };
+}
+
+/**
+ * Extract ecapture (eBPF-based TLS plaintext capture, no CA certificate
+ * needed) from the proxy image onto the runner host, alongside runc/
+ * gen-seccomp-profile above. Run natively on the host (not `docker exec`)
+ * for the same reason those are: it needs to observe the isolated command
+ * directly, and the sandbox's rootfs is a bind-mount of the host's own `/`
+ * (see run-isolated.sh), so a host-native ecapture process resolves the
+ * exact same libssl.so the sandboxed command loads — no cross-mount-
+ * namespace path resolution needed. See docs/security.md's Run Action HTTPS
+ * communication logs section for what this does and doesn't capture.
+ */
+export function extractEcapture({ containerName, destDir }: ExtractRuncBootstrapOptions): string {
+  const ecapturePath = join(destDir, "ecapture");
+  execFileSync(
+    "docker",
+    buildDockerCpArgs({ containerName, containerPath: "/opt/buildcage/bin/ecapture", hostPath: ecapturePath }),
+  );
+  chmodSync(ecapturePath, 0o755);
+  return ecapturePath;
+}
+
+/**
+ * Start ecapture in the background, writing its captured events to `logPath`
+ * (inside this run's own scratch dir). Meant to be started just before
+ * runIsolated() and stopped (stopEcapture) right after it returns, so its
+ * capture window covers exactly one `run:` step.
+ *
+ * No `--pid`/`--cgroup_path` scoping is applied by default: as of now,
+ * ecapture observes every OpenSSL-linked process on the runner host for the
+ * duration of this step, not just the isolated command's own (see
+ * docs/security.md's known limitations). `cgroupPath`, when a caller
+ * eventually has one to pass, would narrow that — see the TODO on this
+ * repo's own dev-loop investigation notes; every attempt to resolve a
+ * runc-nested sandbox's own auto-generated cgroup failed in local testing
+ * for a reason not yet root-caused, so this parameter is unused for now,
+ * pending re-verification on a real Linux CI host.
+ */
+export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?: string): ChildProcess {
+  const args = ["-n", "--", ecapturePath, "tls", "-m", "text"];
+  if (cgroupPath) args.push(`--cgroup_path=${cgroupPath}`);
+  const logFd = openSync(logPath, "w");
+  // detached: true puts ecapture in its own process group, so stopEcapture
+  // can SIGTERM the whole group (-pid) rather than just `sudo`'s own PID —
+  // some sudoers configurations (Defaults use_pty) fork a monitor process
+  // between `sudo` and the actual command, which a plain, non-group kill
+  // would leave running (the same residual gap run-isolated.sh's own
+  // setpriv --pdeathsig comment already documents for a similar reason).
+  const proc = spawn("sudo", args, { stdio: ["ignore", logFd, logFd], detached: true });
+  closeSync(logFd);
+  return proc;
+}
+
+/**
+ * Stop a process started by startEcapture, giving it a brief, fixed grace
+ * period (blocking — see withScratchDir, whose callback must stay
+ * synchronous) to flush and exit before the caller reads its log file.
+ *
+ * Not a wait-until-actually-exited poll: the `Atomics.wait`-based blocking
+ * sleep below (same pattern as removeScratchDir's retry loop) starves the
+ * event loop, so Node can never process this child's own exit notification
+ * while we're in it — `proc.exitCode` would never update. A raw
+ * `process.kill(pid, 0)` liveness probe doesn't work as a substitute either:
+ * it still succeeds against a zombie (exited but not yet reaped) process,
+ * which is exactly the state this child sits in for as long as we keep
+ * starving the event loop, so a loop built on that check would always run
+ * to its full timeout. Distinguishing zombie from running requires an
+ * OS-specific mechanism (e.g. /proc/<pid>/stat's state field on Linux) this
+ * function deliberately avoids needing. ecapture's own writes are
+ * unbuffered per captured event, so anything already written to the log by
+ * the time SIGTERM lands is already on disk regardless of exactly when the
+ * process finishes exiting.
+ */
+export function stopEcapture(proc: ChildProcess): void {
+  if (!proc.pid) return;
+  try {
+    process.kill(-proc.pid, "SIGTERM");
+  } catch {
+    return; // already exited
+  }
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+}
+
+/**
+ * Read and parse ecapture's captured log (see startEcapture), returning the
+ * HTTPS communication logs to attach to this step's report. Returns
+ * undefined (not an empty array) if the log doesn't exist at all — e.g.
+ * ecapture failed to start — distinguishing "not captured" from "captured,
+ * saw nothing".
+ */
+export function readEcaptureLog(logPath: string): AllowedRequest[] | undefined {
+  if (!existsSync(logPath)) return undefined;
+  const content = readFileSync(logPath, "utf8");
+  return scanEcaptureLog(content.split("\n"));
 }
 
 /**

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -182,6 +182,9 @@ export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?
   // not just sudo's own PID (some sudoers configs fork a monitor process).
   const proc = spawn("sudo", args, { stdio: ["ignore", logFd, logFd], detached: true });
   closeSync(logFd);
+  // Swallow spawn failures (async 'error' event) so they can't crash the
+  // process -- waitForEcaptureReady's own timeout already covers this as a no-op.
+  proc.on("error", () => {});
   return proc;
 }
 

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -225,15 +225,18 @@ export function stopEcapture(proc: ChildProcess): void {
     // through even when the thrown error is caught, and "already exited" is
     // an expected, not a warning-worthy, outcome here.
     execFileSync("sudo", ["-n", "--", "kill", "-TERM", pgid], { stdio: "ignore" });
-  } catch {
+  } catch (e) {
+    console.error(`DEBUG stopEcapture: initial TERM to ${pgid} threw: ${errorMessage(e)}`); // TEMPORARY
     return; // already exited, or sudo itself failed
   }
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
   try {
     execFileSync("sudo", ["-n", "--", "kill", "-0", pgid], { stdio: "ignore" }); // throws (ESRCH) if already gone
+    console.error(`DEBUG stopEcapture: ${pgid} still alive after TERM+500ms, escalating to KILL`); // TEMPORARY
     execFileSync("sudo", ["-n", "--", "kill", "-KILL", pgid], { stdio: "ignore" });
-  } catch {
-    // Already gone (kill -0 failed), or sudo itself failed.
+    console.error(`DEBUG stopEcapture: KILL sent to ${pgid}`); // TEMPORARY
+  } catch (e) {
+    console.error(`DEBUG stopEcapture: ${pgid} liveness check/escalation ended: ${errorMessage(e)}`); // TEMPORARY
   }
 }
 

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -183,15 +183,16 @@ export function extractEcapture({ containerName, destDir }: ExtractRuncBootstrap
  * runIsolated() and stopped (stopEcapture) right after it returns, so its
  * capture window covers exactly one `run:` step.
  *
- * No `--pid`/`--cgroup_path` scoping is applied by default: as of now,
- * ecapture observes every OpenSSL-linked process on the runner host for the
- * duration of this step, not just the isolated command's own (see
- * docs/security.md's known limitations). `cgroupPath`, when a caller
- * eventually has one to pass, would narrow that — see the TODO on this
- * repo's own dev-loop investigation notes; every attempt to resolve a
- * runc-nested sandbox's own auto-generated cgroup failed in local testing
- * for a reason not yet root-caused, so this parameter is unused for now,
- * pending re-verification on a real Linux CI host.
+ * `cgroupPath` (see predictCgroupPath/ensureCgroupDir), when given, scopes
+ * ecapture to just the isolated command's own cgroup rather than every
+ * OpenSSL-linked process on the runner host for the step's duration — see
+ * docs/security.md's known limitations for why this matters (cross-talk
+ * between concurrent `run:` steps, or with an unrelated process, on a
+ * shared/self-hosted runner). Earlier attempts to resolve a runc-nested
+ * sandbox's own cgroup failed in Mac dev-loop testing for a reason
+ * eventually traced to that testing environment specifically (see
+ * predictCgroupPath's own doc) — real Linux CI is what determines whether
+ * this actually narrows capture as intended.
  */
 export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?: string): ChildProcess {
   const args = ["-n", "--", ecapturePath, "tls", "-m", "text"];
@@ -273,6 +274,74 @@ export function readEcaptureLog(logPath: string): AllowedRequest[] | undefined {
   if (!existsSync(logPath)) return undefined;
   const content = readFileSync(logPath, "utf8");
   return scanEcaptureLog(content.split("\n"));
+}
+
+/**
+ * Predict the cgroup v2 path runc will create for a container named
+ * `containerName`, given no explicit `linux.cgroupsPath` in the OCI config
+ * (buildOciConfig doesn't set one). Confirmed against runc's own source
+ * (opencontainers/cgroups' fs2.defaultDirPath): with no cgroupsPath and no
+ * systemd cgroup driver, the path is `/sys/fs/cgroup/<parent-of-runc's-own-
+ * current-cgroup>/<containerName>` — i.e. a sibling of whatever cgroup the
+ * process invoking `runc run` (this Node process, via `sudo`, which doesn't
+ * itself move cgroups) is currently in. This is NOT a fixed prefix like
+ * `/docker/<id>` — that was only ever true in Mac dev-loop testing because
+ * the dev-loop container's own cgroup happened to be under `/docker/...`,
+ * confirmed by reading runc's actual path-computation logic instead of
+ * assuming the earlier observation generalized.
+ *
+ * The predicted path doesn't exist yet at this point (runc only creates it
+ * once the container actually starts) — see ensureCgroupDir, which must run
+ * before ecapture's own `--cgroup_path` validation (a plain stat check) can
+ * succeed.
+ */
+export function predictCgroupPath(containerName: string): string {
+  return computeCgroupPath(readFileSync("/proc/self/cgroup", "utf8"), containerName);
+}
+
+/** Pure half of predictCgroupPath, split out so it's testable without a real
+ *  /proc/self/cgroup (not present on macOS, where these tests also run). */
+export function computeCgroupPath(selfCgroupContent: string, containerName: string): string {
+  const line = selfCgroupContent.split("\n").find((l) => l.startsWith("0::"));
+  if (!line) {
+    throw new Error(`could not find a cgroup v2 (unified) entry in /proc/self/cgroup: ${selfCgroupContent}`);
+  }
+  const ownCgroupPath = line.slice("0::".length).trim();
+  const parent = dirname(ownCgroupPath);
+  return join("/sys/fs/cgroup", parent, containerName);
+}
+
+/**
+ * Create the cgroup v2 directory runc will later reuse for the isolated
+ * command (see predictCgroupPath), so ecapture's `--cgroup_path` validation
+ * has something real to stat before the container itself exists. Run via
+ * `sudo` since `/sys/fs/cgroup` isn't writable by the runner's own
+ * unprivileged user. Safe to pre-create: runc's own cgroup setup
+ * (opencontainers/cgroups' fs2.CreateCgroupPath) already tolerates the
+ * directory existing (os.Mkdir + os.IsExist check), and its normal container
+ * teardown (`runc delete -f` in run-isolated.sh's cleanup trap) removes it
+ * regardless of who created it.
+ */
+export function ensureCgroupDir(cgroupPath: string): void {
+  execFileSync("sudo", ["-n", "--", "mkdir", "-p", cgroupPath]);
+}
+
+/**
+ * Best-effort cleanup for the directory ensureCgroupDir created. Normally
+ * already removed by runc's own container teardown (`runc delete -f` in
+ * run-isolated.sh's cleanup trap, which removes the cgroup it manages
+ * regardless of who created the directory) — this is a safety net for the
+ * case where that didn't happen (e.g. runIsolated itself failed before ever
+ * creating a container). `rmdir` only removes an *empty* directory, so this
+ * silently no-ops rather than forcing anything if the cgroup is still in use
+ * or already gone.
+ */
+export function removeCgroupDirIfEmpty(cgroupPath: string): void {
+  try {
+    execFileSync("sudo", ["-n", "--", "rmdir", cgroupPath]);
+  } catch {
+    // Already removed by runc, or still non-empty -- not our job to force it.
+  }
 }
 
 /**

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -60,6 +60,7 @@ interface OciSpec {
     readonlyPaths?: string[];
     namespaces: { type: string; path?: string }[];
     seccomp?: unknown;
+    cgroupsPath?: string;
   };
   root?: unknown;
   process: Record<string, unknown>;
@@ -230,30 +231,21 @@ export function readEcaptureLog(logPath: string): AllowedRequest[] | undefined {
   return scanEcaptureLog(content.split("\n"));
 }
 
-/**
- * Predict the cgroup v2 path runc will create for `containerName` (no
- * explicit `linux.cgroupsPath` is set in the OCI config). Per runc's own
- * source (opencontainers/cgroups' fs2.defaultDirPath), that's
- * `/sys/fs/cgroup/<parent of the caller's own cgroup>/<containerName>` — not
- * a fixed prefix like `/docker/<id>`, which was only ever an artifact of the
- * Mac dev-loop's own container living under `/docker/...`.
- *
- * The path doesn't exist yet here (runc creates it once the container
- * starts) — see ensureCgroupDir.
- */
-export function predictCgroupPath(containerName: string): string {
-  return computeCgroupPath(readFileSync("/proc/self/cgroup", "utf8"), containerName);
+// Passed to buildOciConfig as linux.cgroupsPath, so runc creates the
+// container's cgroup exactly here instead of us predicting its own default.
+// Arbitrary and fixed -- only needs to be unique per container.
+const CGROUP_INNER_PREFIX = "/buildcage-run";
+
+/** The `linux.cgroupsPath` value for `containerName`'s OCI config, relative
+ *  to the cgroup v2 mount root. */
+export function cgroupInnerPath(containerName: string): string {
+  return `${CGROUP_INNER_PREFIX}/${containerName}`;
 }
 
-/** Pure half of predictCgroupPath (no real /proc/self/cgroup on macOS, where these tests also run). */
-export function computeCgroupPath(selfCgroupContent: string, containerName: string): string {
-  const line = selfCgroupContent.split("\n").find((l) => l.startsWith("0::"));
-  if (!line) {
-    throw new Error(`could not find a cgroup v2 (unified) entry in /proc/self/cgroup: ${selfCgroupContent}`);
-  }
-  const ownCgroupPath = line.slice("0::".length).trim();
-  const parent = dirname(ownCgroupPath);
-  return join("/sys/fs/cgroup", parent, containerName);
+/** The real filesystem path of `cgroupInnerPath`'s cgroup, for
+ *  ensureCgroupDir/removeCgroupDirIfEmpty and ecapture's own `--cgroup_path`. */
+export function cgroupFsPath(containerName: string): string {
+  return join("/sys/fs/cgroup", cgroupInnerPath(containerName));
 }
 
 /** Pre-create the cgroup so ecapture's own `--cgroup_path` validation (a
@@ -426,6 +418,8 @@ function assertScratchBaseNotWritable(writableDirs: string[]): void {
  * - linux.seccomp: the Docker-default-profile-derived filter (see
  *   gen-seccomp-profile), resolved against this same empty capability
  *   set.
+ * - linux.cgroupsPath: set when given so runc creates the container's cgroup
+ *   exactly where ensureCgroupDir already prepared it (see cgroupInnerPath).
  *
  * `writablePaths` containing "/" is a sentinel meaning "disable the
  * read-only restriction entirely" (see docs/reference.md's `writable`
@@ -445,6 +439,7 @@ export interface BuildOciConfigOptions {
   seccompProfile: unknown;
   scriptPath: string;
   hostMounts?: HostMount[];
+  cgroupsPath?: string;
 }
 
 export function buildOciConfig(
@@ -459,6 +454,7 @@ export function buildOciConfig(
     env,
     netnsPath,
     rootfsBindDir,
+    cgroupsPath,
     resolvConfPath,
     seccompProfile,
     scriptPath,
@@ -528,6 +524,7 @@ export function buildOciConfig(
       seccomp: seccompProfile,
       maskedPaths,
       readonlyPaths,
+      ...(cgroupsPath ? { cgroupsPath } : {}),
     },
   };
 }

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -156,17 +156,8 @@ export function extractRuncBootstrap({
   return { runcPath, seccompProfile, baseSpec };
 }
 
-/**
- * Extract ecapture (eBPF-based TLS plaintext capture, no CA certificate
- * needed) from the proxy image onto the runner host, alongside runc/
- * gen-seccomp-profile above. Run natively on the host (not `docker exec`)
- * for the same reason those are: it needs to observe the isolated command
- * directly, and the sandbox's rootfs is a bind-mount of the host's own `/`
- * (see run-isolated.sh), so a host-native ecapture process resolves the
- * exact same libssl.so the sandboxed command loads — no cross-mount-
- * namespace path resolution needed. See docs/security.md's Run Action HTTPS
- * communication logs section for what this does and doesn't capture.
- */
+/** Extract ecapture onto the runner host, same as extractRuncBootstrap above.
+ *  See docs/security.md's Run Action HTTPS communication logs section. */
 export function extractEcapture({ containerName, destDir }: ExtractRuncBootstrapOptions): string {
   const ecapturePath = join(destDir, "ecapture");
   execFileSync(
@@ -178,32 +169,17 @@ export function extractEcapture({ containerName, destDir }: ExtractRuncBootstrap
 }
 
 /**
- * Start ecapture in the background, writing its captured events to `logPath`
- * (inside this run's own scratch dir). Meant to be started just before
- * runIsolated() and stopped (stopEcapture) right after it returns, so its
- * capture window covers exactly one `run:` step.
- *
- * `cgroupPath` (see predictCgroupPath/ensureCgroupDir), when given, scopes
- * ecapture to just the isolated command's own cgroup rather than every
- * OpenSSL-linked process on the runner host for the step's duration — see
- * docs/security.md's known limitations for why this matters (cross-talk
- * between concurrent `run:` steps, or with an unrelated process, on a
- * shared/self-hosted runner). Earlier attempts to resolve a runc-nested
- * sandbox's own cgroup failed in Mac dev-loop testing for a reason
- * eventually traced to that testing environment specifically (see
- * predictCgroupPath's own doc) — real Linux CI is what determines whether
- * this actually narrows capture as intended.
+ * Start ecapture in the background. Meant to run for exactly one `run:`
+ * step: start before runIsolated(), stop (stopEcapture) right after.
+ * `cgroupPath` (see predictCgroupPath), when given, scopes capture to the
+ * isolated command's own cgroup instead of the whole runner host.
  */
 export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?: string): ChildProcess {
   const args = ["-n", "--", ecapturePath, "tls", "-m", "text"];
   if (cgroupPath) args.push(`--cgroup_path=${cgroupPath}`);
   const logFd = openSync(logPath, "w");
-  // detached: true puts ecapture in its own process group, so stopEcapture
-  // can SIGTERM the whole group (-pid) rather than just `sudo`'s own PID —
-  // some sudoers configurations (Defaults use_pty) fork a monitor process
-  // between `sudo` and the actual command, which a plain, non-group kill
-  // would leave running (the same residual gap run-isolated.sh's own
-  // setpriv --pdeathsig comment already documents for a similar reason).
+  // detached so stopEcapture can SIGTERM the whole process group (-pid),
+  // not just sudo's own PID (some sudoers configs fork a monitor process).
   const proc = spawn("sudo", args, { stdio: ["ignore", logFd, logFd], detached: true });
   closeSync(logFd);
   return proc;
@@ -212,16 +188,9 @@ export function startEcapture(ecapturePath: string, logPath: string, cgroupPath?
 const ECAPTURE_READY_PATTERN = /started successfully/;
 
 /**
- * Block (synchronously — see withScratchDir) until ecapture's own log shows
- * it has finished loading and attaching its eBPF probes, or `timeoutMs`
- * elapses, whichever comes first. Loading/verifying the eBPF bytecode and
- * attaching probes isn't instant, and its exact duration varies with the
- * kernel; without this, a short-lived isolated command (a handful of quick
- * `wget`/`curl` calls, done in well under a second) can run to completion
- * before ecapture is actually capturing anything, silently yielding an empty
- * (rather than merely absent) httpLogs. Best-effort: on timeout this simply
- * gives up and lets the caller proceed anyway — missing the capture window
- * is preferable to hanging the whole step indefinitely.
+ * Block until ecapture's log shows its eBPF probes are attached, or
+ * `timeoutMs` elapses. Needed because a short isolated command can finish
+ * before ecapture is actually capturing anything.
  */
 export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
   const deadline = Date.now() + timeoutMs;
@@ -234,24 +203,11 @@ export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
 }
 
 /**
- * Stop a process started by startEcapture, giving it a brief, fixed grace
- * period (blocking — see withScratchDir, whose callback must stay
- * synchronous) to flush and exit before the caller reads its log file.
- *
- * Not a wait-until-actually-exited poll: the `Atomics.wait`-based blocking
- * sleep below (same pattern as removeScratchDir's retry loop) starves the
- * event loop, so Node can never process this child's own exit notification
- * while we're in it — `proc.exitCode` would never update. A raw
- * `process.kill(pid, 0)` liveness probe doesn't work as a substitute either:
- * it still succeeds against a zombie (exited but not yet reaped) process,
- * which is exactly the state this child sits in for as long as we keep
- * starving the event loop, so a loop built on that check would always run
- * to its full timeout. Distinguishing zombie from running requires an
- * OS-specific mechanism (e.g. /proc/<pid>/stat's state field on Linux) this
- * function deliberately avoids needing. ecapture's own writes are
- * unbuffered per captured event, so anything already written to the log by
- * the time SIGTERM lands is already on disk regardless of exactly when the
- * process finishes exiting.
+ * Stop a process started by startEcapture, with a brief grace period to
+ * flush and exit before the caller reads its log file. Not a wait-until-
+ * exited poll: the blocking sleep here starves the event loop, so
+ * `proc.exitCode` never updates, and `process.kill(pid, 0)` would still
+ * succeed against a zombie either way.
  */
 export function stopEcapture(proc: ChildProcess): void {
   if (!proc.pid) return;
@@ -263,13 +219,8 @@ export function stopEcapture(proc: ChildProcess): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
 }
 
-/**
- * Read and parse ecapture's captured log (see startEcapture), returning the
- * HTTPS communication logs to attach to this step's report. Returns
- * undefined (not an empty array) if the log doesn't exist at all — e.g.
- * ecapture failed to start — distinguishing "not captured" from "captured,
- * saw nothing".
- */
+/** Parse ecapture's captured log into this step's HTTPS communication logs.
+ *  Undefined (not empty) if the log doesn't exist at all. */
 export function readEcaptureLog(logPath: string): AllowedRequest[] | undefined {
   if (!existsSync(logPath)) return undefined;
   const content = readFileSync(logPath, "utf8");
@@ -277,30 +228,21 @@ export function readEcaptureLog(logPath: string): AllowedRequest[] | undefined {
 }
 
 /**
- * Predict the cgroup v2 path runc will create for a container named
- * `containerName`, given no explicit `linux.cgroupsPath` in the OCI config
- * (buildOciConfig doesn't set one). Confirmed against runc's own source
- * (opencontainers/cgroups' fs2.defaultDirPath): with no cgroupsPath and no
- * systemd cgroup driver, the path is `/sys/fs/cgroup/<parent-of-runc's-own-
- * current-cgroup>/<containerName>` — i.e. a sibling of whatever cgroup the
- * process invoking `runc run` (this Node process, via `sudo`, which doesn't
- * itself move cgroups) is currently in. This is NOT a fixed prefix like
- * `/docker/<id>` — that was only ever true in Mac dev-loop testing because
- * the dev-loop container's own cgroup happened to be under `/docker/...`,
- * confirmed by reading runc's actual path-computation logic instead of
- * assuming the earlier observation generalized.
+ * Predict the cgroup v2 path runc will create for `containerName` (no
+ * explicit `linux.cgroupsPath` is set in the OCI config). Per runc's own
+ * source (opencontainers/cgroups' fs2.defaultDirPath), that's
+ * `/sys/fs/cgroup/<parent of the caller's own cgroup>/<containerName>` — not
+ * a fixed prefix like `/docker/<id>`, which was only ever an artifact of the
+ * Mac dev-loop's own container living under `/docker/...`.
  *
- * The predicted path doesn't exist yet at this point (runc only creates it
- * once the container actually starts) — see ensureCgroupDir, which must run
- * before ecapture's own `--cgroup_path` validation (a plain stat check) can
- * succeed.
+ * The path doesn't exist yet here (runc creates it once the container
+ * starts) — see ensureCgroupDir.
  */
 export function predictCgroupPath(containerName: string): string {
   return computeCgroupPath(readFileSync("/proc/self/cgroup", "utf8"), containerName);
 }
 
-/** Pure half of predictCgroupPath, split out so it's testable without a real
- *  /proc/self/cgroup (not present on macOS, where these tests also run). */
+/** Pure half of predictCgroupPath (no real /proc/self/cgroup on macOS, where these tests also run). */
 export function computeCgroupPath(selfCgroupContent: string, containerName: string): string {
   const line = selfCgroupContent.split("\n").find((l) => l.startsWith("0::"));
   if (!line) {
@@ -311,31 +253,16 @@ export function computeCgroupPath(selfCgroupContent: string, containerName: stri
   return join("/sys/fs/cgroup", parent, containerName);
 }
 
-/**
- * Create the cgroup v2 directory runc will later reuse for the isolated
- * command (see predictCgroupPath), so ecapture's `--cgroup_path` validation
- * has something real to stat before the container itself exists. Run via
- * `sudo` since `/sys/fs/cgroup` isn't writable by the runner's own
- * unprivileged user. Safe to pre-create: runc's own cgroup setup
- * (opencontainers/cgroups' fs2.CreateCgroupPath) already tolerates the
- * directory existing (os.Mkdir + os.IsExist check), and its normal container
- * teardown (`runc delete -f` in run-isolated.sh's cleanup trap) removes it
- * regardless of who created it.
- */
+/** Pre-create the cgroup so ecapture's own `--cgroup_path` validation (a
+ *  stat check) succeeds before the container exists. runc's cgroup setup
+ *  tolerates the directory already existing, and removes it on teardown
+ *  regardless of who created it. */
 export function ensureCgroupDir(cgroupPath: string): void {
   execFileSync("sudo", ["-n", "--", "mkdir", "-p", cgroupPath]);
 }
 
-/**
- * Best-effort cleanup for the directory ensureCgroupDir created. Normally
- * already removed by runc's own container teardown (`runc delete -f` in
- * run-isolated.sh's cleanup trap, which removes the cgroup it manages
- * regardless of who created the directory) — this is a safety net for the
- * case where that didn't happen (e.g. runIsolated itself failed before ever
- * creating a container). `rmdir` only removes an *empty* directory, so this
- * silently no-ops rather than forcing anything if the cgroup is still in use
- * or already gone.
- */
+/** Best-effort cleanup in case runc's own teardown didn't run. `rmdir`
+ *  no-ops if the cgroup is still in use or already gone. */
 export function removeCgroupDirIfEmpty(cgroupPath: string): void {
   try {
     execFileSync("sudo", ["-n", "--", "rmdir", cgroupPath]);

--- a/run/src/lib/isolated-exec.ts
+++ b/run/src/lib/isolated-exec.ts
@@ -203,6 +203,23 @@ export function waitForEcaptureReady(logPath: string, timeoutMs = 5000): void {
   }
 }
 
+// TEMPORARY (debug build): polls `sudo kill -0 <pgid>` instead of a single
+// fixed sleep, to test whether ecapture just needs more than 500ms to exit
+// on its own -- returns true as soon as the group is gone, false if it's
+// still alive once timeoutMs elapses.
+function waitUntilGone(pgid: string, timeoutMs: number): boolean {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      execFileSync("sudo", ["-n", "--", "kill", "-0", pgid], { stdio: "ignore" });
+    } catch {
+      return true; // ESRCH -- gone
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+  }
+  return false;
+}
+
 /**
  * Stop a process started by startEcapture, with a brief grace period to
  * flush and exit before the caller reads its log file. Killed via `sudo`
@@ -229,14 +246,26 @@ export function stopEcapture(proc: ChildProcess): void {
     console.error(`DEBUG stopEcapture: initial TERM to ${pgid} threw: ${errorMessage(e)}`); // TEMPORARY
     return; // already exited, or sudo itself failed
   }
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+  // TEMPORARY: was a fixed 500ms sleep -- now polls up to 8s to test whether
+  // ecapture just needs more time to exit gracefully on its own.
+  if (waitUntilGone(pgid, 8000)) {
+    console.error(`DEBUG stopEcapture: ${pgid} exited on its own within 8s of TERM`); // TEMPORARY
+    return;
+  }
+  console.error(`DEBUG stopEcapture: ${pgid} still alive after TERM+8s, escalating to KILL`); // TEMPORARY
   try {
-    execFileSync("sudo", ["-n", "--", "kill", "-0", pgid], { stdio: "ignore" }); // throws (ESRCH) if already gone
-    console.error(`DEBUG stopEcapture: ${pgid} still alive after TERM+500ms, escalating to KILL`); // TEMPORARY
     execFileSync("sudo", ["-n", "--", "kill", "-KILL", pgid], { stdio: "ignore" });
-    console.error(`DEBUG stopEcapture: KILL sent to ${pgid}`); // TEMPORARY
   } catch (e) {
-    console.error(`DEBUG stopEcapture: ${pgid} liveness check/escalation ended: ${errorMessage(e)}`); // TEMPORARY
+    console.error(`DEBUG stopEcapture: KILL to ${pgid} threw: ${errorMessage(e)}`); // TEMPORARY
+    return;
+  }
+  // TEMPORARY: confirm KILL actually took effect within a further 5s, rather
+  // than returning immediately and letting the next ecapture instance start
+  // while this one is still tearing down.
+  if (waitUntilGone(pgid, 5000)) {
+    console.error(`DEBUG stopEcapture: ${pgid} gone within 5s of KILL`); // TEMPORARY
+  } else {
+    console.error(`DEBUG stopEcapture: ${pgid} STILL ALIVE 5s after KILL`); // TEMPORARY
   }
 }
 

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -247,4 +247,25 @@ describe("buildReportMarkdown", () => {
     const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
     assert.doesNotMatch(markdown, /Expected/);
   });
+
+  it("appends the ecapture HTTPS communication logs section when httpLogs is set", () => {
+    const r = report({ httpLogs: [{ method: "GET", url: "https://example.com/", status: 200 }] });
+    const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
+    assert.match(markdown, /💬 HTTPS communication logs/);
+    assert.match(markdown, /- GET https:\/\/example\.com\/ -> 200/);
+  });
+
+  it("omits the ecapture HTTPS communication logs section when httpLogs is unset", () => {
+    const markdown = buildReportMarkdown(report(), { actionRepo: "dash14/buildcage", actionRef: "v2" });
+    assert.doesNotMatch(markdown, /HTTPS communication logs/);
+  });
+
+  it("shows the ecapture section in audit mode too, not just restrict", () => {
+    const r = report({
+      parameters: parameters({ mode: "audit" }),
+      httpLogs: [{ method: "GET", url: "https://example.com/", status: 200 }],
+    });
+    const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
+    assert.match(markdown, /💬 HTTPS communication logs/);
+  });
 });

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -4,6 +4,7 @@ import { createAnnotation } from "../../../core/lib/actions/annotation.ts";
 import { buildRestrictExample } from "../../../core/lib/report/build-example.ts";
 import { determineBlockedOutcome, buildBlockedMessage } from "../../../core/lib/report/known-blocked.ts";
 import { renderHostTable } from "../../../core/lib/report/host-table.ts";
+import { renderHttpLogList } from "../../../core/lib/report/command-log.ts";
 import { buildTransparentReportData } from "../../../core/lib/report/build-transparent-report-data.ts";
 import type { GenReportParameters, TransparentReportData } from "../../../core/lib/report/report-data.ts";
 
@@ -47,6 +48,8 @@ export function buildReportMarkdown(
     if (report.passed.length > 0) markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(report.passed) + "\n\n";
     if (report.blocked.length > 0) markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(report.blocked, { showReason: true, showExpected }) + "\n\n";
   }
+
+  markdown += renderHttpLogList(report.httpLogs);
 
   return markdown;
 }

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -24,6 +24,9 @@ import {
   writeResolvConf,
   extractRuncBootstrap,
   extractEcapture,
+  predictCgroupPath,
+  ensureCgroupDir,
+  removeCgroupDirIfEmpty,
   startEcapture,
   waitForEcaptureReady,
   stopEcapture,
@@ -249,9 +252,22 @@ async function main(): Promise<void> {
       // annotation, never as a SandboxError that would abort the step itself.
       let ecaptureProc;
       const ecaptureLogPath = join(dir, "ecapture.log");
+      // Scope ecapture to just this step's own cgroup rather than the whole
+      // runner host, when possible. Best-effort and independent of whether
+      // ecapture itself starts below: a failure here (e.g. this host isn't
+      // cgroup v2, or sudo can't create the directory) just falls back to
+      // unscoped, system-wide capture rather than skipping ecapture entirely.
+      let cgroupPath: string | undefined;
+      try {
+        cgroupPath = predictCgroupPath(containerName);
+        ensureCgroupDir(cgroupPath);
+      } catch (e) {
+        annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`);
+        cgroupPath = undefined;
+      }
       try {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
-        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath);
+        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupPath);
         // Loading/attaching its eBPF probes isn't instant -- without this, a
         // short-lived isolated command can finish before ecapture is
         // actually capturing anything (see waitForEcaptureReady's own doc).
@@ -280,6 +296,7 @@ async function main(): Promise<void> {
           annotation.warning(`Failed to read ecapture's HTTPS communication logs: ${errorMessage(e)}`);
         }
       }
+      if (cgroupPath) removeCgroupDirIfEmpty(cgroupPath);
 
       return isolatedExitCode;
     }, containerName);

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -24,7 +24,8 @@ import {
   writeResolvConf,
   extractRuncBootstrap,
   extractEcapture,
-  predictCgroupPath,
+  cgroupInnerPath,
+  cgroupFsPath,
   ensureCgroupDir,
   removeCgroupDirIfEmpty,
   startEcapture,
@@ -213,6 +214,18 @@ async function main(): Promise<void> {
       const netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-");
       const rootfsBindDir = join(dir, "rootfs");
 
+      // Pre-create the cgroup for ecapture's scoped capture (docs/security.md).
+      // Only pass it to buildOciConfig below if this succeeded -- otherwise
+      // fall back to runc's default placement / unscoped capture.
+      const cgroupFs = cgroupFsPath(containerName);
+      let cgroupReady = false;
+      try {
+        ensureCgroupDir(cgroupFs);
+        cgroupReady = true;
+      } catch (e) {
+        annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`);
+      }
+
       let config;
       try {
         const resolvConfPath = writeResolvConf(dns, dir);
@@ -239,6 +252,7 @@ async function main(): Promise<void> {
           seccompProfile,
           scriptPath,
           hostMounts,
+          cgroupsPath: cgroupReady ? cgroupInnerPath(containerName) : undefined,
         });
       } catch (e) {
         throw new SandboxError(`Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`, "OCI_CONFIG_BUILD_FAILED");
@@ -249,17 +263,9 @@ async function main(): Promise<void> {
       // section); a failure here is only ever a warning, never a SandboxError.
       let ecaptureProc;
       const ecaptureLogPath = join(dir, "ecapture.log");
-      let cgroupPath: string | undefined;
-      try {
-        cgroupPath = predictCgroupPath(containerName);
-        ensureCgroupDir(cgroupPath);
-      } catch (e) {
-        annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`);
-        cgroupPath = undefined;
-      }
       try {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
-        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupPath);
+        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupReady ? cgroupFs : undefined);
         waitForEcaptureReady(ecaptureLogPath);
       } catch (e) {
         annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
@@ -285,7 +291,7 @@ async function main(): Promise<void> {
           annotation.warning(`Failed to read ecapture's HTTPS communication logs: ${errorMessage(e)}`);
         }
       }
-      if (cgroupPath) removeCgroupDirIfEmpty(cgroupPath);
+      if (cgroupReady) removeCgroupDirIfEmpty(cgroupFs);
 
       return isolatedExitCode;
     }, containerName);

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -268,8 +268,7 @@ async function main(): Promise<void> {
       const ecaptureLogPath = join(dir, "ecapture.log");
       try {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
-        // TEMPORARY: testing whether --cgroup_path itself is what's causing ecapture to hang on shutdown.
-        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, undefined);
+        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupReady ? cgroupFs : undefined);
         waitForEcaptureReady(ecaptureLogPath);
         if (ecaptureProc.pid && stateFile) {
           appendFileSync(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -23,6 +23,10 @@ import {
   writeRunScript,
   writeResolvConf,
   extractRuncBootstrap,
+  extractEcapture,
+  startEcapture,
+  stopEcapture,
+  readEcaptureLog,
   buildOciConfig,
   writeOciConfig,
   runIsolated,
@@ -30,6 +34,7 @@ import {
   listHostMounts,
 } from "./lib/isolated-exec.ts";
 import { fetchReport, writeReport } from "./lib/report.ts";
+import type { AllowedRequest } from "../../core/lib/log/vertex-log.ts";
 
 export { buildComposeUpArgs, buildComposeDownArgs, buildACLRules };
 
@@ -171,6 +176,7 @@ async function main(): Promise<void> {
   }
 
   let exitCode = 1;
+  let httpLogs: AllowedRequest[] | undefined;
   try {
     const proxyPid = getContainerPid(containerName);
     if (proxyPid === null) {
@@ -235,7 +241,21 @@ async function main(): Promise<void> {
       }
       writeOciConfig(config, dir);
 
-      return runIsolated({
+      // Best-effort HTTPS communication logs (see docs/security.md's Run
+      // Action section): captured alongside the isolated command, not
+      // required for it to run at all. A failure here (e.g. no BTF, no
+      // sudo access to load eBPF programs) only ever surfaces as a warning
+      // annotation, never as a SandboxError that would abort the step itself.
+      let ecaptureProc;
+      const ecaptureLogPath = join(dir, "ecapture.log");
+      try {
+        const ecapturePath = extractEcapture({ containerName, destDir: dir });
+        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath);
+      } catch (e) {
+        annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
+      }
+
+      const isolatedExitCode = runIsolated({
         runcPath,
         proxyPid,
         bundleDir: dir,
@@ -246,6 +266,17 @@ async function main(): Promise<void> {
         dns,
         targetIp,
       });
+
+      if (ecaptureProc) {
+        try {
+          stopEcapture(ecaptureProc);
+          httpLogs = readEcaptureLog(ecaptureLogPath);
+        } catch (e) {
+          annotation.warning(`Failed to read ecapture's HTTPS communication logs: ${errorMessage(e)}`);
+        }
+      }
+
+      return isolatedExitCode;
     }, containerName);
   } finally {
     try {
@@ -256,6 +287,7 @@ async function main(): Promise<void> {
         allowedIpRules: rules.ipRules,
         knownBlockedRules,
       });
+      report.httpLogs = httpLogs;
       writeReport(report, {
         actionRepo,
         actionRef,

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -225,6 +225,9 @@ async function main(): Promise<void> {
       } catch (e) {
         annotation.warning(`Failed to prepare a scoped cgroup for ecapture (falling back to unscoped capture): ${errorMessage(e)}`);
       }
+      if (cgroupReady && stateFile) {
+        appendFileSync(stateFile, `ecapture_cgroup_path=${cgroupFs}\n`);
+      }
 
       let config;
       try {
@@ -267,6 +270,9 @@ async function main(): Promise<void> {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
         ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupReady ? cgroupFs : undefined);
         waitForEcaptureReady(ecaptureLogPath);
+        if (ecaptureProc.pid && stateFile) {
+          appendFileSync(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);
+        }
       } catch (e) {
         annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
       }

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -25,6 +25,7 @@ import {
   extractRuncBootstrap,
   extractEcapture,
   startEcapture,
+  waitForEcaptureReady,
   stopEcapture,
   readEcaptureLog,
   buildOciConfig,
@@ -251,6 +252,10 @@ async function main(): Promise<void> {
       try {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
         ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath);
+        // Loading/attaching its eBPF probes isn't instant -- without this, a
+        // short-lived isolated command can finish before ecapture is
+        // actually capturing anything (see waitForEcaptureReady's own doc).
+        waitForEcaptureReady(ecaptureLogPath);
       } catch (e) {
         annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);
       }

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -268,7 +268,8 @@ async function main(): Promise<void> {
       const ecaptureLogPath = join(dir, "ecapture.log");
       try {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
-        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupReady ? cgroupFs : undefined);
+        // TEMPORARY: testing whether --cgroup_path itself is what's causing ecapture to hang on shutdown.
+        ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, undefined);
         waitForEcaptureReady(ecaptureLogPath);
         if (ecaptureProc.pid && stateFile) {
           appendFileSync(stateFile, `ecapture_pid=${ecaptureProc.pid}\n`);

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -245,18 +245,10 @@ async function main(): Promise<void> {
       }
       writeOciConfig(config, dir);
 
-      // Best-effort HTTPS communication logs (see docs/security.md's Run
-      // Action section): captured alongside the isolated command, not
-      // required for it to run at all. A failure here (e.g. no BTF, no
-      // sudo access to load eBPF programs) only ever surfaces as a warning
-      // annotation, never as a SandboxError that would abort the step itself.
+      // Best-effort HTTPS communication logs (docs/security.md's Run Action
+      // section); a failure here is only ever a warning, never a SandboxError.
       let ecaptureProc;
       const ecaptureLogPath = join(dir, "ecapture.log");
-      // Scope ecapture to just this step's own cgroup rather than the whole
-      // runner host, when possible. Best-effort and independent of whether
-      // ecapture itself starts below: a failure here (e.g. this host isn't
-      // cgroup v2, or sudo can't create the directory) just falls back to
-      // unscoped, system-wide capture rather than skipping ecapture entirely.
       let cgroupPath: string | undefined;
       try {
         cgroupPath = predictCgroupPath(containerName);
@@ -268,9 +260,6 @@ async function main(): Promise<void> {
       try {
         const ecapturePath = extractEcapture({ containerName, destDir: dir });
         ecaptureProc = startEcapture(ecapturePath, ecaptureLogPath, cgroupPath);
-        // Loading/attaching its eBPF probes isn't instant -- without this, a
-        // short-lived isolated command can finish before ecapture is
-        // actually capturing anything (see waitForEcaptureReady's own doc).
         waitForEcaptureReady(ecaptureLogPath);
       } catch (e) {
         annotation.warning(`Failed to start ecapture (HTTPS communication logs will be unavailable): ${errorMessage(e)}`);

--- a/run/src/post.ts
+++ b/run/src/post.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,6 +18,27 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#saving-state.
 const containerName = process.env.STATE_container_name;
 const projectName = process.env.STATE_project_name;
+
+// Fallback-only: main.ts's own stopEcapture already runs on the normal exit
+// path. Checks /proc/<pid>/comm first to guard against PID reuse.
+const ecapturePid = process.env.STATE_ecapture_pid;
+if (ecapturePid) {
+  try {
+    if (readFileSync(`/proc/${ecapturePid}/comm`, "utf8").trim() === "ecapture") {
+      execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${ecapturePid}`]);
+    }
+  } catch {
+    // Already exited, /proc/<pid> is gone, or sudo itself failed.
+  }
+}
+const ecaptureCgroupPath = process.env.STATE_ecapture_cgroup_path;
+if (ecaptureCgroupPath) {
+  try {
+    execFileSync("sudo", ["-n", "--", "rmdir", ecaptureCgroupPath]);
+  } catch {
+    // Already removed by runc's own teardown, or still in use.
+  }
+}
 
 // Reclaim this step's sandbox scratch dir if a hard kill bypassed main.ts's
 // own withScratchDir finally. Its path is derived deterministically from

--- a/run/src/post.ts
+++ b/run/src/post.ts
@@ -25,7 +25,9 @@ const ecapturePid = process.env.STATE_ecapture_pid;
 if (ecapturePid) {
   try {
     if (readFileSync(`/proc/${ecapturePid}/comm`, "utf8").trim() === "ecapture") {
-      execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${ecapturePid}`]);
+      // stdio: "ignore" -- execFileSync leaks a failing child's stderr even
+      // when the error is caught, and "already exited" isn't warning-worthy.
+      execFileSync("sudo", ["-n", "--", "kill", "-TERM", `-${ecapturePid}`], { stdio: "ignore" });
     }
   } catch {
     // Already exited, /proc/<pid> is gone, or sudo itself failed.
@@ -34,7 +36,7 @@ if (ecapturePid) {
 const ecaptureCgroupPath = process.env.STATE_ecapture_cgroup_path;
 if (ecaptureCgroupPath) {
   try {
-    execFileSync("sudo", ["-n", "--", "rmdir", ecaptureCgroupPath]);
+    execFileSync("sudo", ["-n", "--", "rmdir", ecaptureCgroupPath], { stdio: "ignore" });
   } catch {
     // Already removed by runc's own teardown, or still in use.
   }

--- a/run/test/integration-test-concurrent.sh
+++ b/run/test/integration-test-concurrent.sh
@@ -63,6 +63,25 @@ for label_dir in "A:$TMP_A" "B:$TMP_B"; do
   fi
 done
 
+# Beyond reachability, confirm ecapture's cgroup scoping isolates capture too:
+# each summary should show only its own host, never the other (blocked) one.
+for label_dir in "A:$TMP_A:example.com:example.net" "B:$TMP_B:example.net:example.com"; do
+  label="${label_dir%%:*}"
+  rest="${label_dir#*:}"
+  dir="${rest%%:*}"
+  rest="${rest#*:}"
+  own_host="${rest%%:*}"
+  other_host="${rest#*:}"
+  summary="$dir/summary.md"
+  if grep -q "https://$own_host/" "$summary" 2>/dev/null && ! grep -q "https://$other_host/" "$summary" 2>/dev/null; then
+    echo "  PASS  instance $label's HTTPS communication logs show only its own host"
+  else
+    echo "  FAIL  instance $label's HTTPS communication logs are missing its own host or leaked the other's; see summary below"
+    cat "$summary" 2>/dev/null
+    FAILURES=$((FAILURES + 1))
+  fi
+done
+
 LEFTOVER_CONTAINERS=$(docker ps -a --filter "name=buildcage-proxy-" -q)
 if [ -z "$LEFTOVER_CONTAINERS" ]; then
   echo "  PASS  no leftover buildcage-proxy-* containers"

--- a/run/test/integration-test-ecapture-hard-kill-recovery.sh
+++ b/run/test/integration-test-ecapture-hard-kill-recovery.sh
@@ -12,10 +12,6 @@ touch "$WORKDIR/state.env"
 
 cleanup() {
   [ -n "${NODE_PID:-}" ] && kill -9 "$NODE_PID" >/dev/null 2>&1
-  # Matches only the real bash instance running run-isolated.sh, not sudo's
-  # own `use_pty` monitor process (which also has "run-isolated.sh" in its
-  # argv) -- see the kill below for the same distinction.
-  sudo -n pkill -9 -f "/bin/bash .*/run/scripts/run-isolated.sh" >/dev/null 2>&1
   sudo -n pkill -9 -x ecapture >/dev/null 2>&1
   docker ps -aq --filter "name=buildcage-proxy-" | xargs -r docker rm -f >/dev/null 2>&1
   docker network ls --filter "name=buildcage-proxy-" -q | xargs -r docker network rm >/dev/null 2>&1
@@ -29,7 +25,7 @@ GITHUB_STEP_SUMMARY="$WORKDIR/summary.md" \
 BUILDCAGE_BUILD_TEST_HOOKS=1 \
 BUILDCAGE_LOCAL_IMAGE_REF="$BUILDCAGE_LOCAL_IMAGE_REF" \
 INPUT_ALLOWED_HTTPS_RULES="example.com:443" \
-INPUT_RUN='sleep 60' \
+INPUT_RUN='sleep 300' \
   node "$REPO_ROOT/run/dist/main.cjs" > "$WORKDIR/out.log" 2>&1 &
 NODE_PID=$!
 
@@ -50,16 +46,9 @@ fi
 
 ECAPTURE_CGROUP=$(grep "^ecapture_cgroup_path=" "$WORKDIR/state.env" | cut -d= -f2-)
 
-# Bypasses main.ts's own finally block, simulating the runner cancelling the
-# step (or an OOM kill) mid-run. Killing Node alone leaves run-isolated.sh
-# (and runc/the sandboxed command under it) running as an orphan -- killing
-# it too exercises the same pdeathsig-based die-with-parent chain that
-# already covers it dying for any other reason (see docs/security.md and
-# integration-test-die-with-parent.sh, whose pgrep pattern this mirrors: sudo's
-# `use_pty` setting forks a monitor process that also matches a naive
-# `-f run-isolated.sh`, so this must target the real bash instance specifically).
+# Bypasses main.ts's own finally block entirely, simulating the runner
+# cancelling the step (or an OOM kill) mid-run.
 kill -9 "$NODE_PID" >/dev/null 2>&1
-sudo -n pkill -9 -f "/bin/bash .*/run/scripts/run-isolated.sh" >/dev/null 2>&1
 wait "$NODE_PID" 2>/dev/null
 
 if ! pgrep -x ecapture >/dev/null 2>&1; then
@@ -67,33 +56,18 @@ if ! pgrep -x ecapture >/dev/null 2>&1; then
   exit 1
 fi
 
-# Simulate GitHub Actions exposing this step's own GITHUB_STATE entries to its
-# post action as STATE_<name> environment variables -- except container_name/
-# project_name: this test is only about ecapture_pid/ecapture_cgroup_path
-# recovery, and including them would also exercise post.ts's docker-compose-down
-# path, which has hung in this environment when the sandbox network wasn't
-# fully torn down. That path is already exercised by every other passing
-# integration test's normal (non-hard-killed) exit, so it isn't retested here.
+# Simulate GitHub Actions exposing this step's own GITHUB_STATE entries to
+# its post action as STATE_<name> environment variables.
 STATE_ENV_ARGS=()
 while IFS='=' read -r k v; do
-  case "$k" in
-    container_name | project_name) continue ;;
-  esac
   [ -n "$k" ] && STATE_ENV_ARGS+=("STATE_$k=$v")
 done < "$WORKDIR/state.env"
-timeout 60 env "${STATE_ENV_ARGS[@]}" node "$REPO_ROOT/run/dist/post.cjs" > "$WORKDIR/post-out.log" 2>&1
-POST_CODE=$?
+env "${STATE_ENV_ARGS[@]}" node "$REPO_ROOT/run/dist/post.cjs" > "$WORKDIR/post-out.log" 2>&1
 
 echo ""
 echo "=== Ecapture Hard-Kill Recovery Assertions ==="
 echo ""
 FAILURES=0
-
-if [ "$POST_CODE" = "124" ]; then
-  echo "  FAIL  post.ts (run/dist/post.cjs) timed out after 60s; see log below"
-  cat "$WORKDIR/post-out.log"
-  FAILURES=$((FAILURES + 1))
-fi
 
 if pgrep -x ecapture >/dev/null 2>&1; then
   echo "  FAIL  ecapture process still running after post.ts ran; see log below"

--- a/run/test/integration-test-ecapture-hard-kill-recovery.sh
+++ b/run/test/integration-test-ecapture-hard-kill-recovery.sh
@@ -12,7 +12,10 @@ touch "$WORKDIR/state.env"
 
 cleanup() {
   [ -n "${NODE_PID:-}" ] && kill -9 "$NODE_PID" >/dev/null 2>&1
-  sudo -n pkill -9 -f run-isolated.sh >/dev/null 2>&1
+  # Matches only the real bash instance running run-isolated.sh, not sudo's
+  # own `use_pty` monitor process (which also has "run-isolated.sh" in its
+  # argv) -- see the kill below for the same distinction.
+  sudo -n pkill -9 -f "/bin/bash .*/run/scripts/run-isolated.sh" >/dev/null 2>&1
   sudo -n pkill -9 -x ecapture >/dev/null 2>&1
   docker ps -aq --filter "name=buildcage-proxy-" | xargs -r docker rm -f >/dev/null 2>&1
   docker network ls --filter "name=buildcage-proxy-" -q | xargs -r docker network rm >/dev/null 2>&1
@@ -50,10 +53,13 @@ ECAPTURE_CGROUP=$(grep "^ecapture_cgroup_path=" "$WORKDIR/state.env" | cut -d= -
 # Bypasses main.ts's own finally block, simulating the runner cancelling the
 # step (or an OOM kill) mid-run. Killing Node alone leaves run-isolated.sh
 # (and runc/the sandboxed command under it) running as an orphan -- killing
-# it too triggers the same pdeathsig-based die-with-parent chain that covers
-# it dying for any other reason (see docs/security.md).
+# it too exercises the same pdeathsig-based die-with-parent chain that
+# already covers it dying for any other reason (see docs/security.md and
+# integration-test-die-with-parent.sh, whose pgrep pattern this mirrors: sudo's
+# `use_pty` setting forks a monitor process that also matches a naive
+# `-f run-isolated.sh`, so this must target the real bash instance specifically).
 kill -9 "$NODE_PID" >/dev/null 2>&1
-sudo -n pkill -9 -f run-isolated.sh >/dev/null 2>&1
+sudo -n pkill -9 -f "/bin/bash .*/run/scripts/run-isolated.sh" >/dev/null 2>&1
 wait "$NODE_PID" 2>/dev/null
 
 if ! pgrep -x ecapture >/dev/null 2>&1; then
@@ -61,12 +67,18 @@ if ! pgrep -x ecapture >/dev/null 2>&1; then
   exit 1
 fi
 
-# Simulate GitHub Actions exposing this step's own GITHUB_STATE entries to
-# its post action as STATE_<name> environment variables. `timeout`-bounded:
-# post.ts's docker-compose-down call has none of its own, and an incompletely
-# killed sandbox tree previously left it hanging on a busy proxy network.
+# Simulate GitHub Actions exposing this step's own GITHUB_STATE entries to its
+# post action as STATE_<name> environment variables -- except container_name/
+# project_name: this test is only about ecapture_pid/ecapture_cgroup_path
+# recovery, and including them would also exercise post.ts's docker-compose-down
+# path, which has hung in this environment when the sandbox network wasn't
+# fully torn down. That path is already exercised by every other passing
+# integration test's normal (non-hard-killed) exit, so it isn't retested here.
 STATE_ENV_ARGS=()
 while IFS='=' read -r k v; do
+  case "$k" in
+    container_name | project_name) continue ;;
+  esac
   [ -n "$k" ] && STATE_ENV_ARGS+=("STATE_$k=$v")
 done < "$WORKDIR/state.env"
 timeout 60 env "${STATE_ENV_ARGS[@]}" node "$REPO_ROOT/run/dist/post.cjs" > "$WORKDIR/post-out.log" 2>&1

--- a/run/test/integration-test-ecapture-hard-kill-recovery.sh
+++ b/run/test/integration-test-ecapture-hard-kill-recovery.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Verifies post.ts can still clean up ecapture's process and cgroup dir after
+# a hard kill bypasses main.ts's own finally block, via the ecapture_pid /
+# ecapture_cgroup_path GITHUB_STATE entries main.ts records.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+: "${BUILDCAGE_LOCAL_IMAGE_REF:?BUILDCAGE_LOCAL_IMAGE_REF must be set to the locally built proxy image}"
+
+WORKDIR=$(mktemp -d)
+touch "$WORKDIR/state.env"
+
+cleanup() {
+  [ -n "${NODE_PID:-}" ] && kill -9 "$NODE_PID" >/dev/null 2>&1
+  sudo -n pkill -9 -x ecapture >/dev/null 2>&1
+  docker ps -aq --filter "name=buildcage-proxy-" | xargs -r docker rm -f >/dev/null 2>&1
+  docker network ls --filter "name=buildcage-proxy-" -q | xargs -r docker network rm >/dev/null 2>&1
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+GITHUB_WORKSPACE="$WORKDIR" \
+GITHUB_STATE="$WORKDIR/state.env" \
+GITHUB_STEP_SUMMARY="$WORKDIR/summary.md" \
+BUILDCAGE_BUILD_TEST_HOOKS=1 \
+BUILDCAGE_LOCAL_IMAGE_REF="$BUILDCAGE_LOCAL_IMAGE_REF" \
+INPUT_ALLOWED_HTTPS_RULES="example.com:443" \
+INPUT_RUN='sleep 300' \
+  node "$REPO_ROOT/run/dist/main.cjs" > "$WORKDIR/out.log" 2>&1 &
+NODE_PID=$!
+
+echo "waiting for ecapture_pid to be recorded in GITHUB_STATE..." >&2
+FOUND=0
+for _ in $(seq 1 60); do
+  if grep -q "^ecapture_pid=" "$WORKDIR/state.env" 2>/dev/null; then
+    FOUND=1
+    break
+  fi
+  sleep 0.5
+done
+if [ "$FOUND" != "1" ]; then
+  echo "  FAIL  ecapture_pid was never recorded; see log below"
+  cat "$WORKDIR/out.log"
+  exit 1
+fi
+
+ECAPTURE_CGROUP=$(grep "^ecapture_cgroup_path=" "$WORKDIR/state.env" | cut -d= -f2-)
+
+# Bypasses main.ts's own finally block entirely, simulating the runner
+# cancelling the step (or an OOM kill) mid-run.
+kill -9 "$NODE_PID" >/dev/null 2>&1
+wait "$NODE_PID" 2>/dev/null
+
+if ! pgrep -x ecapture >/dev/null 2>&1; then
+  echo "  FAIL  ecapture already exited on its own -- this test can't tell recovery apart from a no-op"
+  exit 1
+fi
+
+# Simulate GitHub Actions exposing this step's own GITHUB_STATE entries to
+# its post action as STATE_<name> environment variables.
+STATE_ENV_ARGS=()
+while IFS='=' read -r k v; do
+  [ -n "$k" ] && STATE_ENV_ARGS+=("STATE_$k=$v")
+done < "$WORKDIR/state.env"
+env "${STATE_ENV_ARGS[@]}" node "$REPO_ROOT/run/dist/post.cjs" > "$WORKDIR/post-out.log" 2>&1
+
+echo ""
+echo "=== Ecapture Hard-Kill Recovery Assertions ==="
+echo ""
+FAILURES=0
+
+if pgrep -x ecapture >/dev/null 2>&1; then
+  echo "  FAIL  ecapture process still running after post.ts ran; see log below"
+  cat "$WORKDIR/post-out.log"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  PASS  ecapture process cleaned up by post.ts"
+fi
+
+if [ -n "$ECAPTURE_CGROUP" ] && [ -d "$ECAPTURE_CGROUP" ]; then
+  echo "  FAIL  cgroup directory $ECAPTURE_CGROUP still exists after post.ts ran"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  PASS  cgroup directory cleaned up (or never left behind)"
+fi
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "❌ FAILED: $FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "✅ All assertions passed."
+echo ""

--- a/run/test/integration-test-ecapture-hard-kill-recovery.sh
+++ b/run/test/integration-test-ecapture-hard-kill-recovery.sh
@@ -12,6 +12,7 @@ touch "$WORKDIR/state.env"
 
 cleanup() {
   [ -n "${NODE_PID:-}" ] && kill -9 "$NODE_PID" >/dev/null 2>&1
+  sudo -n pkill -9 -f run-isolated.sh >/dev/null 2>&1
   sudo -n pkill -9 -x ecapture >/dev/null 2>&1
   docker ps -aq --filter "name=buildcage-proxy-" | xargs -r docker rm -f >/dev/null 2>&1
   docker network ls --filter "name=buildcage-proxy-" -q | xargs -r docker network rm >/dev/null 2>&1
@@ -25,7 +26,7 @@ GITHUB_STEP_SUMMARY="$WORKDIR/summary.md" \
 BUILDCAGE_BUILD_TEST_HOOKS=1 \
 BUILDCAGE_LOCAL_IMAGE_REF="$BUILDCAGE_LOCAL_IMAGE_REF" \
 INPUT_ALLOWED_HTTPS_RULES="example.com:443" \
-INPUT_RUN='sleep 300' \
+INPUT_RUN='sleep 60' \
   node "$REPO_ROOT/run/dist/main.cjs" > "$WORKDIR/out.log" 2>&1 &
 NODE_PID=$!
 
@@ -46,9 +47,13 @@ fi
 
 ECAPTURE_CGROUP=$(grep "^ecapture_cgroup_path=" "$WORKDIR/state.env" | cut -d= -f2-)
 
-# Bypasses main.ts's own finally block entirely, simulating the runner
-# cancelling the step (or an OOM kill) mid-run.
+# Bypasses main.ts's own finally block, simulating the runner cancelling the
+# step (or an OOM kill) mid-run. Killing Node alone leaves run-isolated.sh
+# (and runc/the sandboxed command under it) running as an orphan -- killing
+# it too triggers the same pdeathsig-based die-with-parent chain that covers
+# it dying for any other reason (see docs/security.md).
 kill -9 "$NODE_PID" >/dev/null 2>&1
+sudo -n pkill -9 -f run-isolated.sh >/dev/null 2>&1
 wait "$NODE_PID" 2>/dev/null
 
 if ! pgrep -x ecapture >/dev/null 2>&1; then
@@ -57,17 +62,26 @@ if ! pgrep -x ecapture >/dev/null 2>&1; then
 fi
 
 # Simulate GitHub Actions exposing this step's own GITHUB_STATE entries to
-# its post action as STATE_<name> environment variables.
+# its post action as STATE_<name> environment variables. `timeout`-bounded:
+# post.ts's docker-compose-down call has none of its own, and an incompletely
+# killed sandbox tree previously left it hanging on a busy proxy network.
 STATE_ENV_ARGS=()
 while IFS='=' read -r k v; do
   [ -n "$k" ] && STATE_ENV_ARGS+=("STATE_$k=$v")
 done < "$WORKDIR/state.env"
-env "${STATE_ENV_ARGS[@]}" node "$REPO_ROOT/run/dist/post.cjs" > "$WORKDIR/post-out.log" 2>&1
+timeout 60 env "${STATE_ENV_ARGS[@]}" node "$REPO_ROOT/run/dist/post.cjs" > "$WORKDIR/post-out.log" 2>&1
+POST_CODE=$?
 
 echo ""
 echo "=== Ecapture Hard-Kill Recovery Assertions ==="
 echo ""
 FAILURES=0
+
+if [ "$POST_CODE" = "124" ]; then
+  echo "  FAIL  post.ts (run/dist/post.cjs) timed out after 60s; see log below"
+  cat "$WORKDIR/post-out.log"
+  FAILURES=$((FAILURES + 1))
+fi
 
 if pgrep -x ecapture >/dev/null 2>&1; then
   echo "  FAIL  ecapture process still running after post.ts ran; see log below"

--- a/run/test/integration-test-ecapture-terminates.sh
+++ b/run/test/integration-test-ecapture-terminates.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Verifies ecapture (see isolated-exec.ts's startEcapture/stopEcapture) doesn't
+# leak as an orphaned root process after the `run:` step finishes, and that it
+# actually captured the request. Needs a real passwordless-sudo host, so this
+# can't be a unit test.
+set -uo pipefail
+
+: "${BUILDCAGE_LOCAL_IMAGE_REF:?BUILDCAGE_LOCAL_IMAGE_REF must be set to the locally built proxy image}"
+
+WORKDIR=$(mktemp -d)
+touch "$WORKDIR/state.env"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+GITHUB_WORKSPACE="$WORKDIR" \
+GITHUB_STATE="$WORKDIR/state.env" \
+GITHUB_STEP_SUMMARY="$WORKDIR/summary.md" \
+BUILDCAGE_BUILD_TEST_HOOKS=1 \
+BUILDCAGE_LOCAL_IMAGE_REF="$BUILDCAGE_LOCAL_IMAGE_REF" \
+INPUT_ALLOWED_HTTPS_RULES="example.com:443" \
+INPUT_RUN="wget -q -T 5 -O /dev/null https://example.com/" \
+  node run/dist/main.cjs > "$WORKDIR/out.log" 2>&1
+CODE=$?
+
+echo ""
+echo "=== Ecapture Termination Assertions ==="
+echo ""
+
+if [ "$CODE" != "0" ]; then
+  echo "  FAIL  run/dist/main.cjs exited non-zero ($CODE); see log below"
+  cat "$WORKDIR/out.log"
+  exit 1
+fi
+
+FAILURES=0
+
+if pgrep -x ecapture >/dev/null 2>&1; then
+  echo "  FAIL  ecapture process still running after the step finished"
+  pgrep -a -x ecapture
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  PASS  no ecapture process left running after the step finished"
+fi
+
+# Confirms the feature works end to end: wget -> ecapture -> ecapture-log-parser.ts -> report.
+if grep -q '💬 HTTPS communication logs' "$WORKDIR/summary.md" 2>/dev/null && \
+   grep -qE '^\s*- GET https://example\.com/ -> 200\s*$' "$WORKDIR/summary.md" 2>/dev/null; then
+  echo "  PASS  GITHUB_STEP_SUMMARY records the GET https://example.com/ request"
+else
+  echo "  FAIL  GITHUB_STEP_SUMMARY is missing the expected HTTPS communication logs entry"
+  cat "$WORKDIR/summary.md" 2>/dev/null
+  FAILURES=$((FAILURES + 1))
+fi
+
+# Normal-path cleanup (removeCgroupDirIfEmpty); the hard-kill fallback path is
+# covered separately by integration-test-ecapture-hard-kill-recovery.sh.
+ECAPTURE_CGROUP=$(grep '^ecapture_cgroup_path=' "$WORKDIR/state.env" 2>/dev/null | cut -d= -f2-)
+if [ -z "$ECAPTURE_CGROUP" ]; then
+  echo "  FAIL  ecapture_cgroup_path was never recorded in GITHUB_STATE"
+  FAILURES=$((FAILURES + 1))
+elif [ -d "$ECAPTURE_CGROUP" ]; then
+  echo "  FAIL  cgroup directory $ECAPTURE_CGROUP still exists after the step finished"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  PASS  cgroup directory cleaned up after the step finished"
+fi
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "❌ FAILED: $FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "✅ All assertions passed."
+echo ""


### PR DESCRIPTION
## Summary

The `run` action's Job Summary only ever shows a domain-level allow/block decision (SNI for HTTPS, Host header for HTTP), since it never terminates TLS. This adds method/path detail for HTTPS traffic — a "💬 HTTPS communication logs" section — using [ecapture](https://github.com/gojue/ecapture), an eBPF tool that hooks OpenSSL's own read/write calls to read plaintext directly out of the traced process's memory, with no CA certificate or MITM proxying involved.

This works for `run` because the isolated command's rootfs is a bind-mount of the host's own `/`, so its `libssl.so` is the exact same file ecapture (also running on the host) resolves. Capture is scoped to the isolated command's own cgroup rather than the whole runner host: the cgroup runc will create for it is predicted and pre-created before ecapture starts, so concurrent `run:` steps' reports stay independent of each other.

Coverage is intentionally narrow: OpenSSL/BoringSSL/GnuTLS/NSS-linked tools only, HTTP/1.x request lines only, and blocked HTTPS connections never appear here since their TLS handshake never completes. Only method/host/path/status ever leave the parser — headers and bodies are discarded before this data reaches the Job Summary. Any failure in this path is a warning annotation, never a hard failure of the step.

## Changes

- Bundle a checksum-pinned ecapture release binary into the `run` action's proxy image
  - Extracted onto the runner host the same way `runc`/`gen-seccomp-profile` already are
- Parse ecapture's captured output into method/host/path/status
  - Pairs each request with its response per connection; anything that doesn't match (e.g. HTTP/2) is silently skipped rather than misparsed
- Start/stop ecapture around the isolated command's lifetime, scoped to its own cgroup
  - Waits for ecapture's eBPF probes to actually attach before the isolated command starts, so a short-lived command can't finish before capture begins
  - Predicts and pre-creates the cgroup the isolated command will run in, so concurrent `run:` steps' captures stay independent — falls back to unscoped capture if that preparation fails
- Add the "💬 HTTPS communication logs" section to the Job Summary
  - Flat, time-ordered list shown in both audit and restrict mode
- Exercise concurrent `run:` steps over HTTPS in the parallel sandbox e2e test
- Document the feature, its mechanism, and its coverage limits
