### PR TITLE
chore(deps): update dependencies via pnpm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "dependencies": {
     "@sigstore/bundle": "^5.0.0",
     "@sigstore/tuf": "^5.0.0",
-    "@sigstore/verify": "^4.0.0"
+    "@sigstore/verify": "^4.1.0"
   },
   "devDependencies": {
-    "@types/node": "^24.9.2",
-    "fast-check": "^4.8.0",
-    "rolldown": "^1.1.5",
+    "@types/node": "^24.13.3",
+    "fast-check": "^4.9.0",
+    "rolldown": "^1.2.0",
     "typescript": "^7.0.2",
     "vite-plus": "^0.2.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,20 +214,20 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       '@sigstore/verify':
-        specifier: ^4.0.0
+        specifier: ^4.1.0
         version: 4.1.0
     devDependencies:
       '@types/node':
-        specifier: ^24.9.2
+        specifier: ^24.13.3
         version: 24.13.3
       fast-check:
-        specifier: ^4.8.0
+        specifier: ^4.9.0
         version: 4.9.0
       node:
         specifier: runtime:24.16.0
         version: runtime:24.16.0
       rolldown:
-        specifier: ^1.1.5
+        specifier: ^1.2.0
         version: 1.2.0
       typescript:
         specifier: ^7.0.2
@@ -1236,9 +1236,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -2376,7 +2376,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2472,7 +2472,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   mrmime@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 engineStrict: true
 trustPolicy: no-downgrade
 minimumReleaseAge: 20160 # 2 weeks
+minimumReleaseAgeExclude:
+  - brace-expansion@5.0.7 || 5.0.8

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -1781,9 +1781,9 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 		return result;
 	};
 })), require_commonjs$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
-	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.EXPANSION_MAX = void 0, exports.expand = expand;
+	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.EXPANSION_MAX_LENGTH = exports.EXPANSION_MAX = void 0, exports.expand = expand;
 	let balanced_match_1 = require_commonjs$2(), escSlash = "\0SLASH" + Math.random() + "\0", escOpen = "\0OPEN" + Math.random() + "\0", escClose = "\0CLOSE" + Math.random() + "\0", escComma = "\0COMMA" + Math.random() + "\0", escPeriod = "\0PERIOD" + Math.random() + "\0", escSlashPattern = new RegExp(escSlash, "g"), escOpenPattern = new RegExp(escOpen, "g"), escClosePattern = new RegExp(escClose, "g"), escCommaPattern = new RegExp(escComma, "g"), escPeriodPattern = new RegExp(escPeriod, "g"), slashPattern = /\\\\/g, openPattern = /\\{/g, closePattern = /\\}/g, commaPattern = /\\,/g, periodPattern = /\\\./g;
-	exports.EXPANSION_MAX = 1e5;
+	exports.EXPANSION_MAX = 1e5, exports.EXPANSION_MAX_LENGTH = 4e6;
 	function numeric(str) {
 		return isNaN(str) ? str.charCodeAt(0) : parseInt(str, 10);
 	}
@@ -1809,8 +1809,8 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 	}
 	function expand(str, options = {}) {
 		if (!str) return [];
-		let { max = exports.EXPANSION_MAX } = options;
-		return str.slice(0, 2) === "{}" && (str = "\\{\\}" + str.slice(2)), expand_(escapeBraces(str), max, !0).map(unescapeBraces);
+		let { max = exports.EXPANSION_MAX, maxLength = exports.EXPANSION_MAX_LENGTH } = options;
+		return str.slice(0, 2) === "{}" && (str = "\\{\\}" + str.slice(2)), expand_(escapeBraces(str), max, maxLength, !0).map(unescapeBraces);
 	}
 	function embrace(str) {
 		return "{" + str + "}";
@@ -1824,49 +1824,76 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 	function gte(i, y) {
 		return i >= y;
 	}
-	function expand_(str, max, isTop) {
-		/** @type {string[]} */
-		let expansions = [], m = (0, balanced_match_1.balanced)("{", "}", str);
-		if (!m) return [str];
-		let pre = m.pre, post = m.post.length ? expand_(m.post, max, !1) : [""];
-		if (/\$$/.test(m.pre)) for (let k = 0; k < post.length && k < max; k++) {
-			let expansion = pre + "{" + m.body + "}" + post[k];
-			expansions.push(expansion);
+	function combine(acc, pre, values, max, maxLength, dropEmpties) {
+		let out = [], length = 0;
+		for (let a = 0; a < acc.length; a++) for (let v = 0; v < values.length; v++) {
+			if (out.length >= max) return out;
+			let expansion = acc[a] + pre + values[v];
+			if (!(dropEmpties && !expansion)) {
+				if (length + expansion.length > maxLength) return out;
+				out.push(expansion), length += expansion.length;
+			}
 		}
-		else {
-			let isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body), isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body), isSequence = isNumericSequence || isAlphaSequence, isOptions = m.body.indexOf(",") >= 0;
-			if (!isSequence && !isOptions) return m.post.match(/,(?!,).*\}/) ? (str = m.pre + "{" + m.body + escClose + m.post, expand_(str, max, !0)) : [str];
-			let n;
-			if (isSequence) n = m.body.split(/\.\./);
-			else if (n = parseCommaParts(m.body), n.length === 1 && n[0] !== void 0 && (n = expand_(n[0], max, !1).map(embrace), n.length === 1)) return post.map((p) => m.pre + n[0] + p);
-			let N;
-			if (isSequence && n[0] !== void 0 && n[1] !== void 0) {
-				let x = numeric(n[0]), y = numeric(n[1]), width = Math.max(n[0].length, n[1].length), incr = n.length === 3 && n[2] !== void 0 ? Math.max(Math.abs(numeric(n[2])), 1) : 1, test = lte;
-				y < x && (incr *= -1, test = gte);
-				let pad = n.some(isPadded);
-				N = [];
-				for (let i = x; test(i, y) && N.length < max; i += incr) {
-					let c;
-					if (isAlphaSequence) c = String.fromCharCode(i), c === "\\" && (c = "");
-					else if (c = String(i), pad) {
-						let need = width - c.length;
-						if (need > 0) {
-							let z = Array(need + 1).join("0");
-							c = i < 0 ? "-" + z + c.slice(1) : z + c;
-						}
-					}
-					N.push(c);
+		return out;
+	}
+	function expandSequence(body, isAlphaSequence, max) {
+		let n = body.split(/\.\./), N = [];
+		/* c8 ignore start */
+		if (n[0] === void 0 || n[1] === void 0) return N;
+		/* c8 ignore stop */
+		let x = numeric(n[0]), y = numeric(n[1]), width = Math.max(n[0].length, n[1].length), incr = n.length === 3 && n[2] !== void 0 ? Math.max(Math.abs(numeric(n[2])), 1) : 1, test = lte;
+		y < x && (incr *= -1, test = gte);
+		let pad = n.some(isPadded);
+		for (let i = x; test(i, y) && N.length < max; i += incr) {
+			let c;
+			if (isAlphaSequence) c = String.fromCharCode(i), c === "\\" && (c = "");
+			else if (c = String(i), pad) {
+				let need = width - c.length;
+				if (need > 0) {
+					let z = Array(need + 1).join("0");
+					c = i < 0 ? "-" + z + c.slice(1) : z + c;
 				}
-			} else {
-				N = [];
-				for (let j = 0; j < n.length; j++) N.push.apply(N, expand_(n[j], max, !1));
 			}
-			for (let j = 0; j < N.length; j++) for (let k = 0; k < post.length && expansions.length < max; k++) {
-				let expansion = pre + N[j] + post[k];
-				(!isTop || isSequence || expansion) && expansions.push(expansion);
-			}
+			N.push(c);
 		}
-		return expansions;
+		return N;
+	}
+	function expand_(str, max, maxLength, isTop) {
+		let acc = [""], dropEmpties = !1, firstGroup = !0;
+		for (;;) {
+			let m = (0, balanced_match_1.balanced)("{", "}", str);
+			if (!m) return combine(acc, str, [""], max, maxLength, dropEmpties);
+			let pre = m.pre;
+			if (/\$$/.test(pre)) {
+				if (acc = combine(acc, pre + "{" + m.body + "}", [""], max, maxLength, dropEmpties && !m.post.length), firstGroup = !1, !m.post.length) break;
+				str = m.post;
+				continue;
+			}
+			let isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body), isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body), isSequence = isNumericSequence || isAlphaSequence, isOptions = m.body.indexOf(",") >= 0;
+			if (!isSequence && !isOptions) {
+				if (m.post.match(/,(?!,).*\}/)) {
+					str = m.pre + "{" + m.body + escClose + m.post, isTop = !0;
+					continue;
+				}
+				return combine(acc, pre + "{" + m.body + "}" + m.post, [""], max, maxLength, dropEmpties);
+			}
+			firstGroup &&= (dropEmpties = isTop && !isSequence, !1);
+			let values;
+			if (isSequence) values = expandSequence(m.body, isAlphaSequence, max);
+			else {
+				let n = parseCommaParts(m.body);
+				if (n.length === 1 && n[0] !== void 0 && (n = expand_(n[0], max, maxLength, !1).map(embrace), n.length === 1)) {
+					if (acc = combine(acc, pre + n[0], [""], max, maxLength, dropEmpties && !m.post.length), !m.post.length) break;
+					str = m.post;
+					continue;
+				}
+				values = [];
+				for (let j = 0; j < n.length; j++) values.push.apply(values, expand_(n[j], max, maxLength, !1));
+			}
+			if (acc = combine(acc, pre, values, max, maxLength, dropEmpties && !m.post.length), !m.post.length) break;
+			str = m.post;
+		}
+		return acc;
 	}
 })), require_assert_valid_pattern = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.assertValidPattern = void 0, exports.assertValidPattern = (pattern) => {

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -1872,9 +1872,9 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 		return result;
 	};
 })), require_commonjs$1 = /* @__PURE__ */ __commonJSMin(((exports) => {
-	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.EXPANSION_MAX = void 0, exports.expand = expand;
+	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.EXPANSION_MAX_LENGTH = exports.EXPANSION_MAX = void 0, exports.expand = expand;
 	let balanced_match_1 = require_commonjs$2(), escSlash = "\0SLASH" + Math.random() + "\0", escOpen = "\0OPEN" + Math.random() + "\0", escClose = "\0CLOSE" + Math.random() + "\0", escComma = "\0COMMA" + Math.random() + "\0", escPeriod = "\0PERIOD" + Math.random() + "\0", escSlashPattern = new RegExp(escSlash, "g"), escOpenPattern = new RegExp(escOpen, "g"), escClosePattern = new RegExp(escClose, "g"), escCommaPattern = new RegExp(escComma, "g"), escPeriodPattern = new RegExp(escPeriod, "g"), slashPattern = /\\\\/g, openPattern = /\\{/g, closePattern = /\\}/g, commaPattern = /\\,/g, periodPattern = /\\\./g;
-	exports.EXPANSION_MAX = 1e5;
+	exports.EXPANSION_MAX = 1e5, exports.EXPANSION_MAX_LENGTH = 4e6;
 	function numeric(str) {
 		return isNaN(str) ? str.charCodeAt(0) : parseInt(str, 10);
 	}
@@ -1900,8 +1900,8 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 	}
 	function expand(str, options = {}) {
 		if (!str) return [];
-		let { max = exports.EXPANSION_MAX } = options;
-		return str.slice(0, 2) === "{}" && (str = "\\{\\}" + str.slice(2)), expand_(escapeBraces(str), max, !0).map(unescapeBraces);
+		let { max = exports.EXPANSION_MAX, maxLength = exports.EXPANSION_MAX_LENGTH } = options;
+		return str.slice(0, 2) === "{}" && (str = "\\{\\}" + str.slice(2)), expand_(escapeBraces(str), max, maxLength, !0).map(unescapeBraces);
 	}
 	function embrace(str) {
 		return "{" + str + "}";
@@ -1915,49 +1915,76 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 	function gte(i, y) {
 		return i >= y;
 	}
-	function expand_(str, max, isTop) {
-		/** @type {string[]} */
-		let expansions = [], m = (0, balanced_match_1.balanced)("{", "}", str);
-		if (!m) return [str];
-		let pre = m.pre, post = m.post.length ? expand_(m.post, max, !1) : [""];
-		if (/\$$/.test(m.pre)) for (let k = 0; k < post.length && k < max; k++) {
-			let expansion = pre + "{" + m.body + "}" + post[k];
-			expansions.push(expansion);
+	function combine(acc, pre, values, max, maxLength, dropEmpties) {
+		let out = [], length = 0;
+		for (let a = 0; a < acc.length; a++) for (let v = 0; v < values.length; v++) {
+			if (out.length >= max) return out;
+			let expansion = acc[a] + pre + values[v];
+			if (!(dropEmpties && !expansion)) {
+				if (length + expansion.length > maxLength) return out;
+				out.push(expansion), length += expansion.length;
+			}
 		}
-		else {
-			let isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body), isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body), isSequence = isNumericSequence || isAlphaSequence, isOptions = m.body.indexOf(",") >= 0;
-			if (!isSequence && !isOptions) return m.post.match(/,(?!,).*\}/) ? (str = m.pre + "{" + m.body + escClose + m.post, expand_(str, max, !0)) : [str];
-			let n;
-			if (isSequence) n = m.body.split(/\.\./);
-			else if (n = parseCommaParts(m.body), n.length === 1 && n[0] !== void 0 && (n = expand_(n[0], max, !1).map(embrace), n.length === 1)) return post.map((p) => m.pre + n[0] + p);
-			let N;
-			if (isSequence && n[0] !== void 0 && n[1] !== void 0) {
-				let x = numeric(n[0]), y = numeric(n[1]), width = Math.max(n[0].length, n[1].length), incr = n.length === 3 && n[2] !== void 0 ? Math.max(Math.abs(numeric(n[2])), 1) : 1, test = lte;
-				y < x && (incr *= -1, test = gte);
-				let pad = n.some(isPadded);
-				N = [];
-				for (let i = x; test(i, y) && N.length < max; i += incr) {
-					let c;
-					if (isAlphaSequence) c = String.fromCharCode(i), c === "\\" && (c = "");
-					else if (c = String(i), pad) {
-						let need = width - c.length;
-						if (need > 0) {
-							let z = Array(need + 1).join("0");
-							c = i < 0 ? "-" + z + c.slice(1) : z + c;
-						}
-					}
-					N.push(c);
+		return out;
+	}
+	function expandSequence(body, isAlphaSequence, max) {
+		let n = body.split(/\.\./), N = [];
+		/* c8 ignore start */
+		if (n[0] === void 0 || n[1] === void 0) return N;
+		/* c8 ignore stop */
+		let x = numeric(n[0]), y = numeric(n[1]), width = Math.max(n[0].length, n[1].length), incr = n.length === 3 && n[2] !== void 0 ? Math.max(Math.abs(numeric(n[2])), 1) : 1, test = lte;
+		y < x && (incr *= -1, test = gte);
+		let pad = n.some(isPadded);
+		for (let i = x; test(i, y) && N.length < max; i += incr) {
+			let c;
+			if (isAlphaSequence) c = String.fromCharCode(i), c === "\\" && (c = "");
+			else if (c = String(i), pad) {
+				let need = width - c.length;
+				if (need > 0) {
+					let z = Array(need + 1).join("0");
+					c = i < 0 ? "-" + z + c.slice(1) : z + c;
 				}
-			} else {
-				N = [];
-				for (let j = 0; j < n.length; j++) N.push.apply(N, expand_(n[j], max, !1));
 			}
-			for (let j = 0; j < N.length; j++) for (let k = 0; k < post.length && expansions.length < max; k++) {
-				let expansion = pre + N[j] + post[k];
-				(!isTop || isSequence || expansion) && expansions.push(expansion);
-			}
+			N.push(c);
 		}
-		return expansions;
+		return N;
+	}
+	function expand_(str, max, maxLength, isTop) {
+		let acc = [""], dropEmpties = !1, firstGroup = !0;
+		for (;;) {
+			let m = (0, balanced_match_1.balanced)("{", "}", str);
+			if (!m) return combine(acc, str, [""], max, maxLength, dropEmpties);
+			let pre = m.pre;
+			if (/\$$/.test(pre)) {
+				if (acc = combine(acc, pre + "{" + m.body + "}", [""], max, maxLength, dropEmpties && !m.post.length), firstGroup = !1, !m.post.length) break;
+				str = m.post;
+				continue;
+			}
+			let isNumericSequence = /^-?\d+\.\.-?\d+(?:\.\.-?\d+)?$/.test(m.body), isAlphaSequence = /^[a-zA-Z]\.\.[a-zA-Z](?:\.\.-?\d+)?$/.test(m.body), isSequence = isNumericSequence || isAlphaSequence, isOptions = m.body.indexOf(",") >= 0;
+			if (!isSequence && !isOptions) {
+				if (m.post.match(/,(?!,).*\}/)) {
+					str = m.pre + "{" + m.body + escClose + m.post, isTop = !0;
+					continue;
+				}
+				return combine(acc, pre + "{" + m.body + "}" + m.post, [""], max, maxLength, dropEmpties);
+			}
+			firstGroup &&= (dropEmpties = isTop && !isSequence, !1);
+			let values;
+			if (isSequence) values = expandSequence(m.body, isAlphaSequence, max);
+			else {
+				let n = parseCommaParts(m.body);
+				if (n.length === 1 && n[0] !== void 0 && (n = expand_(n[0], max, maxLength, !1).map(embrace), n.length === 1)) {
+					if (acc = combine(acc, pre + n[0], [""], max, maxLength, dropEmpties && !m.post.length), !m.post.length) break;
+					str = m.post;
+					continue;
+				}
+				values = [];
+				for (let j = 0; j < n.length; j++) values.push.apply(values, expand_(n[j], max, maxLength, !1));
+			}
+			if (acc = combine(acc, pre, values, max, maxLength, dropEmpties && !m.post.length), !m.post.length) break;
+			str = m.post;
+		}
+		return acc;
 	}
 })), require_assert_valid_pattern = /* @__PURE__ */ __commonJSMin(((exports) => {
 	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.assertValidPattern = void 0, exports.assertValidPattern = (pattern) => {


### PR DESCRIPTION
## Summary

Routine `pnpm audit` dependency bump:

- `@sigstore/verify`: `4.0.0` → `4.1.0`
- `@types/node`: `24.9.2` → `24.13.3`
- `fast-check`: `4.8.0` → `4.9.0`
- `rolldown`: `1.1.5` → `1.2.0`
- `brace-expansion` (transitive, via `minimatch`): `5.0.6` → `5.0.8`

`pnpm-workspace.yaml` also gains a `minimumReleaseAgeExclude` entry for `brace-expansion@5.0.7 || 5.0.8`, so its ReDoS fix (an `EXPANSION_MAX_LENGTH` cap alongside the existing `EXPANSION_MAX` count guard) lands ahead of the usual two-week `minimumReleaseAge` policy instead of waiting it out. `run/dist/main.cjs` and `setup/dist/main.cjs` are rebuilt to pick up the patched `brace-expansion`.
