### PR TITLE
feat: collapse buildcage's own run action output into log groups

### DIFF
--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8044,22 +8044,43 @@ function logRules(label, rules) {
 	console.log(`${label} rules:${rules.length === 0 ? " (none)" : ""}`);
 	for (let r of rules) console.log(`  ${r}`);
 }
+/**
+* Wraps buildcage's own (non-user) log output in a collapsed
+* `::group::`/`::endgroup::` block, so a step's default (collapsed) view
+* shows only the user's own `run:` output — matching a plain `run:` step's
+* look. Always closes the group, even if `fn` throws, so a failure mid-group
+* can't leave it open for the rest of the step's output.
+*/
+async function withGroup(label, fn) {
+	console.log(`::group::${label}`);
+	try {
+		return await fn();
+	} finally {
+		console.log("::endgroup::");
+	}
+}
 async function main() {
 	let env = process.env, actionRef = env.GITHUB_ACTION_REF || "v2", actionRepo = env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", runInput = env.INPUT_RUN ?? "";
 	if (!runInput.trim()) throw new SandboxError("Input 'run' is required.", "MISSING_RUN");
 	checkPasswordlessSudo();
-	let annotation = createAnnotation(!!env.GITHUB_STEP_SUMMARY), { imageRef, pullPolicy } = await resolveVerifiedImage({
-		actionRef,
-		actionRepo
-	});
-	console.log(`buildcage-proxy image: ${imageRef}`);
-	let rules = buildACLRules({
-		httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-		ipRulesInput: env.INPUT_ALLOWED_IP_RULES
-	}), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
-	console.log("::group::Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), console.log("::endgroup::");
-	let writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = generateContainerName(), projectName = deriveProjectName(containerName), stateFile = env.GITHUB_STATE;
+	let annotation = createAnnotation(!!env.GITHUB_STEP_SUMMARY), { imageRef, pullPolicy, rules, knownBlockedRules } = await withGroup("Buildcage: image & ACL configuration", async () => {
+		let { imageRef, pullPolicy } = await resolveVerifiedImage({
+			actionRef,
+			actionRepo
+		});
+		console.log(`buildcage-proxy image: ${imageRef}`);
+		let rules = buildACLRules({
+			httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
+			httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
+			ipRulesInput: env.INPUT_ALLOWED_IP_RULES
+		}), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+		return logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), {
+			imageRef,
+			pullPolicy,
+			rules,
+			knownBlockedRules
+		};
+	}), writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = generateContainerName(), projectName = deriveProjectName(containerName), stateFile = env.GITHUB_STATE;
 	stateFile && ((0, node_fs.appendFileSync)(stateFile, `container_name=${containerName}\n`), (0, node_fs.appendFileSync)(stateFile, `project_name=${projectName}\n`));
 	let composeEnv = {
 		...env,
@@ -8070,18 +8091,20 @@ async function main() {
 		ALLOWED_IP_RULES: rules.ipRules.join("\n"),
 		BUILDCAGE_PROXY_IMAGE_REF: imageRef
 	};
-	try {
-		(0, node_child_process.execFileSync)("docker", buildComposeUpArgs({
-			composeFile,
-			projectName,
-			pullPolicy
-		}), {
-			stdio: "inherit",
-			env: composeEnv
-		});
-	} catch (e) {
-		throw new SandboxError(describeDockerFailure(e, { operation: "docker compose up" }), "DOCKER_UNAVAILABLE");
-	}
+	await withGroup("Buildcage: starting sandbox proxy", () => {
+		try {
+			(0, node_child_process.execFileSync)("docker", buildComposeUpArgs({
+				composeFile,
+				projectName,
+				pullPolicy
+			}), {
+				stdio: "inherit",
+				env: composeEnv
+			});
+		} catch (e) {
+			throw new SandboxError(describeDockerFailure(e, { operation: "docker compose up" }), "DOCKER_UNAVAILABLE");
+		}
+	});
 	let exitCode = 1;
 	try {
 		let proxyPid = getContainerPid(containerName);
@@ -8148,17 +8171,19 @@ async function main() {
 		} catch (e) {
 			annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);
 		}
-		try {
-			(0, node_child_process.execFileSync)("docker", buildComposeDownArgs({
-				composeFile,
-				projectName
-			}), {
-				stdio: "inherit",
-				env: composeEnv
-			});
-		} catch (e) {
-			annotation.warning(`Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`);
-		}
+		await withGroup("Buildcage: stopping sandbox proxy", () => {
+			try {
+				(0, node_child_process.execFileSync)("docker", buildComposeDownArgs({
+					composeFile,
+					projectName
+				}), {
+					stdio: "inherit",
+					env: composeEnv
+				});
+			} catch (e) {
+				annotation.warning(`Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`);
+			}
+		});
 	}
 	exitCode !== 0 && (process.exitCode = exitCode);
 }

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8073,7 +8073,7 @@ async function main() {
 		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
 		ipRulesInput: env.INPUT_ALLOWED_IP_RULES
 	}), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
-	console.log("::group::Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), console.log("::endgroup::");
+	console.log("::group::buildcage: Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), console.log("::endgroup::");
 	let writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = generateContainerName(), projectName = deriveProjectName(containerName), stateFile = env.GITHUB_STATE;
 	stateFile && ((0, node_fs.appendFileSync)(stateFile, `container_name=${containerName}\n`), (0, node_fs.appendFileSync)(stateFile, `project_name=${projectName}\n`));
 	let composeEnv = {

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8063,24 +8063,18 @@ async function main() {
 	let env = process.env, actionRef = env.GITHUB_ACTION_REF || "v2", actionRepo = env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", runInput = env.INPUT_RUN ?? "";
 	if (!runInput.trim()) throw new SandboxError("Input 'run' is required.", "MISSING_RUN");
 	checkPasswordlessSudo();
-	let annotation = createAnnotation(!!env.GITHUB_STEP_SUMMARY), { imageRef, pullPolicy, rules, knownBlockedRules } = await withGroup("Buildcage: image & ACL configuration", async () => {
-		let { imageRef, pullPolicy } = await resolveVerifiedImage({
-			actionRef,
-			actionRepo
-		});
-		console.log(`buildcage-proxy image: ${imageRef}`);
-		let rules = buildACLRules({
-			httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-			httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-			ipRulesInput: env.INPUT_ALLOWED_IP_RULES
-		}), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
-		return logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), {
-			imageRef,
-			pullPolicy,
-			rules,
-			knownBlockedRules
-		};
-	}), writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = generateContainerName(), projectName = deriveProjectName(containerName), stateFile = env.GITHUB_STATE;
+	let annotation = createAnnotation(!!env.GITHUB_STEP_SUMMARY), { imageRef, pullPolicy } = await resolveVerifiedImage({
+		actionRef,
+		actionRepo
+	});
+	console.log(`buildcage: proxy image: ${imageRef}`);
+	let rules = buildACLRules({
+		httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
+		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
+		ipRulesInput: env.INPUT_ALLOWED_IP_RULES
+	}), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+	console.log("::group::Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), console.log("::endgroup::");
+	let writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = generateContainerName(), projectName = deriveProjectName(containerName), stateFile = env.GITHUB_STATE;
 	stateFile && ((0, node_fs.appendFileSync)(stateFile, `container_name=${containerName}\n`), (0, node_fs.appendFileSync)(stateFile, `project_name=${projectName}\n`));
 	let composeEnv = {
 		...env,
@@ -8091,7 +8085,7 @@ async function main() {
 		ALLOWED_IP_RULES: rules.ipRules.join("\n"),
 		BUILDCAGE_PROXY_IMAGE_REF: imageRef
 	};
-	await withGroup("Buildcage: starting sandbox proxy", () => {
+	await withGroup("buildcage: starting sandbox proxy", () => {
 		try {
 			(0, node_child_process.execFileSync)("docker", buildComposeUpArgs({
 				composeFile,
@@ -8171,7 +8165,7 @@ async function main() {
 		} catch (e) {
 			annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);
 		}
-		await withGroup("Buildcage: stopping sandbox proxy", () => {
+		await withGroup("buildcage: stopping sandbox proxy", () => {
 			try {
 				(0, node_child_process.execFileSync)("docker", buildComposeDownArgs({
 					composeFile,

--- a/run/scripts/run-isolated.sh
+++ b/run/scripts/run-isolated.sh
@@ -149,23 +149,23 @@ trap cleanup EXIT INT TERM
 # minimizes the gap between isolated-exec.ts's listHostMounts() snapshot
 # (which config.json's readonlyPaths was computed from) and this rbind
 # actually capturing the host's mount table.
-group_start "Buildcage: preparing sandbox"
-echo "run-isolated: bind-mounting host root for runc's rootfs..." >&2
+group_start "buildcage: preparing sandbox"
+echo "Bind-mounting host root for runc's rootfs..." >&2
 mkdir -p "$ROOTFS_BIND_DIR"
 mount --rbind / "$ROOTFS_BIND_DIR"
 # No separate `mount --make-rprivate` needed here: the whole-namespace
 # `--propagation private` set up above already makes every mount created
 # under it private by default, including this one.
 
-echo "run-isolated: creating sandbox network namespace..." >&2
+echo "Creating sandbox network namespace..." >&2
 ip netns add "$NETNS_NAME"
 
-echo "run-isolated: creating veth pair ${VETH_T} <-> ${VETH_P}..." >&2
+echo "Creating veth pair ${VETH_T} <-> ${VETH_P}..." >&2
 ip link add "$VETH_T" type veth peer name "$VETH_P"
 ip link set "$VETH_T" netns "$NETNS_NAME"
 ip link set "$VETH_P" netns "$PROXY_PID"
 
-echo "run-isolated: configuring sandbox namespace network..." >&2
+echo "Configuring sandbox namespace network..." >&2
 ip netns exec "$NETNS_NAME" sh -c "
   set -e
   ip link set '${VETH_T}' name eth0
@@ -175,7 +175,7 @@ ip netns exec "$NETNS_NAME" sh -c "
   ip route add default via '${GATEWAY}'
 "
 
-echo "run-isolated: configuring proxy-side veth as sandbox0..." >&2
+echo "Configuring proxy-side veth as sandbox0..." >&2
 # No bridge: this is always a 1:1 connection (one sandbox, one proxy), so
 # the veth end is simply renamed to a fixed, predictable name and given the
 # proxy's own gateway address directly -- init-iptables's "-i sandbox0"
@@ -188,7 +188,7 @@ nsenter --net="/proc/${PROXY_PID}/ns/net" -- sh -c "
   ip link set sandbox0 up
 "
 
-echo "run-isolated: executing isolated command via runc..." >&2
+echo "Executing isolated command via runc..." >&2
 group_end
 set +e
 # No nsenter wrapper needed here: config.json's linux.namespaces network
@@ -214,4 +214,4 @@ setpriv --pdeathsig=KILL -- "$RUNC_PATH" run --bundle "$BUNDLE_DIR" "$CONTAINER_
 CODE=$?
 set -e
 
-echo "Buildcage: command exited with code ${CODE}" >&2
+echo "buildcage: command exited with code ${CODE}" >&2

--- a/run/scripts/run-isolated.sh
+++ b/run/scripts/run-isolated.sh
@@ -99,8 +99,26 @@ VETH_P="sbxp${RAND_ID}"
 
 CODE=1
 
+# Tracks whether a ::group:: block is currently open (see group_start/
+# group_end below), so cleanup() can force it closed if this script exits
+# mid-group (e.g. a failed `ip netns add`) -- otherwise every line printed
+# afterwards (including the WARNING messages below) would stay nested inside
+# an unclosed, collapsed group in the Actions UI.
+IN_GROUP=0
+
+group_start() {
+  echo "::group::$1" >&2
+  IN_GROUP=1
+}
+
+group_end() {
+  echo "::endgroup::" >&2
+  IN_GROUP=0
+}
+
 cleanup() {
   set +e
+  [ "$IN_GROUP" = "1" ] && group_end
   # -f/--force also kills the container's process tree if it's still
   # running (e.g. this trap fired from INT/TERM mid-run), so it must run
   # before the network/mount resources below are torn out from under it.
@@ -131,6 +149,7 @@ trap cleanup EXIT INT TERM
 # minimizes the gap between isolated-exec.ts's listHostMounts() snapshot
 # (which config.json's readonlyPaths was computed from) and this rbind
 # actually capturing the host's mount table.
+group_start "Buildcage: preparing sandbox"
 echo "run-isolated: bind-mounting host root for runc's rootfs..." >&2
 mkdir -p "$ROOTFS_BIND_DIR"
 mount --rbind / "$ROOTFS_BIND_DIR"
@@ -170,6 +189,7 @@ nsenter --net="/proc/${PROXY_PID}/ns/net" -- sh -c "
 "
 
 echo "run-isolated: executing isolated command via runc..." >&2
+group_end
 set +e
 # No nsenter wrapper needed here: config.json's linux.namespaces network
 # entry already points at /var/run/netns/${NETNS_NAME}, so runc joins it
@@ -194,4 +214,4 @@ setpriv --pdeathsig=KILL -- "$RUNC_PATH" run --bundle "$BUNDLE_DIR" "$CONTAINER_
 CODE=$?
 set -e
 
-echo "run-isolated: command exited with code ${CODE}" >&2
+echo "Buildcage: command exited with code ${CODE}" >&2

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -86,6 +86,22 @@ function logRules(label: string, rules: string[]): void {
   for (const r of rules) console.log(`  ${r}`);
 }
 
+/**
+ * Wraps buildcage's own (non-user) log output in a collapsed
+ * `::group::`/`::endgroup::` block, so a step's default (collapsed) view
+ * shows only the user's own `run:` output — matching a plain `run:` step's
+ * look. Always closes the group, even if `fn` throws, so a failure mid-group
+ * can't leave it open for the rest of the step's output.
+ */
+async function withGroup<T>(label: string, fn: () => T | Promise<T>): Promise<T> {
+  console.log(`::group::${label}`);
+  try {
+    return await fn();
+  } finally {
+    console.log("::endgroup::");
+  }
+}
+
 async function main(): Promise<void> {
   const env = process.env;
   // Empty (not `??`-catchable) for local-path `uses: ./run` invocations —
@@ -106,36 +122,40 @@ async function main(): Promise<void> {
   // when this script isn't running as the real action.
   const annotation = createAnnotation(Boolean(env.GITHUB_STEP_SUMMARY));
 
-  const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
-    ? (await import("../../core/lib/provenance/local-image-override.ts")).readLocalImageOverride(
-        env,
-      )
-    : null;
-  if (localOverride) {
-    console.log(
-      `BUILDCAGE_LOCAL_IMAGE_REF is set (${JSON.stringify(localOverride.imageRef)}) — ` +
-        `skipping image provenance verification entirely. This bypass exists only for ` +
-        `buildcage's own CI self-tests and local development.`,
-    );
-  }
-  const { imageRef, pullPolicy } =
-    localOverride ?? (await resolveVerifiedImage({ actionRef, actionRepo }));
-  console.log(`buildcage-proxy image: ${imageRef}`);
+  const { imageRef, pullPolicy, rules, knownBlockedRules } = await withGroup(
+    "Buildcage: image & ACL configuration",
+    async () => {
+      const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
+        ? (
+            await import("../../core/lib/provenance/local-image-override.ts")
+          ).readLocalImageOverride(env)
+        : null;
+      if (localOverride) {
+        console.log(
+          `BUILDCAGE_LOCAL_IMAGE_REF is set (${JSON.stringify(localOverride.imageRef)}) — ` +
+            `skipping image provenance verification entirely. This bypass exists only for ` +
+            `buildcage's own CI self-tests and local development.`,
+        );
+      }
+      const { imageRef, pullPolicy } =
+        localOverride ?? (await resolveVerifiedImage({ actionRef, actionRepo }));
+      console.log(`buildcage-proxy image: ${imageRef}`);
 
-  const rules = buildACLRules({
-    httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-    httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-    ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
-  });
+      const rules = buildACLRules({
+        httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
+        httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
+        ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
+      });
+      const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
 
-  const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+      logRules("HTTPS", rules.httpsRules);
+      logRules("HTTP", rules.httpRules);
+      logRules("IP", rules.ipRules);
+      logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules);
 
-  console.log("::group::Configured ACL Rules");
-  logRules("HTTPS", rules.httpsRules);
-  logRules("HTTP", rules.httpRules);
-  logRules("IP", rules.ipRules);
-  logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules);
-  console.log("::endgroup::");
+      return { imageRef, pullPolicy, rules, knownBlockedRules };
+    },
+  );
 
   const writablePaths = parseWritablePaths(env.INPUT_WRITABLE);
 
@@ -162,17 +182,19 @@ async function main(): Promise<void> {
     BUILDCAGE_PROXY_IMAGE_REF: imageRef,
   };
 
-  try {
-    execFileSync("docker", buildComposeUpArgs({ composeFile, projectName, pullPolicy }), {
-      stdio: "inherit",
-      env: composeEnv,
-    });
-  } catch (e) {
-    throw new SandboxError(
-      describeDockerFailure(e, { operation: "docker compose up" }),
-      "DOCKER_UNAVAILABLE",
-    );
-  }
+  await withGroup("Buildcage: starting sandbox proxy", () => {
+    try {
+      execFileSync("docker", buildComposeUpArgs({ composeFile, projectName, pullPolicy }), {
+        stdio: "inherit",
+        env: composeEnv,
+      });
+    } catch (e) {
+      throw new SandboxError(
+        describeDockerFailure(e, { operation: "docker compose up" }),
+        "DOCKER_UNAVAILABLE",
+      );
+    }
+  });
 
   let exitCode = 1;
   try {
@@ -282,16 +304,18 @@ async function main(): Promise<void> {
     } catch (e) {
       annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);
     }
-    try {
-      execFileSync("docker", buildComposeDownArgs({ composeFile, projectName }), {
-        stdio: "inherit",
-        env: composeEnv,
-      });
-    } catch (e) {
-      annotation.warning(
-        `Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`,
-      );
-    }
+    await withGroup("Buildcage: stopping sandbox proxy", () => {
+      try {
+        execFileSync("docker", buildComposeDownArgs({ composeFile, projectName }), {
+          stdio: "inherit",
+          env: composeEnv,
+        });
+      } catch (e) {
+        annotation.warning(
+          `Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`,
+        );
+      }
+    });
   }
 
   if (exitCode !== 0) {

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -122,40 +122,35 @@ async function main(): Promise<void> {
   // when this script isn't running as the real action.
   const annotation = createAnnotation(Boolean(env.GITHUB_STEP_SUMMARY));
 
-  const { imageRef, pullPolicy, rules, knownBlockedRules } = await withGroup(
-    "buildcage: image & ACL configuration",
-    async () => {
-      const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
-        ? (
-            await import("../../core/lib/provenance/local-image-override.ts")
-          ).readLocalImageOverride(env)
-        : null;
-      if (localOverride) {
-        console.log(
-          `BUILDCAGE_LOCAL_IMAGE_REF is set (${JSON.stringify(localOverride.imageRef)}) — ` +
-            `skipping image provenance verification entirely. This bypass exists only for ` +
-            `buildcage's own CI self-tests and local development.`,
-        );
-      }
-      const { imageRef, pullPolicy } =
-        localOverride ?? (await resolveVerifiedImage({ actionRef, actionRepo }));
-      console.log(`buildcage-proxy image: ${imageRef}`);
+  const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
+    ? (await import("../../core/lib/provenance/local-image-override.ts")).readLocalImageOverride(
+        env,
+      )
+    : null;
+  if (localOverride) {
+    console.log(
+      `BUILDCAGE_LOCAL_IMAGE_REF is set (${JSON.stringify(localOverride.imageRef)}) — ` +
+        `skipping image provenance verification entirely. This bypass exists only for ` +
+        `buildcage's own CI self-tests and local development.`,
+    );
+  }
+  const { imageRef, pullPolicy } =
+    localOverride ?? (await resolveVerifiedImage({ actionRef, actionRepo }));
+  console.log(`buildcage: proxy image: ${imageRef}`);
 
-      const rules = buildACLRules({
-        httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-        httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-        ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
-      });
-      const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+  const rules = buildACLRules({
+    httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
+    httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
+    ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
+  });
+  const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
 
-      logRules("HTTPS", rules.httpsRules);
-      logRules("HTTP", rules.httpRules);
-      logRules("IP", rules.ipRules);
-      logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules);
-
-      return { imageRef, pullPolicy, rules, knownBlockedRules };
-    },
-  );
+  console.log("::group::Configured ACL Rules");
+  logRules("HTTPS", rules.httpsRules);
+  logRules("HTTP", rules.httpRules);
+  logRules("IP", rules.ipRules);
+  logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules);
+  console.log("::endgroup::");
 
   const writablePaths = parseWritablePaths(env.INPUT_WRITABLE);
 

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -145,7 +145,7 @@ async function main(): Promise<void> {
   });
   const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
 
-  console.log("::group::Configured ACL Rules");
+  console.log("::group::buildcage: Configured ACL Rules");
   logRules("HTTPS", rules.httpsRules);
   logRules("HTTP", rules.httpRules);
   logRules("IP", rules.ipRules);

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -123,7 +123,7 @@ async function main(): Promise<void> {
   const annotation = createAnnotation(Boolean(env.GITHUB_STEP_SUMMARY));
 
   const { imageRef, pullPolicy, rules, knownBlockedRules } = await withGroup(
-    "Buildcage: image & ACL configuration",
+    "buildcage: image & ACL configuration",
     async () => {
       const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
         ? (
@@ -182,7 +182,7 @@ async function main(): Promise<void> {
     BUILDCAGE_PROXY_IMAGE_REF: imageRef,
   };
 
-  await withGroup("Buildcage: starting sandbox proxy", () => {
+  await withGroup("buildcage: starting sandbox proxy", () => {
     try {
       execFileSync("docker", buildComposeUpArgs({ composeFile, projectName, pullPolicy }), {
         stdio: "inherit",
@@ -304,7 +304,7 @@ async function main(): Promise<void> {
     } catch (e) {
       annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);
     }
-    await withGroup("Buildcage: stopping sandbox proxy", () => {
+    await withGroup("buildcage: stopping sandbox proxy", () => {
       try {
         execFileSync("docker", buildComposeDownArgs({ composeFile, projectName }), {
           stdio: "inherit",

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -7153,7 +7153,7 @@ async function main() {
 		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
 		ipRulesInput: env.INPUT_ALLOWED_IP_RULES
 	}), knownBlockedRules = parseRulesOrThrow(env.INPUT_KNOWN_BLOCKED_RULES);
-	console.log("::group::Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known blocked", knownBlockedRules), console.log("::endgroup::");
+	console.log("::group::buildcage: Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known blocked", knownBlockedRules), console.log("::endgroup::");
 	let builderName = env.INPUT_BUILDER_NAME || "buildcage", projectName = deriveProjectName(builderName), composeEnv = {
 		...env,
 		BUILDER_NAME: builderName,

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -7147,7 +7147,7 @@ async function main() {
 		actionRepo,
 		proxyEngine
 	});
-	console.log(`buildcage image: ${imageRef}`);
+	console.log(`buildcage: image: ${imageRef}`);
 	let rules = buildACLRules({
 		httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
 		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,

--- a/setup/src/main.ts
+++ b/setup/src/main.ts
@@ -79,7 +79,7 @@ async function main(): Promise<void> {
   });
   const knownBlockedRules = parseRulesOrThrow(env.INPUT_KNOWN_BLOCKED_RULES);
 
-  console.log("::group::Configured ACL Rules");
+  console.log("::group::buildcage: Configured ACL Rules");
   logRules("HTTPS", rules.httpsRules);
   logRules("HTTP", rules.httpRules);
   logRules("IP", rules.ipRules);

--- a/setup/src/main.ts
+++ b/setup/src/main.ts
@@ -70,7 +70,7 @@ async function main(): Promise<void> {
   }
   const { imageRef, pullPolicy } =
     localOverride ?? (await resolveVerifiedImage({ actionRef, actionRepo, proxyEngine }));
-  console.log(`buildcage image: ${imageRef}`);
+  console.log(`buildcage: image: ${imageRef}`);
 
   const rules = buildACLRules({
     httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,


### PR DESCRIPTION
## Summary

The `run` action's step log interleaved buildcage's own operational output (image/ACL setup, the proxy container's lifecycle, sandbox bootstrap) with the user's own `run:` command output, with no clear separation between the two. This collapses buildcage's own output into named `buildcage: ...` log groups and lines, so a step's default view shows only the user's own command — matching what a plain `run:` step looks like. The `setup` action's own image-ref log line is renamed to the same `buildcage:` prefix for consistency.
