### PR TITLE
refactor: centralize report-source contract and drop dash14 label prefix

### DIFF
--- a/core/lib/docker/client.test.ts
+++ b/core/lib/docker/client.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { describe, it, assert, reportResults } from "../test/test-shim.ts";
 import { createDocker, parseContainerIds, type SpawnCommand } from "./client.ts";
+import { REPORT_ACTION_SCRIPT_PATH } from "./report-source.ts";
 
 describe("parseContainerIds", () => {
   it("splits one ID per line", () => {
@@ -45,11 +46,11 @@ describe("createDocker", () => {
     const { run, calls } = fakeRun([""]);
     createDocker(run).copyFromContainer(
       "abc123",
-      "/opt/buildcage/scripts/report-action.js",
+      REPORT_ACTION_SCRIPT_PATH,
       "/tmp/report-action.js",
     );
     assert.deepEqual(calls, [
-      ["cp", "abc123:/opt/buildcage/scripts/report-action.js", "/tmp/report-action.js"],
+      ["cp", `abc123:${REPORT_ACTION_SCRIPT_PATH}`, "/tmp/report-action.js"],
     ]);
   });
 

--- a/core/lib/docker/report-source.ts
+++ b/core/lib/docker/report-source.ts
@@ -1,0 +1,13 @@
+/**
+ * Contract between setup's Docker images and the report action: the label
+ * setup applies to the builder container so report can find it, and the
+ * path inside that container where setup bakes in report-action.js for
+ * report to `docker cp` out and run.
+ *
+ * setup's Dockerfiles (setup/docker/{transparent,explicit}/Dockerfile)
+ * can't import this directly — Dockerfile LABEL/COPY instructions are
+ * static text — so their values must be kept in sync with these constants
+ * by hand. report/src imports them directly.
+ */
+export const REPORT_SOURCE_LABEL = "io.github.dash14.buildcage.report-source";
+export const REPORT_ACTION_SCRIPT_PATH = "/opt/buildcage/scripts/report-action.js";

--- a/core/lib/docker/report-source.ts
+++ b/core/lib/docker/report-source.ts
@@ -1,13 +1,7 @@
 /**
- * Contract between setup's Docker images and the report action: the label
- * setup applies to the builder container so report can find it, and the
- * path inside that container where setup bakes in report-action.js for
- * report to `docker cp` out and run.
- *
- * setup's Dockerfiles (setup/docker/{transparent,explicit}/Dockerfile)
- * can't import this directly — Dockerfile LABEL/COPY instructions are
- * static text — so their values must be kept in sync with these constants
- * by hand. report/src imports them directly.
+ * Single source of truth for the setup <-> report contract, so the two
+ * can't silently drift apart. setup's Dockerfiles can't import this
+ * directly (LABEL/COPY are static text) — keep those values in sync by hand.
  */
 export const REPORT_SOURCE_LABEL = "io.github.buildcage.report-source";
 export const REPORT_ACTION_SCRIPT_PATH = "/opt/buildcage/scripts/report-action.js";

--- a/core/lib/docker/report-source.ts
+++ b/core/lib/docker/report-source.ts
@@ -9,5 +9,5 @@
  * static text — so their values must be kept in sync with these constants
  * by hand. report/src imports them directly.
  */
-export const REPORT_SOURCE_LABEL = "io.github.dash14.buildcage.report-source";
+export const REPORT_SOURCE_LABEL = "io.github.buildcage.report-source";
 export const REPORT_ACTION_SCRIPT_PATH = "/opt/buildcage/scripts/report-action.js";

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -229,7 +229,7 @@ function resolveProjectName(builderName, env) {
 async function main() {
 	let builderName = process.env.INPUT_BUILDER_NAME || "buildcage", projectName = resolveProjectName(builderName, process.env), docker = createDocker(), containerId;
 	try {
-		let ids = docker.findContainers([`label=com.docker.compose.project=${projectName}`, "label=io.github.dash14.buildcage.report-source=true"]);
+		let ids = docker.findContainers([`label=com.docker.compose.project=${projectName}`, "label=io.github.buildcage.report-source=true"]);
 		if (ids.length !== 1) throw new ReportError(`Expected exactly one buildcage container for builder_name ${JSON.stringify(builderName)}, found ${ids.length}. Did the setup step run first, with the same builder_name?`, "CONTAINER_NOT_FOUND");
 		containerId = ids[0];
 	} catch (e) {

--- a/report/src/main.ts
+++ b/report/src/main.ts
@@ -7,6 +7,10 @@ import { fileURLToPath } from "node:url";
 import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
 import { deriveProjectName } from "../../core/lib/docker/container.ts";
 import { createDocker } from "../../core/lib/docker/client.ts";
+import {
+  REPORT_ACTION_SCRIPT_PATH,
+  REPORT_SOURCE_LABEL,
+} from "../../core/lib/docker/report-source.ts";
 import { ActionError } from "../../core/lib/general/action-error.ts";
 import { errorMessage } from "../../core/lib/general/error-message.ts";
 import { ReportError } from "./lib/errors.ts";
@@ -32,7 +36,7 @@ async function main(): Promise<void> {
   try {
     const ids = docker.findContainers([
       `label=com.docker.compose.project=${projectName}`,
-      "label=io.github.dash14.buildcage.report-source=true",
+      `label=${REPORT_SOURCE_LABEL}=true`,
     ]);
     if (ids.length !== 1) {
       throw new ReportError(
@@ -60,11 +64,7 @@ async function main(): Promise<void> {
     const reportActionPath = join(scratchDir, "report-action.js");
 
     try {
-      docker.copyFromContainer(
-        containerId,
-        "/opt/buildcage/scripts/report-action.js",
-        reportActionPath,
-      );
+      docker.copyFromContainer(containerId, REPORT_ACTION_SCRIPT_PATH, reportActionPath);
     } catch (e) {
       throw new ReportError(
         describeDockerFailure(e, {

--- a/setup/docker/explicit/Dockerfile
+++ b/setup/docker/explicit/Dockerfile
@@ -48,7 +48,7 @@ LABEL org.opencontainers.image.title="buildcage (explicit proxy engine)" \
       org.opencontainers.image.licenses="MIT AND Apache-2.0" \
       org.opencontainers.image.source="https://github.com/dash14/buildcage" \
       io.github.buildcage.report-source="true"
-# Keep in sync with core/lib/docker/report-source.ts's REPORT_SOURCE_LABEL.
+# report finds this container by this label — must match core/lib/docker/report-source.ts.
 
 # quickjs-ng is the only extra package needed, for source-policy generation.
 RUN apk add --no-cache quickjs-ng

--- a/setup/docker/explicit/Dockerfile
+++ b/setup/docker/explicit/Dockerfile
@@ -47,7 +47,8 @@ LABEL org.opencontainers.image.title="buildcage (explicit proxy engine)" \
       org.opencontainers.image.description="Secure Docker build environment using BuildKit's native --proxy-network" \
       org.opencontainers.image.licenses="MIT AND Apache-2.0" \
       org.opencontainers.image.source="https://github.com/dash14/buildcage" \
-      io.github.dash14.buildcage.report-source="true"
+      io.github.buildcage.report-source="true"
+# Keep in sync with core/lib/docker/report-source.ts's REPORT_SOURCE_LABEL.
 
 # quickjs-ng is the only extra package needed, for source-policy generation.
 RUN apk add --no-cache quickjs-ng

--- a/setup/docker/transparent/Dockerfile
+++ b/setup/docker/transparent/Dockerfile
@@ -45,7 +45,7 @@ LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.licenses="MIT AND GPL-2.0-or-later" \
       org.opencontainers.image.source="https://github.com/dash14/buildcage" \
       io.github.buildcage.report-source="true"
-# Keep in sync with core/lib/docker/report-source.ts's REPORT_SOURCE_LABEL.
+# report finds this container by this label — must match core/lib/docker/report-source.ts.
 
 RUN apk add --no-cache \
       s6-overlay \

--- a/setup/docker/transparent/Dockerfile
+++ b/setup/docker/transparent/Dockerfile
@@ -44,7 +44,8 @@ LABEL org.opencontainers.image.title="buildcage" \
       org.opencontainers.image.description="Secure Docker build environment with network access control" \
       org.opencontainers.image.licenses="MIT AND GPL-2.0-or-later" \
       org.opencontainers.image.source="https://github.com/dash14/buildcage" \
-      io.github.dash14.buildcage.report-source="true"
+      io.github.buildcage.report-source="true"
+# Keep in sync with core/lib/docker/report-source.ts's REPORT_SOURCE_LABEL.
 
 RUN apk add --no-cache \
       s6-overlay \


### PR DESCRIPTION
## Summary

`report/src/main.ts` locates the running builder container purely via Docker metadata, then `docker cp`s `report-action.js` out of it and executes it — it never contains the report-rendering logic itself, which is baked into `setup`'s Docker image at build time. That contract (a Docker label to find the container, a fixed path to fetch the script from) was duplicated as separate hardcoded string literals across `setup`'s two Dockerfiles and `report/src/main.ts`, with nothing tying them together or catching a mismatch except end-to-end tests actually running both actions.

This centralizes both constants into a new `core/lib/docker/report-source.ts` module that `report/src` imports directly. Dockerfiles can't import TypeScript, so their `LABEL`/`COPY` values stay as literals, now with a comment pointing back at the module they must stay in sync with.

While touching this, the label itself is also renamed from `io.github.dash14.buildcage.report-source` to `io.github.buildcage.report-source`, dropping the dash14-specific ownership from the identifier. This is a breaking change to an internal contract, done now while `setup` and `report` still ship from the same repo and release together, so both sides update atomically.

## Changes

- Centralize the setup ↔ report contract in one place
  - The label report uses to find the builder container, and the path to the report script setup bakes into its image, used to live as separate literals with nothing catching drift between them.
- Drop the dash14-specific prefix from the report-source label
  - Decouples this internal identifier's naming from the current repo owner, done now while setup and report still release together so both sides move in lockstep.