### PR TITLE
test: switch unit test runner from node:test to vp test (vitest)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,7 @@ help:
 .PHONY: test_unit
 test_unit: test_unit_core test_unit_setup test_unit_report test_unit_sandbox test_unit_qjs ## Run unit tests
 
-# vitest's CLI positional args are substring filters against each resolved
-# test file's path (not glob expansion like `node --test` used), matched
-# against vite.config.ts's `test.include`. "report/src" (not bare "report")
-# avoids matching core/lib/report/*.test.ts; adding new test files under
-# paths that share one of these substrings could misroute them.
+# vitest matches these by path substring, not glob, so keep them package-specific.
 .PHONY: test_unit_core
 test_unit_core: ## Run core unit tests
 	@vp test run core/

--- a/Makefile
+++ b/Makefile
@@ -22,21 +22,26 @@ help:
 .PHONY: test_unit
 test_unit: test_unit_core test_unit_setup test_unit_report test_unit_sandbox test_unit_qjs ## Run unit tests
 
+# vitest's CLI positional args are substring filters against each resolved
+# test file's path (not glob expansion like `node --test` used), matched
+# against vite.config.ts's `test.include`. "report/src" (not bare "report")
+# avoids matching core/lib/report/*.test.ts; adding new test files under
+# paths that share one of these substrings could misroute them.
 .PHONY: test_unit_core
 test_unit_core: ## Run core unit tests
-	@node --test 'core/**/*.test.ts'
+	@vp test run core/
 
 .PHONY: test_unit_setup
 test_unit_setup: ## Run setup action unit tests
-	@node --test 'setup/src/**/*.test.ts'
+	@vp test run setup/src
 
 .PHONY: test_unit_report
 test_unit_report: ## Run report unit tests
-	@node --test 'report/src/**/*.test.ts'
+	@vp test run report/src
 
 .PHONY: test_unit_sandbox
 test_unit_sandbox: ## Run the run action's unit tests
-	@node --test 'run/src/**/*.test.ts'
+	@vp test run run/src
 
 # qjs can't execute .ts directly, so compile fresh (vp run build:qjs-test)
 # and bind-mount the output in. qjs itself is identical across images, so one

--- a/core/lib/acl/wildcard-rules.property.test.ts
+++ b/core/lib/acl/wildcard-rules.property.test.ts
@@ -1,9 +1,9 @@
 /**
  * Property-based tests for core/lib/acl/wildcard-rules.ts.
  *
- * Run with: node --test core/lib/acl/wildcard-rules.property.test.ts
+ * Run with: vp test run core/lib/acl/wildcard-rules.property.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 

--- a/core/lib/actions/annotation.test.ts
+++ b/core/lib/actions/annotation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { createAnnotation } from "./annotation.ts";
 

--- a/core/lib/actions/annotation.test.ts
+++ b/core/lib/actions/annotation.test.ts
@@ -1,46 +1,46 @@
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 import { createAnnotation } from "./annotation.ts";
 
 describe("createAnnotation", () => {
   describe("enabled", () => {
-    it("notice() logs a ::notice:: line", (t) => {
-      const log = t.mock.method(console, "log", () => {});
+    it("notice() logs a ::notice:: line", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(true).notice("hello");
       assert.equal(log.mock.calls.length, 1);
-      assert.equal(log.mock.calls[0].arguments[0], "::notice::hello");
+      assert.equal(log.mock.calls[0][0], "::notice::hello");
     });
 
-    it("error() logs a ::error:: line", (t) => {
-      const log = t.mock.method(console, "log", () => {});
+    it("error() logs a ::error:: line", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(true).error("boom");
       assert.equal(log.mock.calls.length, 1);
-      assert.equal(log.mock.calls[0].arguments[0], "::error::boom");
+      assert.equal(log.mock.calls[0][0], "::error::boom");
     });
 
-    it("warning() logs a ::warning:: line", (t) => {
-      const log = t.mock.method(console, "log", () => {});
+    it("warning() logs a ::warning:: line", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(true).warning("careful");
       assert.equal(log.mock.calls.length, 1);
-      assert.equal(log.mock.calls[0].arguments[0], "::warning::careful");
+      assert.equal(log.mock.calls[0][0], "::warning::careful");
     });
   });
 
   describe("disabled", () => {
-    it("notice() logs nothing", (t) => {
-      const log = t.mock.method(console, "log", () => {});
+    it("notice() logs nothing", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(false).notice("hello");
       assert.equal(log.mock.calls.length, 0);
     });
 
-    it("error() logs nothing", (t) => {
-      const log = t.mock.method(console, "log", () => {});
+    it("error() logs nothing", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(false).error("boom");
       assert.equal(log.mock.calls.length, 0);
     });
 
-    it("warning() logs nothing", (t) => {
-      const log = t.mock.method(console, "log", () => {});
+    it("warning() logs nothing", () => {
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(false).warning("careful");
       assert.equal(log.mock.calls.length, 0);
     });

--- a/core/lib/actions/docker-error.test.ts
+++ b/core/lib/actions/docker-error.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { describeDockerFailure, isLikelySlimRunner } from "./docker-error.ts";

--- a/core/lib/actions/markdown-table.test.ts
+++ b/core/lib/actions/markdown-table.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { markdownTable } from "./markdown-table.ts";
 

--- a/core/lib/general/action-error.test.ts
+++ b/core/lib/general/action-error.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { ActionError } from "./action-error.ts";

--- a/core/lib/log/haproxy-log-parser.property.test.ts
+++ b/core/lib/log/haproxy-log-parser.property.test.ts
@@ -1,9 +1,9 @@
 /**
  * Property-based tests for core/lib/log/haproxy-log-parser.ts.
  *
- * Run with: node --test core/lib/log/haproxy-log-parser.property.test.ts
+ * Run with: vp test run core/lib/log/haproxy-log-parser.property.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 

--- a/core/lib/log/vertex-log.test.ts
+++ b/core/lib/log/vertex-log.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/core/lib/provenance/local-image-override.test.ts
+++ b/core/lib/provenance/local-image-override.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { readLocalImageOverride } from "./local-image-override.ts";

--- a/core/lib/provenance/oci-registry.test.ts
+++ b/core/lib/provenance/oci-registry.test.ts
@@ -3,9 +3,9 @@
  *
  * Tests use injectable _exec / _fetch arguments to avoid real network/docker calls.
  *
- * Run with: node --test core/lib/provenance/oci-registry.test.ts
+ * Run with: vp test run core/lib/provenance/oci-registry.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import {

--- a/core/lib/provenance/sigstore.test.ts
+++ b/core/lib/provenance/sigstore.test.ts
@@ -6,10 +6,10 @@
  *
  * assertSignedDigest() is pure synchronous logic and is fully unit-tested here.
  *
- * Run with: node --test core/lib/provenance/sigstore.test.ts
+ * Run with: vp test run core/lib/provenance/sigstore.test.ts
  */
 
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { assertSignedDigest } from "./sigstore.ts";
 import { VerifyImageError } from "./errors.ts";

--- a/core/lib/provenance/verify-image.property.test.ts
+++ b/core/lib/provenance/verify-image.property.test.ts
@@ -1,9 +1,9 @@
 /**
  * Property-based tests for verify-image.ts helpers.
  *
- * Run with: node --test core/lib/provenance/verify-image.property.test.ts
+ * Run with: vp test run core/lib/provenance/verify-image.property.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 

--- a/core/lib/provenance/verify-image.test.ts
+++ b/core/lib/provenance/verify-image.test.ts
@@ -8,9 +8,9 @@
  * verifyBundle and verifyImageDigest require a live TUF network call; those
  * paths are covered by end-to-end / integration tests.
  *
- * Run with: node --test core/lib/provenance/verify-image.test.ts
+ * Run with: vp test run core/lib/provenance/verify-image.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { imageTagFromRef, buildVerifyOptions, verifyImageDigestOrThrow } from "./verify-image.ts";

--- a/core/lib/report/emit-blocked-outcome.test.ts
+++ b/core/lib/report/emit-blocked-outcome.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
 import assert from "node:assert/strict";
 
 import { emitBlockedOutcome } from "./emit-blocked-outcome.ts";
@@ -133,8 +133,8 @@ describe("emitBlockedOutcome", () => {
     assert.equal(process.exitCode, undefined);
   });
 
-  it("emits ::notice:: (not ::error::) when console output is enabled and outcome level is notice", (t) => {
-    const log = t.mock.method(console, "log", () => {});
+  it("emits ::notice:: (not ::error::) when console output is enabled and outcome level is notice", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const r = report({
       parameters: parameters({ mode: "audit" }),
       blockedCount: 1,
@@ -153,17 +153,17 @@ describe("emitBlockedOutcome", () => {
     });
     emitBlockedOutcome(r, { failOnBlocked: true, summaryFile: "/tmp/summary.md" });
     const notices = log.mock.calls
-      .map((c) => c.arguments[0] as string)
+      .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::notice::"));
     const errors = log.mock.calls
-      .map((c) => c.arguments[0] as string)
+      .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::error::"));
     assert.equal(notices.length, 1);
     assert.equal(errors.length, 0);
   });
 
-  it("emits ::error:: when console output is enabled and outcome level is error", (t) => {
-    const log = t.mock.method(console, "log", () => {});
+  it("emits ::error:: when console output is enabled and outcome level is error", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const r = report({
       blockedCount: 1,
       blocked: annotateKnownBlocked(
@@ -181,13 +181,13 @@ describe("emitBlockedOutcome", () => {
     });
     emitBlockedOutcome(r, { failOnBlocked: true, summaryFile: "/tmp/summary.md" });
     const errors = log.mock.calls
-      .map((c) => c.arguments[0] as string)
+      .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::error::"));
     assert.equal(errors.length, 1);
   });
 
-  it("suppresses annotation output when summaryFile is undefined (not running as the real action)", (t) => {
-    const log = t.mock.method(console, "log", () => {});
+  it("suppresses annotation output when summaryFile is undefined (not running as the real action)", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const r = report({
       blockedCount: 1,
       blocked: annotateKnownBlocked(
@@ -205,7 +205,7 @@ describe("emitBlockedOutcome", () => {
     });
     emitBlockedOutcome(r, { failOnBlocked: true, summaryFile: undefined });
     const annotations = log.mock.calls
-      .map((c) => c.arguments[0] as string)
+      .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::notice::") || s.startsWith("::error::"));
     assert.equal(annotations.length, 0);
   });

--- a/core/lib/report/emit-blocked-outcome.test.ts
+++ b/core/lib/report/emit-blocked-outcome.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, beforeEach, afterEach } from "vitest";
 import assert from "node:assert/strict";
 
 import { emitBlockedOutcome } from "./emit-blocked-outcome.ts";

--- a/core/lib/test/test-shim.ts
+++ b/core/lib/test/test-shim.ts
@@ -1,6 +1,6 @@
 /**
- * Test shim, portable between Node (delegates to node:test/node:assert) and
- * QuickJS (its own minimal implementation — node:test and fast-check aren't
+ * Test shim, portable between Node (delegates to vitest/node:assert) and
+ * QuickJS (its own minimal implementation — vitest and fast-check aren't
  * available there). The same *.test.ts source runs unmodified under both.
  *
  * Module specifiers below are routed through non-literal string variables:
@@ -30,11 +30,11 @@ interface Shim {
 }
 
 async function createNodeShim(): Promise<Shim> {
-  const nodeTestSpecifier = "node:test";
+  const testRunnerSpecifier = "vitest";
   const nodeAssertSpecifier = "node:assert/strict";
-  const { describe, it } = await import(nodeTestSpecifier);
+  const { describe, it } = await import(testRunnerSpecifier);
   const { default: assert } = await import(nodeAssertSpecifier);
-  // node:test tracks pass/fail and sets the process exit code itself.
+  // vitest tracks pass/fail and sets the process exit code itself.
   return { describe, it, assert, reportResults() {} };
 }
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,8 +4,6 @@ minimumReleaseAge: 20160 # 2 weeks
 minimumReleaseAgeExclude:
   - brace-expansion@5.0.7 || 5.0.8
 
-# vitest is only a transitive dependency (bundled inside vite-plus, which
-# `vp test` execs directly regardless of root node_modules), but *.test.ts
-# files import it by name, so tsc needs it resolvable from the project root.
+# Lets tsc resolve vitest's types, even though it's only vite-plus's transitive dependency.
 publicHoistPattern:
   - vitest

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ trustPolicy: no-downgrade
 minimumReleaseAge: 20160 # 2 weeks
 minimumReleaseAgeExclude:
   - brace-expansion@5.0.7 || 5.0.8
+
+# vitest is only a transitive dependency (bundled inside vite-plus, which
+# `vp test` execs directly regardless of root node_modules), but *.test.ts
+# files import it by name, so tsc needs it resolvable from the project root.
+publicHoistPattern:
+  - vitest

--- a/report/src/main.test.ts
+++ b/report/src/main.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { deriveProjectName } from "../../core/lib/docker/container.ts";

--- a/rolldown.scripts.config.js
+++ b/rolldown.scripts.config.js
@@ -7,8 +7,8 @@ const productionInputs = globSync(["**/scripts/*.ts"], {
   exclude: ["node_modules/**", "dist/**", "**/*.test.ts"],
 });
 
-// core/lib/acl/*.test.ts is dual-consumed (also runs under node:test);
-// *.property.test.ts siblings are node:test/fast-check only, not qjs-compatible.
+// core/lib/acl/*.test.ts is dual-consumed (also runs under vitest);
+// *.property.test.ts siblings are vitest/fast-check only, not qjs-compatible.
 const qjsTestInputs = [
   "core/scripts/test/run-tests.qjs.ts",
   ...globSync(["core/lib/acl/*.test.ts"], { exclude: ["**/*.property.test.ts"] }),

--- a/run/src/lib/container.test.ts
+++ b/run/src/lib/container.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { generateContainerName, getContainerPid, isContainerNotFoundError } from "./container.ts";

--- a/run/src/lib/isolated-exec.test.ts
+++ b/run/src/lib/isolated-exec.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -4,7 +4,7 @@
  * the isolated command's own exit code (see main.ts), never resetting it
  * back to success.
  */
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, beforeEach, afterEach } from "vitest";
 import assert from "node:assert/strict";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -4,7 +4,7 @@
  * the isolated command's own exit code (see main.ts), never resetting it
  * back to success.
  */
-import { describe, it, beforeEach, afterEach } from "vitest";
+import { describe, it, beforeEach, afterEach, vi } from "vitest";
 import assert from "node:assert/strict";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -204,8 +204,8 @@ describe("writeReport", () => {
 
   // Audit's outcome never depends on known_blocked_rules matching, so the
   // notice text shouldn't either.
-  it("audit-mode notice text stays fixed even when known_blocked_rules matches every blocked connection", (t) => {
-    const log = t.mock.method(console, "log", () => {});
+  it("audit-mode notice text stays fixed even when known_blocked_rules matches every blocked connection", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const knownBlockedRules = ["known-bad.example.com:443"];
     const r = report({
       parameters: parameters({ mode: "audit", knownBlockedRules }),
@@ -218,7 +218,7 @@ describe("writeReport", () => {
     writeReportWithSummary(r, { failOnBlocked: true });
     assert.equal(log.mock.calls.length, 1);
     assert.equal(
-      log.mock.calls[0].arguments[0],
+      log.mock.calls[0][0],
       "::notice::2 blocked connection(s) detected by buildcage sandbox",
     );
   });

--- a/run/src/lib/sudo-preflight.test.ts
+++ b/run/src/lib/sudo-preflight.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { describeSudoFailure } from "./sudo-preflight.ts";

--- a/run/src/main.property.test.ts
+++ b/run/src/main.property.test.ts
@@ -1,9 +1,9 @@
 /**
  * Property-based tests for run/main.ts and its helpers.
  *
- * Run with: node --test run/src/main.property.test.ts
+ * Run with: vp test run run/src/main.property.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 

--- a/run/src/main.test.ts
+++ b/run/src/main.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for run/main.ts
  *
- * Run with: node --test run/src/main.test.ts
+ * Run with: vp test run run/src/main.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import {

--- a/setup/src/main.property.test.ts
+++ b/setup/src/main.property.test.ts
@@ -1,9 +1,9 @@
 /**
  * Property-based tests for setup/main.ts and its helpers.
  *
- * Run with: node --test setup/src/main.property.test.ts
+ * Run with: vp test run setup/src/main.property.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 

--- a/setup/src/main.test.ts
+++ b/setup/src/main.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for setup/main.ts
  *
- * Run with: node --test setup/src/main.test.ts
+ * Run with: vp test run setup/src/main.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";

--- a/setup/src/post.test.ts
+++ b/setup/src/post.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { deriveProjectName } from "../../core/lib/docker/container.ts";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,4 +29,13 @@ export default defineConfig({
     "run/docker/gen-seccomp-profile/**/*.go": "gofmt -w",
     "setup/docker/explicit/buildkit-proxy/**/*.go": "gofmt -w",
   },
+  test: {
+    include: [
+      "core/**/*.test.ts",
+      "setup/src/**/*.test.ts",
+      "report/src/**/*.test.ts",
+      "run/src/**/*.test.ts",
+    ],
+    restoreMocks: true,
+  },
 });


### PR DESCRIPTION
## Summary

PR #218 adopted vite-plus for the package manager and lint/format tooling but deliberately left its build/test-runner replacement out of scope, since `vp build`/`vp test` (Rolldown/Vitest) were unrelated to that PR's purpose. This finishes that deferred piece for tests: unit tests now run under `vp test` (vitest) instead of `node --test`, so the whole toolchain (lint, format, tests) goes through the same `vp` command surface vite-plus already owns.

The `core/lib/test/test-shim.ts` portability shim (which lets the same `*.test.ts` source run under both Node and QuickJS) now delegates to vitest instead of `node:test` on the Node side — the QuickJS branch and its Docker-based `test_unit_qjs` execution path are untouched. The 3 files using `node:test`'s `t.mock.method` were rewritten to `vi.spyOn`, relying on a new global `restoreMocks: true` to match `node:test`'s automatic per-test mock restoration.

`vitest` is only a transitive dependency (bundled inside `vite-plus`, which `vp test` execs directly), but `*.test.ts` files import it by name, so `tsc` couldn't resolve its types under pnpm's strict linking. Fixed via `publicHoistPattern` in `pnpm-workspace.yaml` rather than adding `vitest` as a direct devDependency, since its version is vite-plus's to own, not this project's.

## Changes

- Switch all `*.test.ts` files' `describe`/`it`/`beforeEach`/`afterEach` imports from `node:test` to `vitest`, including the Node branch of `core/lib/test/test-shim.ts`.
- Rewrite the 3 files using `node:test`'s `t.mock.method` (`annotation.test.ts`, `emit-blocked-outcome.test.ts`, `run/src/lib/report.test.ts`) to `vi.spyOn`, updating their `.mock.calls[n].arguments[m]` call-record shape to vitest/jest's `.mock.calls[n][m]`.
- Add a `test` block to `vite.config.ts` (per-package `include` globs, `restoreMocks: true`).
- Replace the 4 `node --test '<glob>'` Makefile targets with `vp test run <path>` — vitest's CLI filters are path substrings rather than globs, so the patterns changed accordingly (noted in a Makefile comment for future test files).
- Add `publicHoistPattern: [vitest]` to `pnpm-workspace.yaml` so `tsc` can resolve `vitest`'s types without declaring it as a direct dependency.
- Update stale `node:test` references in comments (property-test file headers, `rolldown.scripts.config.js`).

## Test plan
- [x] `make test_unit_core` / `test_unit_setup` / `test_unit_report` / `test_unit_sandbox` — 41 files / 456 tests, matching pre-migration counts
- [x] `make test_unit_qjs` — unchanged, 21 + 30 tests passing
- [x] `make test_unit` (full aggregate, matches CI's `unit_test` job)
- [x] `vp run typecheck` — 0 errors
- [x] `vp check` — 0 errors