### PR TITLE
refactor: adopt @actions/core for input/state/summary handling

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -109,6 +109,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # report/src/main.ts is run straight from source below (Show logs
+      # step) and now imports @actions/core, so node_modules must exist.
+      - uses: ./.github/actions/setup-vp
+
       - name: Build containers
         env:
           PROXY_ENGINE: ${{ matrix.proxy_engine }}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc -p tsconfig.json && tsc -p tsconfig.qjs.json"
   },
   "dependencies": {
+    "@actions/core": "^3.0.1",
     "@sigstore/bundle": "^5.0.0",
     "@sigstore/tuf": "^5.0.0",
     "@sigstore/verify": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
 
   .:
     dependencies:
+      '@actions/core':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@sigstore/bundle':
         specifier: ^5.0.0
         version: 5.0.0
@@ -237,6 +240,18 @@ importers:
         version: 0.2.5(@types/node@24.13.3)(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3))
 
 packages:
+
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
+
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
+
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1635,6 +1650,10 @@ packages:
     resolution: {integrity: sha512-zlJVOIO68hmgo1//X4ENEcTGfuOTAtDPi8PsTsG+FyxD85E/ww1ZnwBbWo/yCEExGpI+Kilg7Z3qCdHX2BoJTQ==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -1642,6 +1661,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+    engines: {node: '>=18.17'}
 
   vite-plus@0.2.5:
     resolution: {integrity: sha512-QNJ0FnN8rfs5u8lZKZ1uR2Tegjg3VkT0AGTxSLGHg4fYmGxRNfAV0YX1parZrVa4VybSI56SWCoo7wQ6D7pMew==}
@@ -1764,6 +1787,22 @@ packages:
     resolution: {integrity: sha512-OWBfhrpgK9+/4+IXG9oT8Bao4AhViQA7vdyNNH7EUg8dQYgwa70XtIBWTpCEme1P1ECyoDNYkn0wT63f8XRcVA==}
 
 snapshots:
+
+  '@actions/core@3.0.1':
+    dependencies:
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.1
+
+  '@actions/exec@3.0.0':
+    dependencies:
+      '@actions/io': 3.0.2
+
+  '@actions/http-client@4.0.1':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.27.0
+
+  '@actions/io@3.0.2': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2648,6 +2687,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  tunnel@0.0.6: {}
+
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -2672,6 +2713,8 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.18.2: {}
+
+  undici@6.27.0: {}
 
   vite-plus@0.2.5(@types/node@24.13.3)(typescript@7.0.2)(vite@8.1.5(@types/node@24.13.3)):
     dependencies:

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -1,5 +1,481 @@
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_os = require("node:os"), node_path = require("node:path"), node_url = require("node:url"), node_crypto = require("node:crypto"), node_events = require("node:events"), node_readline = require("node:readline");
+//#region \0rolldown/runtime.js
+var __create = Object.create, __defProp = Object.defineProperty, __getOwnPropDesc = Object.getOwnPropertyDescriptor, __getOwnPropNames = Object.getOwnPropertyNames, __getProtoOf = Object.getPrototypeOf, __hasOwnProp = Object.prototype.hasOwnProperty, __copyProps = (to, from, except, desc) => {
+	if (from && typeof from == "object" || typeof from == "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) key = keys[i], !__hasOwnProp.call(to, key) && key !== except && __defProp(to, key, {
+		get: ((k) => from[k]).bind(null, key),
+		enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+	});
+	return to;
+}, __toESM = (mod, isNodeMode, target) => (target = mod == null ? {} : __create(__getProtoOf(mod)), __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: !0
+}) : target, mod));
+//#endregion
+let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_os = require("node:os"), node_path = require("node:path"), node_url = require("node:url"), os = require("os");
+os = __toESM(os, 1);
+let fs = require("fs");
+fs = __toESM(fs, 1);
+let path = require("path");
+path = __toESM(path, 1);
+let events = require("events");
+events = __toESM(events, 1);
+let node_events = require("node:events"), node_crypto = require("node:crypto"), child_process = require("child_process");
+child_process = __toESM(child_process, 1), require("timers");
+let node_readline = require("node:readline");
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/summary.js
+var __awaiter$6 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { access, appendFile, writeFile } = fs.promises, SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
+new class {
+	constructor() {
+		this._buffer = "";
+	}
+	/**
+	* Finds the summary file path from the environment, rejects if env var is not found or file does not exist
+	* Also checks r/w permissions.
+	*
+	* @returns step summary file path
+	*/
+	filePath() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			if (this._filePath) return this._filePath;
+			let pathFromEnv = process.env[SUMMARY_ENV_VAR];
+			if (!pathFromEnv) throw Error(`Unable to find environment variable for $${SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
+			try {
+				yield access(pathFromEnv, fs.constants.R_OK | fs.constants.W_OK);
+			} catch {
+				throw Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
+			}
+			return this._filePath = pathFromEnv, this._filePath;
+		});
+	}
+	/**
+	* Wraps content in an HTML tag, adding any HTML attributes
+	*
+	* @param {string} tag HTML tag to wrap
+	* @param {string | null} content content within the tag
+	* @param {[attribute: string]: string} attrs key-value list of HTML attributes to add
+	*
+	* @returns {string} content wrapped in HTML element
+	*/
+	wrap(tag, content, attrs = {}) {
+		let htmlAttrs = Object.entries(attrs).map(([key, value]) => ` ${key}="${value}"`).join("");
+		return content ? `<${tag}${htmlAttrs}>${content}</${tag}>` : `<${tag}${htmlAttrs}>`;
+	}
+	/**
+	* Writes text in the buffer to the summary buffer file and empties buffer. Will append by default.
+	*
+	* @param {SummaryWriteOptions} [options] (optional) options for write operation
+	*
+	* @returns {Promise<Summary>} summary instance
+	*/
+	write(options) {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			let overwrite = !!options?.overwrite, filePath = yield this.filePath();
+			return yield (overwrite ? writeFile : appendFile)(filePath, this._buffer, { encoding: "utf8" }), this.emptyBuffer();
+		});
+	}
+	/**
+	* Clears the summary buffer and wipes the summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	clear() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			return this.emptyBuffer().write({ overwrite: !0 });
+		});
+	}
+	/**
+	* Returns the current summary buffer as a string
+	*
+	* @returns {string} string of summary buffer
+	*/
+	stringify() {
+		return this._buffer;
+	}
+	/**
+	* If the summary buffer is empty
+	*
+	* @returns {boolen} true if the buffer is empty
+	*/
+	isEmptyBuffer() {
+		return this._buffer.length === 0;
+	}
+	/**
+	* Resets the summary buffer without writing to summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	emptyBuffer() {
+		return this._buffer = "", this;
+	}
+	/**
+	* Adds raw text to the summary buffer
+	*
+	* @param {string} text content to add
+	* @param {boolean} [addEOL=false] (optional) append an EOL to the raw text (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addRaw(text, addEOL = !1) {
+		return this._buffer += text, addEOL ? this.addEOL() : this;
+	}
+	/**
+	* Adds the operating system-specific end-of-line marker to the buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addEOL() {
+		return this.addRaw(os.EOL);
+	}
+	/**
+	* Adds an HTML codeblock to the summary buffer
+	*
+	* @param {string} code content to render within fenced code block
+	* @param {string} lang (optional) language to syntax highlight code
+	*
+	* @returns {Summary} summary instance
+	*/
+	addCodeBlock(code, lang) {
+		let attrs = Object.assign({}, lang && { lang }), element = this.wrap("pre", this.wrap("code", code), attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML list to the summary buffer
+	*
+	* @param {string[]} items list of items to render
+	* @param {boolean} [ordered=false] (optional) if the rendered list should be ordered or not (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addList(items, ordered = !1) {
+		let tag = ordered ? "ol" : "ul", listItems = items.map((item) => this.wrap("li", item)).join(""), element = this.wrap(tag, listItems);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML table to the summary buffer
+	*
+	* @param {SummaryTableCell[]} rows table rows
+	*
+	* @returns {Summary} summary instance
+	*/
+	addTable(rows) {
+		let tableBody = rows.map((row) => {
+			let cells = row.map((cell) => {
+				if (typeof cell == "string") return this.wrap("td", cell);
+				let { header, data, colspan, rowspan } = cell, tag = header ? "th" : "td", attrs = Object.assign(Object.assign({}, colspan && { colspan }), rowspan && { rowspan });
+				return this.wrap(tag, data, attrs);
+			}).join("");
+			return this.wrap("tr", cells);
+		}).join(""), element = this.wrap("table", tableBody);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds a collapsable HTML details element to the summary buffer
+	*
+	* @param {string} label text for the closed state
+	* @param {string} content collapsable content
+	*
+	* @returns {Summary} summary instance
+	*/
+	addDetails(label, content) {
+		let element = this.wrap("details", this.wrap("summary", label) + content);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML image tag to the summary buffer
+	*
+	* @param {string} src path to the image you to embed
+	* @param {string} alt text description of the image
+	* @param {SummaryImageOptions} options (optional) addition image attributes
+	*
+	* @returns {Summary} summary instance
+	*/
+	addImage(src, alt, options) {
+		let { width, height } = options || {}, attrs = Object.assign(Object.assign({}, width && { width }), height && { height }), element = this.wrap("img", null, Object.assign({
+			src,
+			alt
+		}, attrs));
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML section heading element
+	*
+	* @param {string} text heading text
+	* @param {number | string} [level=1] (optional) the heading level, default: 1
+	*
+	* @returns {Summary} summary instance
+	*/
+	addHeading(text, level) {
+		let tag = `h${level}`, allowedTag = [
+			"h1",
+			"h2",
+			"h3",
+			"h4",
+			"h5",
+			"h6"
+		].includes(tag) ? tag : "h1", element = this.wrap(allowedTag, text);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML thematic break (<hr>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addSeparator() {
+		let element = this.wrap("hr", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML line break (<br>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addBreak() {
+		let element = this.wrap("br", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML blockquote to the summary buffer
+	*
+	* @param {string} text quote text
+	* @param {string} cite (optional) citation url
+	*
+	* @returns {Summary} summary instance
+	*/
+	addQuote(text, cite) {
+		let attrs = Object.assign({}, cite && { cite }), element = this.wrap("blockquote", text, attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML anchor tag to the summary buffer
+	*
+	* @param {string} text link text/content
+	* @param {string} href hyperlink
+	*
+	* @returns {Summary} summary instance
+	*/
+	addLink(text, href) {
+		let element = this.wrap("a", text, { href });
+		return this.addRaw(element).addEOL();
+	}
+}();
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io-util.js
+var __awaiter$5 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises, IS_WINDOWS$1 = process.platform === "win32";
+fs.constants.O_RDONLY;
+/**
+* On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+* \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+*/
+function isRooted(p) {
+	if (p = normalizeSeparators(p), !p) throw Error("isRooted() parameter \"p\" cannot be empty");
+	return IS_WINDOWS$1 ? p.startsWith("\\") || /^[A-Z]:/i.test(p) : p.startsWith("/");
+}
+/**
+* Best effort attempt to determine whether a file exists and is executable.
+* @param filePath    file path to check
+* @param extensions  additional file extensions to try
+* @return if file exists and is executable, returns the file path. otherwise empty string.
+*/
+function tryGetExecutablePath(filePath, extensions) {
+	return __awaiter$5(this, void 0, void 0, function* () {
+		let stats;
+		try {
+			stats = yield stat(filePath);
+		} catch (err) {
+			err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+		}
+		if (stats && stats.isFile()) {
+			if (IS_WINDOWS$1) {
+				let upperExt = path.extname(filePath).toUpperCase();
+				if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) return filePath;
+			} else if (isUnixExecutable(stats)) return filePath;
+		}
+		let originalFilePath = filePath;
+		for (let extension of extensions) {
+			filePath = originalFilePath + extension, stats = void 0;
+			try {
+				stats = yield stat(filePath);
+			} catch (err) {
+				err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+			}
+			if (stats && stats.isFile()) {
+				if (IS_WINDOWS$1) {
+					try {
+						let directory = path.dirname(filePath), upperName = path.basename(filePath).toUpperCase();
+						for (let actualName of yield readdir(directory)) if (upperName === actualName.toUpperCase()) {
+							filePath = path.join(directory, actualName);
+							break;
+						}
+					} catch (err) {
+						console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+					}
+					return filePath;
+				} else if (isUnixExecutable(stats)) return filePath;
+			}
+		}
+		return "";
+	});
+}
+function normalizeSeparators(p) {
+	return p ||= "", IS_WINDOWS$1 ? (p = p.replace(/\//g, "\\"), p.replace(/\\\\+/g, "\\")) : p.replace(/\/\/+/g, "/");
+}
+function isUnixExecutable(stats) {
+	return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io.js
+var __awaiter$4 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+/**
+* Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+* If you check and the tool does not exist, it will throw.
+*
+* @param     tool              name of the tool
+* @param     check             whether to check if tool exists
+* @returns   Promise<string>   path to tool
+*/
+function which(tool, check) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		if (check) {
+			let result = yield which(tool, !1);
+			if (!result) throw Error(IS_WINDOWS$1 ? `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.` : `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+			return result;
+		}
+		let matches = yield findInPath(tool);
+		return matches && matches.length > 0 ? matches[0] : "";
+	});
+}
+/**
+* Returns a list of all occurrences of the given tool on the system path.
+*
+* @returns   Promise<string[]>  the paths of the tool
+*/
+function findInPath(tool) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		let extensions = [];
+		if (IS_WINDOWS$1 && process.env.PATHEXT) for (let extension of process.env.PATHEXT.split(path.delimiter)) extension && extensions.push(extension);
+		if (isRooted(tool)) {
+			let filePath = yield tryGetExecutablePath(tool, extensions);
+			return filePath ? [filePath] : [];
+		}
+		if (tool.includes(path.sep)) return [];
+		let directories = [];
+		if (process.env.PATH) for (let p of process.env.PATH.split(path.delimiter)) p && directories.push(p);
+		let matches = [];
+		for (let directory of directories) {
+			let filePath = yield tryGetExecutablePath(path.join(directory, tool), extensions);
+			filePath && matches.push(filePath);
+		}
+		return matches;
+	});
+}
+process.platform, events.EventEmitter, events.EventEmitter, os.default.platform(), os.default.arch();
+/**
+* The code to exit an action
+*/
+var ExitCode;
+(function(ExitCode) {
+	/**
+	* A code indicating that the action was a failure
+	*/
+	ExitCode[ExitCode.Success = 0] = "Success", ExitCode[ExitCode.Failure = 1] = "Failure";
+})(ExitCode ||= {});
+/**
+* Gets the value of an input.
+* Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
+* Returns an empty string if the value is not defined.
+*
+* @param     name     name of the input to get
+* @param     options  optional. See InputOptions.
+* @returns   string
+*/
+function getInput(name, options) {
+	let val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+	if (options && options.required && !val) throw Error(`Input required and not supplied: ${name}`);
+	return options && options.trimWhitespace === !1 ? val : val.trim();
+}
 /**
 * Turns a caught `docker` invocation error into an actionable message,
 * pointing at the runner requirement instead of surfacing execFileSync's
@@ -227,7 +703,7 @@ function resolveProjectName(builderName, env) {
 	return deriveProjectName(builderName);
 }
 async function main() {
-	let builderName = process.env.INPUT_BUILDER_NAME || "buildcage", projectName = resolveProjectName(builderName, process.env), docker = createDocker(), containerId;
+	let builderName = getInput("builder_name") || "buildcage", projectName = resolveProjectName(builderName, process.env), docker = createDocker(), containerId;
 	try {
 		let ids = docker.findContainers([`label=com.docker.compose.project=${projectName}`, "label=io.github.buildcage.report-source=true"]);
 		if (ids.length !== 1) throw new ReportError(`Expected exactly one buildcage container for builder_name ${JSON.stringify(builderName)}, found ${ids.length}. Did the setup step run first, with the same builder_name?`, "CONTAINER_NOT_FOUND");

--- a/report/src/main.ts
+++ b/report/src/main.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as core from "@actions/core";
 
 import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
 import { deriveProjectName } from "../../core/lib/docker/container.ts";
@@ -27,7 +28,7 @@ export function resolveProjectName(builderName: string, env: NodeJS.ProcessEnv):
 }
 
 async function main(): Promise<void> {
-  const builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
+  const builderName = core.getInput("builder_name") || "buildcage";
   const projectName = resolveProjectName(builderName, process.env);
   const docker = createDocker();
 

--- a/rolldown.config.js
+++ b/rolldown.config.js
@@ -49,6 +49,9 @@ export default defineConfig(
     input,
     external: [/^node:/],
     platform: "node",
+    treeshake: {
+      moduleSideEffects: [{ test: /\/(@actions\/http-client|undici)\//, sideEffects: false }],
+    },
     plugins,
     output: {
       file,

--- a/rolldown.scripts.config.js
+++ b/rolldown.scripts.config.js
@@ -27,6 +27,12 @@ function settingsFor(input) {
         stripSuffix: /\.node\.ts$/,
         external: [/^node:/],
         platform: "node",
+        // report-action.node.ts only uses core.getInput/summary, but
+        // @actions/core statically imports @actions/http-client (for the
+        // unused getIDToken) which pulls in all of undici otherwise.
+        treeshake: {
+          moduleSideEffects: [{ test: /\/(@actions\/http-client|undici)\//, sideEffects: false }],
+        },
       };
 }
 
@@ -58,11 +64,12 @@ export default defineConfig(
         output: { file: `dist/test-qjs/${input.replace(/\.ts$/, ".js")}`, ...baseOutput },
       }))
     : scriptInputs.map((input) => {
-        const { outDir, stripSuffix, external, platform } = settingsFor(input);
+        const { outDir, stripSuffix, external, platform, treeshake } = settingsFor(input);
         return {
           input,
           external,
           platform,
+          treeshake,
           output: { file: `${outDir}/${input.replace(stripSuffix, ".js")}`, ...baseOutput },
         };
       }),

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -13,9 +13,593 @@ var __create = Object.create, __defProp = Object.defineProperty, __getOwnPropDes
 //#endregion
 let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_path = require("node:path");
 node_path = __toESM(node_path, 1);
-let node_url = require("node:url"), node_os = require("node:os");
+let node_url = require("node:url"), os = require("os");
+os = __toESM(os, 1);
+let crypto = require("crypto");
+crypto = __toESM(crypto, 1);
+let fs = require("fs");
+fs = __toESM(fs, 1);
+let path = require("path");
+path = __toESM(path, 1);
+let events = require("events");
+events = __toESM(events, 1);
+let node_events = require("node:events"), node_crypto = require("node:crypto"), child_process = require("child_process");
+child_process = __toESM(child_process, 1), require("timers");
+let node_os = require("node:os");
 node_os = __toESM(node_os, 1);
-let node_crypto = require("node:crypto"), node_events = require("node:events"), node_readline = require("node:readline");
+let node_readline = require("node:readline");
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/utils.js
+/**
+* Sanitizes an input into a string so it can be passed into issueCommand safely
+* @param input input to sanitize into a string
+*/
+function toCommandValue(input) {
+	return input == null ? "" : typeof input == "string" || input instanceof String ? input : JSON.stringify(input);
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/command.js
+/**
+* Issues a command to the GitHub Actions runner
+*
+* @param command - The command name to issue
+* @param properties - Additional properties for the command (key-value pairs)
+* @param message - The message to include with the command
+* @remarks
+* This function outputs a specially formatted string to stdout that the Actions
+* runner interprets as a command. These commands can control workflow behavior,
+* set outputs, create annotations, mask values, and more.
+*
+* Command Format:
+*   ::name key=value,key=value::message
+*
+* @example
+* ```typescript
+* // Issue a warning annotation
+* issueCommand('warning', {}, 'This is a warning message');
+* // Output: ::warning::This is a warning message
+*
+* // Set an environment variable
+* issueCommand('set-env', { name: 'MY_VAR' }, 'some value');
+* // Output: ::set-env name=MY_VAR::some value
+*
+* // Add a secret mask
+* issueCommand('add-mask', {}, 'secretValue123');
+* // Output: ::add-mask::secretValue123
+* ```
+*
+* @internal
+* This is an internal utility function that powers the public API functions
+* such as setSecret, warning, error, and exportVariable.
+*/
+function issueCommand(command, properties, message) {
+	let cmd = new Command(command, properties, message);
+	process.stdout.write(cmd.toString() + os.EOL);
+}
+var Command = class {
+	constructor(command, properties, message) {
+		command ||= "missing.command", this.command = command, this.properties = properties, this.message = message;
+	}
+	toString() {
+		let cmdStr = "::" + this.command;
+		if (this.properties && Object.keys(this.properties).length > 0) {
+			cmdStr += " ";
+			let first = !0;
+			for (let key in this.properties) if (this.properties.hasOwnProperty(key)) {
+				let val = this.properties[key];
+				val && (first ? first = !1 : cmdStr += ",", cmdStr += `${key}=${escapeProperty(val)}`);
+			}
+		}
+		return cmdStr += `::${escapeData(this.message)}`, cmdStr;
+	}
+};
+function escapeData(s) {
+	return toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A");
+}
+function escapeProperty(s) {
+	return toCommandValue(s).replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A").replace(/:/g, "%3A").replace(/,/g, "%2C");
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/file-command.js
+function issueFileCommand(command, message) {
+	let filePath = process.env[`GITHUB_${command}`];
+	if (!filePath) throw Error(`Unable to find environment variable for file command ${command}`);
+	if (!fs.existsSync(filePath)) throw Error(`Missing file at path: ${filePath}`);
+	fs.appendFileSync(filePath, `${toCommandValue(message)}${os.EOL}`, { encoding: "utf8" });
+}
+function prepareKeyValueMessage(key, value) {
+	let delimiter = `ghadelimiter_${crypto.randomUUID()}`, convertedValue = toCommandValue(value);
+	if (key.includes(delimiter)) throw Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+	if (convertedValue.includes(delimiter)) throw Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+	return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/summary.js
+var __awaiter$6 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { access, appendFile, writeFile } = fs.promises, SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY", summary = new class {
+	constructor() {
+		this._buffer = "";
+	}
+	/**
+	* Finds the summary file path from the environment, rejects if env var is not found or file does not exist
+	* Also checks r/w permissions.
+	*
+	* @returns step summary file path
+	*/
+	filePath() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			if (this._filePath) return this._filePath;
+			let pathFromEnv = process.env[SUMMARY_ENV_VAR];
+			if (!pathFromEnv) throw Error(`Unable to find environment variable for $${SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
+			try {
+				yield access(pathFromEnv, fs.constants.R_OK | fs.constants.W_OK);
+			} catch {
+				throw Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
+			}
+			return this._filePath = pathFromEnv, this._filePath;
+		});
+	}
+	/**
+	* Wraps content in an HTML tag, adding any HTML attributes
+	*
+	* @param {string} tag HTML tag to wrap
+	* @param {string | null} content content within the tag
+	* @param {[attribute: string]: string} attrs key-value list of HTML attributes to add
+	*
+	* @returns {string} content wrapped in HTML element
+	*/
+	wrap(tag, content, attrs = {}) {
+		let htmlAttrs = Object.entries(attrs).map(([key, value]) => ` ${key}="${value}"`).join("");
+		return content ? `<${tag}${htmlAttrs}>${content}</${tag}>` : `<${tag}${htmlAttrs}>`;
+	}
+	/**
+	* Writes text in the buffer to the summary buffer file and empties buffer. Will append by default.
+	*
+	* @param {SummaryWriteOptions} [options] (optional) options for write operation
+	*
+	* @returns {Promise<Summary>} summary instance
+	*/
+	write(options) {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			let overwrite = !!options?.overwrite, filePath = yield this.filePath();
+			return yield (overwrite ? writeFile : appendFile)(filePath, this._buffer, { encoding: "utf8" }), this.emptyBuffer();
+		});
+	}
+	/**
+	* Clears the summary buffer and wipes the summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	clear() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			return this.emptyBuffer().write({ overwrite: !0 });
+		});
+	}
+	/**
+	* Returns the current summary buffer as a string
+	*
+	* @returns {string} string of summary buffer
+	*/
+	stringify() {
+		return this._buffer;
+	}
+	/**
+	* If the summary buffer is empty
+	*
+	* @returns {boolen} true if the buffer is empty
+	*/
+	isEmptyBuffer() {
+		return this._buffer.length === 0;
+	}
+	/**
+	* Resets the summary buffer without writing to summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	emptyBuffer() {
+		return this._buffer = "", this;
+	}
+	/**
+	* Adds raw text to the summary buffer
+	*
+	* @param {string} text content to add
+	* @param {boolean} [addEOL=false] (optional) append an EOL to the raw text (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addRaw(text, addEOL = !1) {
+		return this._buffer += text, addEOL ? this.addEOL() : this;
+	}
+	/**
+	* Adds the operating system-specific end-of-line marker to the buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addEOL() {
+		return this.addRaw(os.EOL);
+	}
+	/**
+	* Adds an HTML codeblock to the summary buffer
+	*
+	* @param {string} code content to render within fenced code block
+	* @param {string} lang (optional) language to syntax highlight code
+	*
+	* @returns {Summary} summary instance
+	*/
+	addCodeBlock(code, lang) {
+		let attrs = Object.assign({}, lang && { lang }), element = this.wrap("pre", this.wrap("code", code), attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML list to the summary buffer
+	*
+	* @param {string[]} items list of items to render
+	* @param {boolean} [ordered=false] (optional) if the rendered list should be ordered or not (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addList(items, ordered = !1) {
+		let tag = ordered ? "ol" : "ul", listItems = items.map((item) => this.wrap("li", item)).join(""), element = this.wrap(tag, listItems);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML table to the summary buffer
+	*
+	* @param {SummaryTableCell[]} rows table rows
+	*
+	* @returns {Summary} summary instance
+	*/
+	addTable(rows) {
+		let tableBody = rows.map((row) => {
+			let cells = row.map((cell) => {
+				if (typeof cell == "string") return this.wrap("td", cell);
+				let { header, data, colspan, rowspan } = cell, tag = header ? "th" : "td", attrs = Object.assign(Object.assign({}, colspan && { colspan }), rowspan && { rowspan });
+				return this.wrap(tag, data, attrs);
+			}).join("");
+			return this.wrap("tr", cells);
+		}).join(""), element = this.wrap("table", tableBody);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds a collapsable HTML details element to the summary buffer
+	*
+	* @param {string} label text for the closed state
+	* @param {string} content collapsable content
+	*
+	* @returns {Summary} summary instance
+	*/
+	addDetails(label, content) {
+		let element = this.wrap("details", this.wrap("summary", label) + content);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML image tag to the summary buffer
+	*
+	* @param {string} src path to the image you to embed
+	* @param {string} alt text description of the image
+	* @param {SummaryImageOptions} options (optional) addition image attributes
+	*
+	* @returns {Summary} summary instance
+	*/
+	addImage(src, alt, options) {
+		let { width, height } = options || {}, attrs = Object.assign(Object.assign({}, width && { width }), height && { height }), element = this.wrap("img", null, Object.assign({
+			src,
+			alt
+		}, attrs));
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML section heading element
+	*
+	* @param {string} text heading text
+	* @param {number | string} [level=1] (optional) the heading level, default: 1
+	*
+	* @returns {Summary} summary instance
+	*/
+	addHeading(text, level) {
+		let tag = `h${level}`, allowedTag = [
+			"h1",
+			"h2",
+			"h3",
+			"h4",
+			"h5",
+			"h6"
+		].includes(tag) ? tag : "h1", element = this.wrap(allowedTag, text);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML thematic break (<hr>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addSeparator() {
+		let element = this.wrap("hr", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML line break (<br>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addBreak() {
+		let element = this.wrap("br", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML blockquote to the summary buffer
+	*
+	* @param {string} text quote text
+	* @param {string} cite (optional) citation url
+	*
+	* @returns {Summary} summary instance
+	*/
+	addQuote(text, cite) {
+		let attrs = Object.assign({}, cite && { cite }), element = this.wrap("blockquote", text, attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML anchor tag to the summary buffer
+	*
+	* @param {string} text link text/content
+	* @param {string} href hyperlink
+	*
+	* @returns {Summary} summary instance
+	*/
+	addLink(text, href) {
+		let element = this.wrap("a", text, { href });
+		return this.addRaw(element).addEOL();
+	}
+}();
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io-util.js
+var __awaiter$5 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises, IS_WINDOWS$1 = process.platform === "win32";
+fs.constants.O_RDONLY;
+/**
+* On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+* \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+*/
+function isRooted(p) {
+	if (p = normalizeSeparators(p), !p) throw Error("isRooted() parameter \"p\" cannot be empty");
+	return IS_WINDOWS$1 ? p.startsWith("\\") || /^[A-Z]:/i.test(p) : p.startsWith("/");
+}
+/**
+* Best effort attempt to determine whether a file exists and is executable.
+* @param filePath    file path to check
+* @param extensions  additional file extensions to try
+* @return if file exists and is executable, returns the file path. otherwise empty string.
+*/
+function tryGetExecutablePath(filePath, extensions) {
+	return __awaiter$5(this, void 0, void 0, function* () {
+		let stats;
+		try {
+			stats = yield stat(filePath);
+		} catch (err) {
+			err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+		}
+		if (stats && stats.isFile()) {
+			if (IS_WINDOWS$1) {
+				let upperExt = path.extname(filePath).toUpperCase();
+				if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) return filePath;
+			} else if (isUnixExecutable(stats)) return filePath;
+		}
+		let originalFilePath = filePath;
+		for (let extension of extensions) {
+			filePath = originalFilePath + extension, stats = void 0;
+			try {
+				stats = yield stat(filePath);
+			} catch (err) {
+				err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+			}
+			if (stats && stats.isFile()) {
+				if (IS_WINDOWS$1) {
+					try {
+						let directory = path.dirname(filePath), upperName = path.basename(filePath).toUpperCase();
+						for (let actualName of yield readdir(directory)) if (upperName === actualName.toUpperCase()) {
+							filePath = path.join(directory, actualName);
+							break;
+						}
+					} catch (err) {
+						console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+					}
+					return filePath;
+				} else if (isUnixExecutable(stats)) return filePath;
+			}
+		}
+		return "";
+	});
+}
+function normalizeSeparators(p) {
+	return p ||= "", IS_WINDOWS$1 ? (p = p.replace(/\//g, "\\"), p.replace(/\\\\+/g, "\\")) : p.replace(/\/\/+/g, "/");
+}
+function isUnixExecutable(stats) {
+	return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io.js
+var __awaiter$4 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+/**
+* Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+* If you check and the tool does not exist, it will throw.
+*
+* @param     tool              name of the tool
+* @param     check             whether to check if tool exists
+* @returns   Promise<string>   path to tool
+*/
+function which(tool, check) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		if (check) {
+			let result = yield which(tool, !1);
+			if (!result) throw Error(IS_WINDOWS$1 ? `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.` : `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+			return result;
+		}
+		let matches = yield findInPath(tool);
+		return matches && matches.length > 0 ? matches[0] : "";
+	});
+}
+/**
+* Returns a list of all occurrences of the given tool on the system path.
+*
+* @returns   Promise<string[]>  the paths of the tool
+*/
+function findInPath(tool) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		let extensions = [];
+		if (IS_WINDOWS$1 && process.env.PATHEXT) for (let extension of process.env.PATHEXT.split(path.delimiter)) extension && extensions.push(extension);
+		if (isRooted(tool)) {
+			let filePath = yield tryGetExecutablePath(tool, extensions);
+			return filePath ? [filePath] : [];
+		}
+		if (tool.includes(path.sep)) return [];
+		let directories = [];
+		if (process.env.PATH) for (let p of process.env.PATH.split(path.delimiter)) p && directories.push(p);
+		let matches = [];
+		for (let directory of directories) {
+			let filePath = yield tryGetExecutablePath(path.join(directory, tool), extensions);
+			filePath && matches.push(filePath);
+		}
+		return matches;
+	});
+}
+process.platform, events.EventEmitter, events.EventEmitter, os.default.platform(), os.default.arch();
+/**
+* The code to exit an action
+*/
+var ExitCode;
+(function(ExitCode) {
+	/**
+	* A code indicating that the action was a failure
+	*/
+	ExitCode[ExitCode.Success = 0] = "Success", ExitCode[ExitCode.Failure = 1] = "Failure";
+})(ExitCode ||= {});
+/**
+* Gets the value of an input.
+* Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
+* Returns an empty string if the value is not defined.
+*
+* @param     name     name of the input to get
+* @param     options  optional. See InputOptions.
+* @returns   string
+*/
+function getInput(name, options) {
+	let val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+	if (options && options.required && !val) throw Error(`Input required and not supplied: ${name}`);
+	return options && options.trimWhitespace === !1 ? val : val.trim();
+}
+/**
+* Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
+* Support boolean input list: `true | True | TRUE | false | False | FALSE` .
+* The return value is also in boolean type.
+* ref: https://yaml.org/spec/1.2/spec.html#id2804923
+*
+* @param     name     name of the input to get
+* @param     options  optional. See InputOptions.
+* @returns   boolean
+*/
+function getBooleanInput(name, options) {
+	let trueValue = [
+		"true",
+		"True",
+		"TRUE"
+	], falseValue = [
+		"false",
+		"False",
+		"FALSE"
+	], val = getInput(name, options);
+	if (trueValue.includes(val)) return !0;
+	if (falseValue.includes(val)) return !1;
+	throw TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}\nSupport boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+}
+/**
+* Saves state for current action, the state can only be retrieved by this action's post job execution.
+*
+* @param     name     name of the state to store
+* @param     value    value to store. Non-string values will be converted to a string via JSON.stringify
+*/
+function saveState(name, value) {
+	if (process.env.GITHUB_STATE) return issueFileCommand("STATE", prepareKeyValueMessage(name, value));
+	issueCommand("save-state", { name }, toCommandValue(value));
+}
+//#endregion
 //#region core/lib/provenance/image-ref.ts
 function resolveBuildcageImageRef({ imageDigest, actionRepository }) {
 	return `${`ghcr.io/${actionRepository}`.toLowerCase()}@${imageDigest}`;
@@ -4360,7 +4944,7 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 		return mod && mod.__esModule ? mod : { default: mod };
 	};
 	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.Updater = void 0;
-	let models_1 = require_dist$4(), debug_1 = __importDefault(require_src()), fs = __importStar(require("fs")), path = __importStar(require("path")), package_json_1 = require_package$1(), config_1 = require_config(), error_1 = require_error$4(), fetcher_1 = require_fetcher(), store_1 = require_store(), url = __importStar(require_url()), log = (0, debug_1.default)("tuf:cache");
+	let models_1 = require_dist$4(), debug_1 = __importDefault(require_src()), fs$1 = __importStar(require("fs")), path$1 = __importStar(require("path")), package_json_1 = require_package$1(), config_1 = require_config(), error_1 = require_error$4(), fetcher_1 = require_fetcher(), store_1 = require_store(), url = __importStar(require_url()), log = (0, debug_1.default)("tuf:cache");
 	exports.Updater = class {
 		dir;
 		metadataBaseUrl;
@@ -4405,25 +4989,25 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 			}
 			let targetFilePath = targetInfo.path;
 			if (this.trustedSet.root.signed.consistentSnapshot && this.config.prefixTargetsWithHash) {
-				let hashes = Object.values(targetInfo.hashes), { dir, base } = path.parse(targetFilePath), filename = `${hashes[0]}.${base}`;
+				let hashes = Object.values(targetInfo.hashes), { dir, base } = path$1.parse(targetFilePath), filename = `${hashes[0]}.${base}`;
 				targetFilePath = dir ? `${dir}/${filename}` : filename;
 			}
 			let targetUrl = url.join(targetBaseUrl, targetFilePath);
 			return await this.fetcher.downloadFile(targetUrl, targetInfo.length, async (fileName) => {
-				await targetInfo.verify(fs.createReadStream(fileName)), log("WRITE %s", targetPath), fs.copyFileSync(fileName, targetPath);
+				await targetInfo.verify(fs$1.createReadStream(fileName)), log("WRITE %s", targetPath), fs$1.copyFileSync(fileName, targetPath);
 			}), targetPath;
 		}
 		async findCachedTarget(targetInfo, filePath) {
 			filePath ||= this.generateTargetPath(targetInfo);
 			try {
-				if (fs.existsSync(filePath)) return await targetInfo.verify(fs.createReadStream(filePath)), filePath;
+				if (fs$1.existsSync(filePath)) return await targetInfo.verify(fs$1.createReadStream(filePath)), filePath;
 			} catch {
 				return;
 			}
 		}
 		loadLocalMetadata(fileName) {
-			let filePath = path.join(this.dir, `${fileName}.json`);
-			return log("READ %s", filePath), fs.readFileSync(filePath);
+			let filePath = path$1.join(this.dir, `${fileName}.json`);
+			return log("READ %s", filePath), fs$1.readFileSync(filePath);
 		}
 		async loadRoot() {
 			let lowerBound = this.trustedSet.root.signed.version + 1, upperBound = lowerBound + this.config.maxRootRotations;
@@ -4512,13 +5096,13 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 		generateTargetPath(targetInfo) {
 			if (!this.targetDir) throw new error_1.ValueError("Target directory not set");
 			let filePath = encodeURIComponent(targetInfo.path);
-			return path.join(this.targetDir, filePath);
+			return path$1.join(this.targetDir, filePath);
 		}
 		persistMetadata(metaDataName, bytesData) {
 			let encodedName = encodeURIComponent(metaDataName);
 			try {
-				let filePath = path.join(this.dir, `${encodedName}.json`);
-				log("WRITE %s", filePath), fs.writeFileSync(filePath, bytesData.toString("utf8"));
+				let filePath = path$1.join(this.dir, `${encodedName}.json`);
+				log("WRITE %s", filePath), fs$1.writeFileSync(filePath, bytesData.toString("utf8"));
 			} catch (error) {
 				throw new error_1.PersistError(`Failed to persist metadata ${encodedName} error: ${error}`);
 			}
@@ -8007,7 +8591,12 @@ function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runComm
 		showExpected
 	}) + "\n\n")), markdown;
 }
-function writeReport(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand } = {}) {
+/**
+* Pure decision + rendering step, kept free of process.env/file I/O so it's
+* testable without touching the filesystem — see main.ts's writeReportSummary
+* for the side-effecting half (actual summary/annotation output).
+*/
+function computeReportOutcome(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand } = {}) {
 	let isAudit = report.parameters.mode === "audit", outcome = determineBlockedOutcome({
 		isAudit,
 		failOnBlocked: failOnBlocked ?? !1,
@@ -8019,17 +8608,18 @@ function writeReport(report, { stepLabel, failOnBlocked, actionRepo, actionRef, 
 		blockedRows: report.blocked,
 		engineLabel: "sandbox",
 		isAudit
-	}), markdown = buildReportMarkdown(report, {
-		stepLabel,
-		actionRepo,
-		actionRef,
-		runCommand
-	}), summaryFile = process.env.GITHUB_STEP_SUMMARY;
-	summaryFile ? (0, node_fs.appendFileSync)(summaryFile, markdown) : console.log(markdown);
-	let debugSummaryFile = process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
-	debugSummaryFile && (0, node_fs.appendFileSync)(debugSummaryFile, markdown);
-	let annotation = createAnnotation(!!summaryFile);
-	outcome.level === "error" ? (annotation.error(message), process.exitCode = 1) : outcome.level === "notice" && annotation.notice(message);
+	});
+	return {
+		markdown: buildReportMarkdown(report, {
+			stepLabel,
+			actionRepo,
+			actionRef,
+			runCommand
+		}),
+		message,
+		level: outcome.level,
+		shouldFail: outcome.shouldFail
+	};
 }
 //#endregion
 //#region run/src/main.ts
@@ -8086,8 +8676,18 @@ async function withGroup(label, fn) {
 		console.log("::endgroup::");
 	}
 }
+/**
+* Side-effecting half of the report step: computeReportOutcome() decides
+* what to say, this writes it to the Job Summary/annotations/exit code.
+*/
+async function writeReportSummary(report, annotation, options) {
+	let outcome = computeReportOutcome(report, options);
+	process.env.GITHUB_STEP_SUMMARY ? await summary.addRaw(outcome.markdown).write() : console.log(outcome.markdown);
+	let debugSummaryFile = process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
+	debugSummaryFile && (0, node_fs.appendFileSync)(debugSummaryFile, outcome.markdown), outcome.level === "error" ? (annotation.error(outcome.message), process.exitCode = 1) : outcome.level === "notice" && annotation.notice(outcome.message);
+}
 async function main() {
-	let env = process.env, actionRef = env.GITHUB_ACTION_REF || "v2", actionRepo = env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", runInput = env.INPUT_RUN ?? "";
+	let env = process.env, actionRef = env.GITHUB_ACTION_REF || "v2", actionRepo = env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage", runInput = getInput("run", { trimWhitespace: !1 });
 	if (!runInput.trim()) throw new SandboxError("Input 'run' is required.", "MISSING_RUN");
 	checkPasswordlessSudo();
 	let annotation = createAnnotation(!!env.GITHUB_STEP_SUMMARY), { imageRef, pullPolicy } = await resolveVerifiedImage({
@@ -8096,17 +8696,17 @@ async function main() {
 	});
 	console.log(`buildcage: proxy image: ${imageRef}`);
 	let rules = buildACLRules({
-		httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-		ipRulesInput: env.INPUT_ALLOWED_IP_RULES
-	}), knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+		httpsRulesInput: getInput("allowed_https_rules"),
+		httpRulesInput: getInput("allowed_http_rules"),
+		ipRulesInput: getInput("allowed_ip_rules")
+	}), knownBlockedRules = readKnownBlockedRules(getInput("known_blocked_rules"));
 	console.log("::group::buildcage: Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules), console.log("::endgroup::");
-	let writablePaths = parseWritablePaths(env.INPUT_WRITABLE), containerName = generateContainerName(), projectName = deriveProjectName(containerName), stateFile = env.GITHUB_STATE;
-	stateFile && ((0, node_fs.appendFileSync)(stateFile, `container_name=${containerName}\n`), (0, node_fs.appendFileSync)(stateFile, `project_name=${projectName}\n`));
+	let writablePaths = parseWritablePaths(getInput("writable")), containerName = generateContainerName(), projectName = deriveProjectName(containerName);
+	env.GITHUB_STATE && (saveState("container_name", containerName), saveState("project_name", projectName));
 	let composeEnv = {
 		...env,
 		PROXY_CONTAINER_NAME: containerName,
-		PROXY_MODE: env.INPUT_PROXY_MODE || "restrict",
+		PROXY_MODE: getInput("proxy_mode") || "restrict",
 		ALLOWED_HTTPS_RULES: rules.httpsRules.join("\n"),
 		ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),
 		ALLOWED_IP_RULES: rules.ipRules.join("\n"),
@@ -8176,18 +8776,24 @@ async function main() {
 		}, containerName);
 	} finally {
 		try {
-			writeReport(await fetchReport(containerName, {
-				mode: env.INPUT_PROXY_MODE || "restrict",
+			let report = await fetchReport(containerName, {
+				mode: getInput("proxy_mode") || "restrict",
 				allowedHttpsRules: rules.httpsRules,
 				allowedHttpRules: rules.httpRules,
 				allowedIpRules: rules.ipRules,
 				knownBlockedRules
-			}), {
+			}), failOnBlocked;
+			try {
+				failOnBlocked = getBooleanInput("fail_on_blocked");
+			} catch {
+				failOnBlocked = !0;
+			}
+			await writeReportSummary(report, annotation, {
 				actionRepo,
 				actionRef,
 				runCommand: runInput,
-				stepLabel: env.INPUT_LABEL || void 0,
-				failOnBlocked: (env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true"
+				stepLabel: getInput("label") || void 0,
+				failOnBlocked
 			});
 		} catch (e) {
 			annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);

--- a/run/dist/post.cjs
+++ b/run/dist/post.cjs
@@ -1,4 +1,475 @@
-let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_path = require("node:path"), node_url = require("node:url");
+//#region \0rolldown/runtime.js
+var __create = Object.create, __defProp = Object.defineProperty, __getOwnPropDesc = Object.getOwnPropertyDescriptor, __getOwnPropNames = Object.getOwnPropertyNames, __getProtoOf = Object.getPrototypeOf, __hasOwnProp = Object.prototype.hasOwnProperty, __copyProps = (to, from, except, desc) => {
+	if (from && typeof from == "object" || typeof from == "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) key = keys[i], !__hasOwnProp.call(to, key) && key !== except && __defProp(to, key, {
+		get: ((k) => from[k]).bind(null, key),
+		enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+	});
+	return to;
+}, __toESM = (mod, isNodeMode, target) => (target = mod == null ? {} : __create(__getProtoOf(mod)), __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: !0
+}) : target, mod));
+//#endregion
+let node_child_process = require("node:child_process"), node_fs = require("node:fs"), node_path = require("node:path"), node_url = require("node:url"), os = require("os");
+os = __toESM(os, 1);
+let fs = require("fs");
+fs = __toESM(fs, 1);
+let path = require("path");
+path = __toESM(path, 1);
+let events = require("events");
+events = __toESM(events, 1);
+let child_process = require("child_process");
+child_process = __toESM(child_process, 1), require("timers");
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/summary.js
+var __awaiter$6 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { access, appendFile, writeFile } = fs.promises, SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
+new class {
+	constructor() {
+		this._buffer = "";
+	}
+	/**
+	* Finds the summary file path from the environment, rejects if env var is not found or file does not exist
+	* Also checks r/w permissions.
+	*
+	* @returns step summary file path
+	*/
+	filePath() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			if (this._filePath) return this._filePath;
+			let pathFromEnv = process.env[SUMMARY_ENV_VAR];
+			if (!pathFromEnv) throw Error(`Unable to find environment variable for $${SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
+			try {
+				yield access(pathFromEnv, fs.constants.R_OK | fs.constants.W_OK);
+			} catch {
+				throw Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
+			}
+			return this._filePath = pathFromEnv, this._filePath;
+		});
+	}
+	/**
+	* Wraps content in an HTML tag, adding any HTML attributes
+	*
+	* @param {string} tag HTML tag to wrap
+	* @param {string | null} content content within the tag
+	* @param {[attribute: string]: string} attrs key-value list of HTML attributes to add
+	*
+	* @returns {string} content wrapped in HTML element
+	*/
+	wrap(tag, content, attrs = {}) {
+		let htmlAttrs = Object.entries(attrs).map(([key, value]) => ` ${key}="${value}"`).join("");
+		return content ? `<${tag}${htmlAttrs}>${content}</${tag}>` : `<${tag}${htmlAttrs}>`;
+	}
+	/**
+	* Writes text in the buffer to the summary buffer file and empties buffer. Will append by default.
+	*
+	* @param {SummaryWriteOptions} [options] (optional) options for write operation
+	*
+	* @returns {Promise<Summary>} summary instance
+	*/
+	write(options) {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			let overwrite = !!options?.overwrite, filePath = yield this.filePath();
+			return yield (overwrite ? writeFile : appendFile)(filePath, this._buffer, { encoding: "utf8" }), this.emptyBuffer();
+		});
+	}
+	/**
+	* Clears the summary buffer and wipes the summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	clear() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			return this.emptyBuffer().write({ overwrite: !0 });
+		});
+	}
+	/**
+	* Returns the current summary buffer as a string
+	*
+	* @returns {string} string of summary buffer
+	*/
+	stringify() {
+		return this._buffer;
+	}
+	/**
+	* If the summary buffer is empty
+	*
+	* @returns {boolen} true if the buffer is empty
+	*/
+	isEmptyBuffer() {
+		return this._buffer.length === 0;
+	}
+	/**
+	* Resets the summary buffer without writing to summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	emptyBuffer() {
+		return this._buffer = "", this;
+	}
+	/**
+	* Adds raw text to the summary buffer
+	*
+	* @param {string} text content to add
+	* @param {boolean} [addEOL=false] (optional) append an EOL to the raw text (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addRaw(text, addEOL = !1) {
+		return this._buffer += text, addEOL ? this.addEOL() : this;
+	}
+	/**
+	* Adds the operating system-specific end-of-line marker to the buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addEOL() {
+		return this.addRaw(os.EOL);
+	}
+	/**
+	* Adds an HTML codeblock to the summary buffer
+	*
+	* @param {string} code content to render within fenced code block
+	* @param {string} lang (optional) language to syntax highlight code
+	*
+	* @returns {Summary} summary instance
+	*/
+	addCodeBlock(code, lang) {
+		let attrs = Object.assign({}, lang && { lang }), element = this.wrap("pre", this.wrap("code", code), attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML list to the summary buffer
+	*
+	* @param {string[]} items list of items to render
+	* @param {boolean} [ordered=false] (optional) if the rendered list should be ordered or not (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addList(items, ordered = !1) {
+		let tag = ordered ? "ol" : "ul", listItems = items.map((item) => this.wrap("li", item)).join(""), element = this.wrap(tag, listItems);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML table to the summary buffer
+	*
+	* @param {SummaryTableCell[]} rows table rows
+	*
+	* @returns {Summary} summary instance
+	*/
+	addTable(rows) {
+		let tableBody = rows.map((row) => {
+			let cells = row.map((cell) => {
+				if (typeof cell == "string") return this.wrap("td", cell);
+				let { header, data, colspan, rowspan } = cell, tag = header ? "th" : "td", attrs = Object.assign(Object.assign({}, colspan && { colspan }), rowspan && { rowspan });
+				return this.wrap(tag, data, attrs);
+			}).join("");
+			return this.wrap("tr", cells);
+		}).join(""), element = this.wrap("table", tableBody);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds a collapsable HTML details element to the summary buffer
+	*
+	* @param {string} label text for the closed state
+	* @param {string} content collapsable content
+	*
+	* @returns {Summary} summary instance
+	*/
+	addDetails(label, content) {
+		let element = this.wrap("details", this.wrap("summary", label) + content);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML image tag to the summary buffer
+	*
+	* @param {string} src path to the image you to embed
+	* @param {string} alt text description of the image
+	* @param {SummaryImageOptions} options (optional) addition image attributes
+	*
+	* @returns {Summary} summary instance
+	*/
+	addImage(src, alt, options) {
+		let { width, height } = options || {}, attrs = Object.assign(Object.assign({}, width && { width }), height && { height }), element = this.wrap("img", null, Object.assign({
+			src,
+			alt
+		}, attrs));
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML section heading element
+	*
+	* @param {string} text heading text
+	* @param {number | string} [level=1] (optional) the heading level, default: 1
+	*
+	* @returns {Summary} summary instance
+	*/
+	addHeading(text, level) {
+		let tag = `h${level}`, allowedTag = [
+			"h1",
+			"h2",
+			"h3",
+			"h4",
+			"h5",
+			"h6"
+		].includes(tag) ? tag : "h1", element = this.wrap(allowedTag, text);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML thematic break (<hr>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addSeparator() {
+		let element = this.wrap("hr", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML line break (<br>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addBreak() {
+		let element = this.wrap("br", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML blockquote to the summary buffer
+	*
+	* @param {string} text quote text
+	* @param {string} cite (optional) citation url
+	*
+	* @returns {Summary} summary instance
+	*/
+	addQuote(text, cite) {
+		let attrs = Object.assign({}, cite && { cite }), element = this.wrap("blockquote", text, attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML anchor tag to the summary buffer
+	*
+	* @param {string} text link text/content
+	* @param {string} href hyperlink
+	*
+	* @returns {Summary} summary instance
+	*/
+	addLink(text, href) {
+		let element = this.wrap("a", text, { href });
+		return this.addRaw(element).addEOL();
+	}
+}();
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io-util.js
+var __awaiter$5 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises, IS_WINDOWS$1 = process.platform === "win32";
+fs.constants.O_RDONLY;
+/**
+* On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+* \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+*/
+function isRooted(p) {
+	if (p = normalizeSeparators(p), !p) throw Error("isRooted() parameter \"p\" cannot be empty");
+	return IS_WINDOWS$1 ? p.startsWith("\\") || /^[A-Z]:/i.test(p) : p.startsWith("/");
+}
+/**
+* Best effort attempt to determine whether a file exists and is executable.
+* @param filePath    file path to check
+* @param extensions  additional file extensions to try
+* @return if file exists and is executable, returns the file path. otherwise empty string.
+*/
+function tryGetExecutablePath(filePath, extensions) {
+	return __awaiter$5(this, void 0, void 0, function* () {
+		let stats;
+		try {
+			stats = yield stat(filePath);
+		} catch (err) {
+			err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+		}
+		if (stats && stats.isFile()) {
+			if (IS_WINDOWS$1) {
+				let upperExt = path.extname(filePath).toUpperCase();
+				if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) return filePath;
+			} else if (isUnixExecutable(stats)) return filePath;
+		}
+		let originalFilePath = filePath;
+		for (let extension of extensions) {
+			filePath = originalFilePath + extension, stats = void 0;
+			try {
+				stats = yield stat(filePath);
+			} catch (err) {
+				err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+			}
+			if (stats && stats.isFile()) {
+				if (IS_WINDOWS$1) {
+					try {
+						let directory = path.dirname(filePath), upperName = path.basename(filePath).toUpperCase();
+						for (let actualName of yield readdir(directory)) if (upperName === actualName.toUpperCase()) {
+							filePath = path.join(directory, actualName);
+							break;
+						}
+					} catch (err) {
+						console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+					}
+					return filePath;
+				} else if (isUnixExecutable(stats)) return filePath;
+			}
+		}
+		return "";
+	});
+}
+function normalizeSeparators(p) {
+	return p ||= "", IS_WINDOWS$1 ? (p = p.replace(/\//g, "\\"), p.replace(/\\\\+/g, "\\")) : p.replace(/\/\/+/g, "/");
+}
+function isUnixExecutable(stats) {
+	return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io.js
+var __awaiter$4 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+/**
+* Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+* If you check and the tool does not exist, it will throw.
+*
+* @param     tool              name of the tool
+* @param     check             whether to check if tool exists
+* @returns   Promise<string>   path to tool
+*/
+function which(tool, check) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		if (check) {
+			let result = yield which(tool, !1);
+			if (!result) throw Error(IS_WINDOWS$1 ? `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.` : `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+			return result;
+		}
+		let matches = yield findInPath(tool);
+		return matches && matches.length > 0 ? matches[0] : "";
+	});
+}
+/**
+* Returns a list of all occurrences of the given tool on the system path.
+*
+* @returns   Promise<string[]>  the paths of the tool
+*/
+function findInPath(tool) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		let extensions = [];
+		if (IS_WINDOWS$1 && process.env.PATHEXT) for (let extension of process.env.PATHEXT.split(path.delimiter)) extension && extensions.push(extension);
+		if (isRooted(tool)) {
+			let filePath = yield tryGetExecutablePath(tool, extensions);
+			return filePath ? [filePath] : [];
+		}
+		if (tool.includes(path.sep)) return [];
+		let directories = [];
+		if (process.env.PATH) for (let p of process.env.PATH.split(path.delimiter)) p && directories.push(p);
+		let matches = [];
+		for (let directory of directories) {
+			let filePath = yield tryGetExecutablePath(path.join(directory, tool), extensions);
+			filePath && matches.push(filePath);
+		}
+		return matches;
+	});
+}
+process.platform, events.EventEmitter, events.EventEmitter, os.default.platform(), os.default.arch();
+/**
+* The code to exit an action
+*/
+var ExitCode;
+(function(ExitCode) {
+	/**
+	* A code indicating that the action was a failure
+	*/
+	ExitCode[ExitCode.Success = 0] = "Success", ExitCode[ExitCode.Failure = 1] = "Failure";
+})(ExitCode ||= {});
+/**
+* Gets the value of an state set by this action's main execution.
+*
+* @param     name     name of the state to get
+* @returns   string
+*/
+function getState(name) {
+	return process.env[`STATE_${name}`] || "";
+}
+//#endregion
 //#region run/src/lib/compose-args.ts
 /** Build the `docker compose ... down` argv — see buildComposeUpArgs above. */
 function buildComposeDownArgs({ composeFile, projectName }) {
@@ -125,8 +596,8 @@ function scratchDirFor(containerName) {
 }
 //#endregion
 //#region run/src/post.ts
-const __dirname$1 = (0, node_path.dirname)((0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href)), containerName = process.env.STATE_container_name, projectName = process.env.STATE_project_name;
-if (containerName?.startsWith("buildcage-proxy-")) try {
+const __dirname$1 = (0, node_path.dirname)((0, node_url.fileURLToPath)(require("url").pathToFileURL(__filename).href)), containerName = getState("container_name"), projectName = getState("project_name");
+if (containerName.startsWith("buildcage-proxy-")) try {
 	let scratchDir = scratchDirFor(containerName);
 	(0, node_fs.existsSync)(scratchDir) && cleanupScratchDir(scratchDir);
 } catch (e) {

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -1,42 +1,9 @@
-/**
- * Unit tests for run/lib/report.ts — specifically writeReport's exit-code
- * semantics. `process.exitCode = 1` here is only ever additive on top of
- * the isolated command's own exit code (see main.ts), never resetting it
- * back to success.
- */
-import { describe, it, beforeEach, afterEach, vi } from "vitest";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { writeFileSync } from "node:fs";
-import { join } from "node:path";
 
-import {
-  writeReport,
-  buildReportMarkdown,
-  type Report,
-  type WriteReportOptions,
-} from "./report.ts";
+import { computeReportOutcome, buildReportMarkdown, type Report } from "./report.ts";
 import { annotateKnownBlocked } from "../../../core/lib/report/known-blocked.ts";
-import { withScratchDir } from "./isolated-exec.ts";
 import type { GenReportParameters } from "../../../core/lib/report/report-data.ts";
-
-// writeReport reads GITHUB_STEP_SUMMARY/BUILDCAGE_RUN_DEBUG_SUMMARY_FILE
-// from process.env and mutates process.exitCode directly (mirroring what
-// main.ts itself does) -- both are saved/restored per test so a test here
-// can never leak into another test in this file, another test file, or
-// (critically) into `node --test`'s own final exit status.
-let prevEnv: NodeJS.ProcessEnv;
-let prevExitCode: number | string | null | undefined;
-
-beforeEach(() => {
-  prevEnv = { ...process.env };
-  prevExitCode = process.exitCode;
-  process.exitCode = undefined;
-});
-
-afterEach(() => {
-  process.env = prevEnv;
-  process.exitCode = prevExitCode;
-});
 
 function parameters(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {
@@ -50,7 +17,7 @@ function parameters(overrides: Partial<GenReportParameters> = {}): GenReportPara
 }
 
 // blocked rows are already expected to be annotated by the time a Report
-// reaches writeReport/buildReportMarkdown (see build-transparent-report-data.ts)
+// reaches computeReportOutcome/buildReportMarkdown (see build-transparent-report-data.ts)
 // — this mirrors that, applying parameters.knownBlockedRules the same way.
 function report(overrides: Partial<Report> = {}): Report {
   const params = overrides.parameters ?? parameters();
@@ -65,24 +32,13 @@ function report(overrides: Partial<Report> = {}): Report {
   };
 }
 
-function writeReportWithSummary(r: Report, opts: WriteReportOptions) {
-  return withScratchDir((dir) => {
-    const summaryPath = join(dir, "summary.md");
-    writeFileSync(summaryPath, "");
-    process.env.GITHUB_STEP_SUMMARY = summaryPath;
-    delete process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
-    writeReport(r, opts);
-    return process.exitCode;
-  });
-}
-
-describe("writeReport", () => {
-  it("leaves exitCode untouched when there are no blocked connections", () => {
+describe("computeReportOutcome", () => {
+  it("does not fail when there are no blocked connections", () => {
     const r = report({ blockedCount: 0 });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: true }), undefined);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, false);
   });
 
-  it("sets exitCode=1 when blocked connections are detected and failOnBlocked is true", () => {
+  it("fails when blocked connections are detected and failOnBlocked is true", () => {
     const r = report({
       blockedCount: 2,
       blocked: annotateKnownBlocked(
@@ -98,10 +54,10 @@ describe("writeReport", () => {
         [],
       ),
     });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: true }), 1);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, true);
   });
 
-  it("leaves exitCode untouched when failOnBlocked is false, even with blocked connections", () => {
+  it("does not fail when failOnBlocked is false, even with blocked connections", () => {
     const r = report({
       blockedCount: 2,
       blocked: annotateKnownBlocked(
@@ -117,10 +73,10 @@ describe("writeReport", () => {
         [],
       ),
     });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: false }), undefined);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: false }).shouldFail, false);
   });
 
-  it("leaves exitCode untouched in audit mode even when failOnBlocked is true", () => {
+  it("does not fail in audit mode even when failOnBlocked is true", () => {
     const r = report({
       parameters: parameters({ mode: "audit" }),
       blockedCount: 2,
@@ -137,10 +93,10 @@ describe("writeReport", () => {
         [],
       ),
     });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: true }), undefined);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, false);
   });
 
-  it("leaves exitCode untouched when every blocked connection matches known_blocked_rules", () => {
+  it("does not fail when every blocked connection matches known_blocked_rules", () => {
     const knownBlockedRules = ["known-bad.example.com:443"];
     const r = report({
       parameters: parameters({ knownBlockedRules }),
@@ -158,10 +114,10 @@ describe("writeReport", () => {
         knownBlockedRules,
       ),
     });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: true }), undefined);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, false);
   });
 
-  it("sets exitCode=1 when some blocked rows don't match known_blocked_rules", () => {
+  it("fails when some blocked rows don't match known_blocked_rules", () => {
     const knownBlockedRules = ["known-bad.example.com:443"];
     const r = report({
       parameters: parameters({ knownBlockedRules }),
@@ -186,10 +142,10 @@ describe("writeReport", () => {
         knownBlockedRules,
       ),
     });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: true }), 1);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, true);
   });
 
-  it("leaves exitCode untouched in audit mode even with known_blocked_rules set", () => {
+  it("does not fail in audit mode even with known_blocked_rules set", () => {
     const knownBlockedRules = ["known-bad.example.com:443"];
     const r = report({
       parameters: parameters({ mode: "audit", knownBlockedRules }),
@@ -199,13 +155,12 @@ describe("writeReport", () => {
         knownBlockedRules,
       ),
     });
-    assert.equal(writeReportWithSummary(r, { failOnBlocked: true }), undefined);
+    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, false);
   });
 
   // Audit's outcome never depends on known_blocked_rules matching, so the
   // notice text shouldn't either.
   it("audit-mode notice text stays fixed even when known_blocked_rules matches every blocked connection", () => {
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const knownBlockedRules = ["known-bad.example.com:443"];
     const r = report({
       parameters: parameters({ mode: "audit", knownBlockedRules }),
@@ -215,12 +170,9 @@ describe("writeReport", () => {
         knownBlockedRules,
       ),
     });
-    writeReportWithSummary(r, { failOnBlocked: true });
-    assert.equal(log.mock.calls.length, 1);
-    assert.equal(
-      log.mock.calls[0][0],
-      "::notice::2 blocked connection(s) detected by buildcage sandbox",
-    );
+    const outcome = computeReportOutcome(r, { failOnBlocked: true });
+    assert.equal(outcome.level, "notice");
+    assert.equal(outcome.message, "2 blocked connection(s) detected by buildcage sandbox");
   });
 });
 

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -1,6 +1,4 @@
-import { appendFileSync } from "node:fs";
 import { createDocker } from "../../../core/lib/docker/client.ts";
-import { createAnnotation } from "../../../core/lib/actions/annotation.ts";
 import { buildRestrictExample } from "../../../core/lib/report/build-example.ts";
 import {
   determineBlockedOutcome,
@@ -76,14 +74,26 @@ export function buildReportMarkdown(
   return markdown;
 }
 
-export interface WriteReportOptions extends ReportRenderContext {
+export interface ComputeReportOutcomeOptions extends ReportRenderContext {
   failOnBlocked?: boolean;
 }
 
-export function writeReport(
+export interface ReportOutcome {
+  markdown: string;
+  message: string;
+  level: "none" | "notice" | "error";
+  shouldFail: boolean;
+}
+
+/**
+ * Pure decision + rendering step, kept free of process.env/file I/O so it's
+ * testable without touching the filesystem — see main.ts's writeReportSummary
+ * for the side-effecting half (actual summary/annotation output).
+ */
+export function computeReportOutcome(
   report: Report,
-  { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand }: WriteReportOptions = {},
-): void {
+  { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand }: ComputeReportOutcomeOptions = {},
+): ReportOutcome {
   const isAudit = report.parameters.mode === "audit";
   const outcome = determineBlockedOutcome({
     isAudit,
@@ -98,27 +108,7 @@ export function writeReport(
     engineLabel: "sandbox",
     isAudit,
   });
-
   const markdown = buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand });
-  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
-  if (summaryFile) {
-    appendFileSync(summaryFile, markdown);
-  } else {
-    console.log(markdown);
-  }
 
-  // Debug-only mirror: GITHUB_STEP_SUMMARY is unique per step and can't be
-  // reassigned, so a later step has no way to read this step's copy back.
-  const debugSummaryFile = process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
-  if (debugSummaryFile) {
-    appendFileSync(debugSummaryFile, markdown);
-  }
-
-  const annotation = createAnnotation(Boolean(summaryFile));
-  if (outcome.level === "error") {
-    annotation.error(message);
-    process.exitCode = 1;
-  } else if (outcome.level === "notice") {
-    annotation.notice(message);
-  }
+  return { markdown, message, level: outcome.level, shouldFail: outcome.shouldFail };
 }

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -1,5 +1,4 @@
 import { execFileSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
@@ -160,12 +159,11 @@ async function main(): Promise<void> {
   // rather than sharing one across steps in the same job.
   const containerName = generateContainerName();
   const projectName = deriveProjectName(containerName);
-  const stateFile = env.GITHUB_STATE;
   // Recorded so post.ts can still clean up if this run is killed outright
   // before reaching its own finally block below.
-  if (stateFile) {
-    appendFileSync(stateFile, `container_name=${containerName}\n`);
-    appendFileSync(stateFile, `project_name=${projectName}\n`);
+  if (env.GITHUB_STATE) {
+    core.saveState("container_name", containerName);
+    core.saveState("project_name", projectName);
   }
 
   const composeEnv = {

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
@@ -10,7 +11,7 @@ import {
   type ResolvedImage,
 } from "../../core/lib/provenance/verify-image.ts";
 import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
-import { createAnnotation } from "../../core/lib/actions/annotation.ts";
+import { createAnnotation, type Annotation } from "../../core/lib/actions/annotation.ts";
 import { ActionError } from "../../core/lib/general/action-error.ts";
 import { errorMessage } from "../../core/lib/general/error-message.ts";
 import { buildACLRules, parseRulesOrThrow } from "../../core/lib/acl/rules.ts";
@@ -29,7 +30,12 @@ import {
   withScratchDir,
   listHostMounts,
 } from "./lib/isolated-exec.ts";
-import { fetchReport, writeReport } from "./lib/report.ts";
+import {
+  fetchReport,
+  computeReportOutcome,
+  type Report,
+  type ComputeReportOutcomeOptions,
+} from "./lib/report.ts";
 
 export { buildComposeUpArgs, buildComposeDownArgs, buildACLRules };
 
@@ -102,6 +108,39 @@ async function withGroup<T>(label: string, fn: () => T | Promise<T>): Promise<T>
   }
 }
 
+/**
+ * Side-effecting half of the report step: computeReportOutcome() decides
+ * what to say, this writes it to the Job Summary/annotations/exit code.
+ */
+async function writeReportSummary(
+  report: Report,
+  annotation: Annotation,
+  options: ComputeReportOutcomeOptions,
+): Promise<void> {
+  const outcome = computeReportOutcome(report, options);
+
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) {
+    await core.summary.addRaw(outcome.markdown).write();
+  } else {
+    console.log(outcome.markdown);
+  }
+
+  // Debug-only mirror: GITHUB_STEP_SUMMARY is unique per step and can't be
+  // reassigned, so a later step has no way to read this step's copy back.
+  const debugSummaryFile = process.env.BUILDCAGE_RUN_DEBUG_SUMMARY_FILE;
+  if (debugSummaryFile) {
+    appendFileSync(debugSummaryFile, outcome.markdown);
+  }
+
+  if (outcome.level === "error") {
+    annotation.error(outcome.message);
+    process.exitCode = 1;
+  } else if (outcome.level === "notice") {
+    annotation.notice(outcome.message);
+  }
+}
+
 async function main(): Promise<void> {
   const env = process.env;
   // Empty (not `??`-catchable) for local-path `uses: ./run` invocations —
@@ -118,8 +157,8 @@ async function main(): Promise<void> {
   // if the runner can't support the isolation setup at all.
   checkPasswordlessSudo();
 
-  // Same gate as writeReport() in lib/report.ts — suppresses annotations
-  // when this script isn't running as the real action.
+  // Same gate as writeReportSummary() below — suppresses annotations when
+  // this script isn't running as the real action.
   const annotation = createAnnotation(Boolean(env.GITHUB_STEP_SUMMARY));
 
   const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
@@ -297,7 +336,7 @@ async function main(): Promise<void> {
       } catch {
         failOnBlocked = true;
       }
-      writeReport(report, {
+      await writeReportSummary(report, annotation, {
         actionRepo,
         actionRef,
         runCommand: runInput,

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as core from "@actions/core";
 
 import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
 import {
@@ -109,7 +110,7 @@ async function main(): Promise<void> {
   const actionRef = env.GITHUB_ACTION_REF || "v2";
   const actionRepo = env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage";
 
-  const runInput = env.INPUT_RUN ?? "";
+  const runInput = core.getInput("run", { trimWhitespace: false });
   if (!runInput.trim()) {
     throw new SandboxError("Input 'run' is required.", "MISSING_RUN");
   }
@@ -139,11 +140,11 @@ async function main(): Promise<void> {
   console.log(`buildcage: proxy image: ${imageRef}`);
 
   const rules = buildACLRules({
-    httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-    httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-    ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
+    httpsRulesInput: core.getInput("allowed_https_rules"),
+    httpRulesInput: core.getInput("allowed_http_rules"),
+    ipRulesInput: core.getInput("allowed_ip_rules"),
   });
-  const knownBlockedRules = readKnownBlockedRules(env.INPUT_KNOWN_BLOCKED_RULES);
+  const knownBlockedRules = readKnownBlockedRules(core.getInput("known_blocked_rules"));
 
   console.log("::group::buildcage: Configured ACL Rules");
   logRules("HTTPS", rules.httpsRules);
@@ -152,7 +153,7 @@ async function main(): Promise<void> {
   logRules("Known-blocked (informational only, not sent to proxy ACL)", knownBlockedRules);
   console.log("::endgroup::");
 
-  const writablePaths = parseWritablePaths(env.INPUT_WRITABLE);
+  const writablePaths = parseWritablePaths(core.getInput("writable"));
 
   // Each `run` step gets its own throwaway proxy container — start, run
   // the isolated command, report, and stop, all within this one step —
@@ -170,7 +171,7 @@ async function main(): Promise<void> {
   const composeEnv = {
     ...env,
     PROXY_CONTAINER_NAME: containerName,
-    PROXY_MODE: env.INPUT_PROXY_MODE || "restrict",
+    PROXY_MODE: core.getInput("proxy_mode") || "restrict",
     ALLOWED_HTTPS_RULES: rules.httpsRules.join("\n"),
     ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),
     ALLOWED_IP_RULES: rules.ipRules.join("\n"),
@@ -283,18 +284,27 @@ async function main(): Promise<void> {
   } finally {
     try {
       const report = await fetchReport(containerName, {
-        mode: env.INPUT_PROXY_MODE || "restrict",
+        mode: core.getInput("proxy_mode") || "restrict",
         allowedHttpsRules: rules.httpsRules,
         allowedHttpRules: rules.httpRules,
         allowedIpRules: rules.ipRules,
         knownBlockedRules,
       });
+      // Several integration scripts invoke this action directly without
+      // setting fail_on_blocked, unlike a real workflow where action.yml's
+      // own default always supplies it — fall back to that same default.
+      let failOnBlocked: boolean;
+      try {
+        failOnBlocked = core.getBooleanInput("fail_on_blocked");
+      } catch {
+        failOnBlocked = true;
+      }
       writeReport(report, {
         actionRepo,
         actionRef,
         runCommand: runInput,
-        stepLabel: env.INPUT_LABEL || undefined,
-        failOnBlocked: (env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true",
+        stepLabel: core.getInput("label") || undefined,
+        failOnBlocked,
       });
     } catch (e) {
       annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);

--- a/run/src/post.ts
+++ b/run/src/post.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as core from "@actions/core";
 
 import { buildComposeDownArgs } from "./lib/compose-args.ts";
 import { cleanupScratchDir, scratchDirFor } from "./lib/isolated-exec.ts";
@@ -12,12 +13,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Fallback-only cleanup: main.ts already stops the proxy container in its
 // own finally block on every normal exit path. This only matters if the
 // process was killed outright before reaching that finally (e.g. the
-// runner cancels the step). GITHUB_STATE's container_name=.../project_name=...
-// (written by main.ts) surface here as STATE_container_name/STATE_project_name
-// — see
+// runner cancels the step). State saved by main.ts's core.saveState surfaces
+// here via core.getState — see
 // https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#saving-state.
-const containerName = process.env.STATE_container_name;
-const projectName = process.env.STATE_project_name;
+const containerName = core.getState("container_name");
+const projectName = core.getState("project_name");
 
 // Reclaim this step's sandbox scratch dir if a hard kill bypassed main.ts's
 // own withScratchDir finally. Its path is derived deterministically from
@@ -25,7 +25,7 @@ const projectName = process.env.STATE_project_name;
 // cleanupScratchDir force-detaches the rootfs bind-mount before deleting, so
 // this can't walk into the host filesystem even if a mount somehow survived.
 // Independent of the container teardown below, so it runs regardless.
-if (containerName?.startsWith("buildcage-proxy-")) {
+if (containerName.startsWith("buildcage-proxy-")) {
   try {
     const scratchDir = scratchDirFor(containerName);
     if (existsSync(scratchDir)) cleanupScratchDir(scratchDir);

--- a/run/test/integration-test-concurrent.sh
+++ b/run/test/integration-test-concurrent.sh
@@ -36,7 +36,7 @@ fi" \
 }
 
 : "${BUILDCAGE_LOCAL_IMAGE_REF:?BUILDCAGE_LOCAL_IMAGE_REF must be set to the locally built proxy image}"
-touch "$TMP_A/state.env" "$TMP_B/state.env"
+touch "$TMP_A/state.env" "$TMP_A/summary.md" "$TMP_B/state.env" "$TMP_B/summary.md"
 
 run_instance "$TMP_A" "example.com:443" "https://example.com/" "https://example.net/" &
 PID_A=$!

--- a/run/test/integration-test-defaults.sh
+++ b/run/test/integration-test-defaults.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/run/test/integration-test-die-with-parent.sh
+++ b/run/test/integration-test-die-with-parent.sh
@@ -10,7 +10,7 @@ set -uo pipefail
 : "${BUILDCAGE_LOCAL_IMAGE_REF:?BUILDCAGE_LOCAL_IMAGE_REF must be set to the locally built proxy image}"
 
 WORKDIR=$(mktemp -d)
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 FAILURES=0
 
 cleanup() {

--- a/run/test/integration-test-fs-escape.sh
+++ b/run/test/integration-test-fs-escape.sh
@@ -12,7 +12,7 @@ set -uo pipefail
 WORKDIR=$(mktemp -d)
 WORKDIR2=$(mktemp -d)
 trap 'rm -rf "$WORKDIR" "$WORKDIR2"' EXIT
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \
@@ -68,7 +68,7 @@ echo ""
 # it) would recursively re-expose the sandbox's own rootfs read-write --
 # assertScratchBaseNotWritable in isolated-exec.ts must fail the step closed
 # rather than silently running with that hole open.
-touch "$WORKDIR2/state.env"
+touch "$WORKDIR2/state.env" "$WORKDIR2/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR2" \
 GITHUB_STATE="$WORKDIR2/state.env" \

--- a/run/test/integration-test-known-blocked-rules.sh
+++ b/run/test/integration-test-known-blocked-rules.sh
@@ -35,7 +35,7 @@ echo ""
 # Case 1: the only blocked connection matches known_blocked_rules -> the
 # step must succeed despite fail_on_blocked defaulting to true.
 TMP_MATCH=$(mktemp -d)
-touch "$TMP_MATCH/state.env"
+touch "$TMP_MATCH/state.env" "$TMP_MATCH/summary.md"
 run_instance "$TMP_MATCH" "neverssl.com:80"
 CODE_MATCH=$(cat "$TMP_MATCH/exit_code")
 if [ "$CODE_MATCH" = "0" ]; then
@@ -51,7 +51,7 @@ rm -rf "$TMP_MATCH"
 # connection -> the step must still fail as normal (known_blocked_rules
 # isn't a backdoor allowlist).
 TMP_MISMATCH=$(mktemp -d)
-touch "$TMP_MISMATCH/state.env"
+touch "$TMP_MISMATCH/state.env" "$TMP_MISMATCH/summary.md"
 run_instance "$TMP_MISMATCH" "some-other-domain.example.com:443"
 CODE_MISMATCH=$(cat "$TMP_MISMATCH/exit_code")
 if [ "$CODE_MISMATCH" != "0" ]; then

--- a/run/test/integration-test-nested-mount-readonly.sh
+++ b/run/test/integration-test-nested-mount-readonly.sh
@@ -27,7 +27,7 @@ cleanup() {
 trap cleanup EXIT
 
 sudo -n mount --bind "$NESTED_SRC" "$MOUNT_POINT"
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/run/test/integration-test-non-runc-default-pseudofs-readonly.sh
+++ b/run/test/integration-test-non-runc-default-pseudofs-readonly.sh
@@ -27,7 +27,7 @@ cleanup() {
 trap cleanup EXIT
 
 sudo -n mount -t securityfs securityfs "$MOUNT_POINT"
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/run/test/integration-test-runner-temp.sh
+++ b/run/test/integration-test-runner-temp.sh
@@ -11,7 +11,7 @@ set -uo pipefail
 WORKDIR=$(mktemp -d)
 RUNNER_TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR" "$RUNNER_TEMP_DIR"' EXIT
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/run/test/integration-test-seccomp.sh
+++ b/run/test/integration-test-seccomp.sh
@@ -10,7 +10,7 @@ set -uo pipefail
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/run/test/integration-test-writable-dir.sh
+++ b/run/test/integration-test-writable-dir.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/run/test/integration-test-writable-disabled.sh
+++ b/run/test/integration-test-writable-disabled.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 
 WORKDIR=$(mktemp -d)
 trap 'rm -rf "$WORKDIR"' EXIT
-touch "$WORKDIR/state.env"
+touch "$WORKDIR/state.env" "$WORKDIR/summary.md"
 
 GITHUB_WORKSPACE="$WORKDIR" \
 GITHUB_STATE="$WORKDIR/state.env" \

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -13,9 +13,473 @@ var __create = Object.create, __defProp = Object.defineProperty, __getOwnPropDes
 //#endregion
 let node_child_process = require("node:child_process"), node_path = require("node:path");
 node_path = __toESM(node_path, 1);
-let node_url = require("node:url"), node_fs = require("node:fs"), node_os = require("node:os");
+let node_url = require("node:url"), os = require("os");
+os = __toESM(os, 1);
+let fs = require("fs");
+fs = __toESM(fs, 1);
+let path = require("path");
+path = __toESM(path, 1);
+let events = require("events");
+events = __toESM(events, 1);
+let node_crypto = require("node:crypto"), child_process = require("child_process");
+child_process = __toESM(child_process, 1), require("timers");
+let node_fs = require("node:fs"), node_os = require("node:os");
 node_os = __toESM(node_os, 1);
-let node_crypto = require("node:crypto");
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/summary.js
+var __awaiter$6 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { access, appendFile, writeFile } = fs.promises, SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
+new class {
+	constructor() {
+		this._buffer = "";
+	}
+	/**
+	* Finds the summary file path from the environment, rejects if env var is not found or file does not exist
+	* Also checks r/w permissions.
+	*
+	* @returns step summary file path
+	*/
+	filePath() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			if (this._filePath) return this._filePath;
+			let pathFromEnv = process.env[SUMMARY_ENV_VAR];
+			if (!pathFromEnv) throw Error(`Unable to find environment variable for $${SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
+			try {
+				yield access(pathFromEnv, fs.constants.R_OK | fs.constants.W_OK);
+			} catch {
+				throw Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
+			}
+			return this._filePath = pathFromEnv, this._filePath;
+		});
+	}
+	/**
+	* Wraps content in an HTML tag, adding any HTML attributes
+	*
+	* @param {string} tag HTML tag to wrap
+	* @param {string | null} content content within the tag
+	* @param {[attribute: string]: string} attrs key-value list of HTML attributes to add
+	*
+	* @returns {string} content wrapped in HTML element
+	*/
+	wrap(tag, content, attrs = {}) {
+		let htmlAttrs = Object.entries(attrs).map(([key, value]) => ` ${key}="${value}"`).join("");
+		return content ? `<${tag}${htmlAttrs}>${content}</${tag}>` : `<${tag}${htmlAttrs}>`;
+	}
+	/**
+	* Writes text in the buffer to the summary buffer file and empties buffer. Will append by default.
+	*
+	* @param {SummaryWriteOptions} [options] (optional) options for write operation
+	*
+	* @returns {Promise<Summary>} summary instance
+	*/
+	write(options) {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			let overwrite = !!options?.overwrite, filePath = yield this.filePath();
+			return yield (overwrite ? writeFile : appendFile)(filePath, this._buffer, { encoding: "utf8" }), this.emptyBuffer();
+		});
+	}
+	/**
+	* Clears the summary buffer and wipes the summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	clear() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			return this.emptyBuffer().write({ overwrite: !0 });
+		});
+	}
+	/**
+	* Returns the current summary buffer as a string
+	*
+	* @returns {string} string of summary buffer
+	*/
+	stringify() {
+		return this._buffer;
+	}
+	/**
+	* If the summary buffer is empty
+	*
+	* @returns {boolen} true if the buffer is empty
+	*/
+	isEmptyBuffer() {
+		return this._buffer.length === 0;
+	}
+	/**
+	* Resets the summary buffer without writing to summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	emptyBuffer() {
+		return this._buffer = "", this;
+	}
+	/**
+	* Adds raw text to the summary buffer
+	*
+	* @param {string} text content to add
+	* @param {boolean} [addEOL=false] (optional) append an EOL to the raw text (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addRaw(text, addEOL = !1) {
+		return this._buffer += text, addEOL ? this.addEOL() : this;
+	}
+	/**
+	* Adds the operating system-specific end-of-line marker to the buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addEOL() {
+		return this.addRaw(os.EOL);
+	}
+	/**
+	* Adds an HTML codeblock to the summary buffer
+	*
+	* @param {string} code content to render within fenced code block
+	* @param {string} lang (optional) language to syntax highlight code
+	*
+	* @returns {Summary} summary instance
+	*/
+	addCodeBlock(code, lang) {
+		let attrs = Object.assign({}, lang && { lang }), element = this.wrap("pre", this.wrap("code", code), attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML list to the summary buffer
+	*
+	* @param {string[]} items list of items to render
+	* @param {boolean} [ordered=false] (optional) if the rendered list should be ordered or not (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addList(items, ordered = !1) {
+		let tag = ordered ? "ol" : "ul", listItems = items.map((item) => this.wrap("li", item)).join(""), element = this.wrap(tag, listItems);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML table to the summary buffer
+	*
+	* @param {SummaryTableCell[]} rows table rows
+	*
+	* @returns {Summary} summary instance
+	*/
+	addTable(rows) {
+		let tableBody = rows.map((row) => {
+			let cells = row.map((cell) => {
+				if (typeof cell == "string") return this.wrap("td", cell);
+				let { header, data, colspan, rowspan } = cell, tag = header ? "th" : "td", attrs = Object.assign(Object.assign({}, colspan && { colspan }), rowspan && { rowspan });
+				return this.wrap(tag, data, attrs);
+			}).join("");
+			return this.wrap("tr", cells);
+		}).join(""), element = this.wrap("table", tableBody);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds a collapsable HTML details element to the summary buffer
+	*
+	* @param {string} label text for the closed state
+	* @param {string} content collapsable content
+	*
+	* @returns {Summary} summary instance
+	*/
+	addDetails(label, content) {
+		let element = this.wrap("details", this.wrap("summary", label) + content);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML image tag to the summary buffer
+	*
+	* @param {string} src path to the image you to embed
+	* @param {string} alt text description of the image
+	* @param {SummaryImageOptions} options (optional) addition image attributes
+	*
+	* @returns {Summary} summary instance
+	*/
+	addImage(src, alt, options) {
+		let { width, height } = options || {}, attrs = Object.assign(Object.assign({}, width && { width }), height && { height }), element = this.wrap("img", null, Object.assign({
+			src,
+			alt
+		}, attrs));
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML section heading element
+	*
+	* @param {string} text heading text
+	* @param {number | string} [level=1] (optional) the heading level, default: 1
+	*
+	* @returns {Summary} summary instance
+	*/
+	addHeading(text, level) {
+		let tag = `h${level}`, allowedTag = [
+			"h1",
+			"h2",
+			"h3",
+			"h4",
+			"h5",
+			"h6"
+		].includes(tag) ? tag : "h1", element = this.wrap(allowedTag, text);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML thematic break (<hr>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addSeparator() {
+		let element = this.wrap("hr", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML line break (<br>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addBreak() {
+		let element = this.wrap("br", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML blockquote to the summary buffer
+	*
+	* @param {string} text quote text
+	* @param {string} cite (optional) citation url
+	*
+	* @returns {Summary} summary instance
+	*/
+	addQuote(text, cite) {
+		let attrs = Object.assign({}, cite && { cite }), element = this.wrap("blockquote", text, attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML anchor tag to the summary buffer
+	*
+	* @param {string} text link text/content
+	* @param {string} href hyperlink
+	*
+	* @returns {Summary} summary instance
+	*/
+	addLink(text, href) {
+		let element = this.wrap("a", text, { href });
+		return this.addRaw(element).addEOL();
+	}
+}();
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io-util.js
+var __awaiter$5 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises, IS_WINDOWS$1 = process.platform === "win32";
+fs.constants.O_RDONLY;
+/**
+* On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+* \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+*/
+function isRooted(p) {
+	if (p = normalizeSeparators(p), !p) throw Error("isRooted() parameter \"p\" cannot be empty");
+	return IS_WINDOWS$1 ? p.startsWith("\\") || /^[A-Z]:/i.test(p) : p.startsWith("/");
+}
+/**
+* Best effort attempt to determine whether a file exists and is executable.
+* @param filePath    file path to check
+* @param extensions  additional file extensions to try
+* @return if file exists and is executable, returns the file path. otherwise empty string.
+*/
+function tryGetExecutablePath(filePath, extensions) {
+	return __awaiter$5(this, void 0, void 0, function* () {
+		let stats;
+		try {
+			stats = yield stat(filePath);
+		} catch (err) {
+			err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+		}
+		if (stats && stats.isFile()) {
+			if (IS_WINDOWS$1) {
+				let upperExt = path.extname(filePath).toUpperCase();
+				if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) return filePath;
+			} else if (isUnixExecutable(stats)) return filePath;
+		}
+		let originalFilePath = filePath;
+		for (let extension of extensions) {
+			filePath = originalFilePath + extension, stats = void 0;
+			try {
+				stats = yield stat(filePath);
+			} catch (err) {
+				err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+			}
+			if (stats && stats.isFile()) {
+				if (IS_WINDOWS$1) {
+					try {
+						let directory = path.dirname(filePath), upperName = path.basename(filePath).toUpperCase();
+						for (let actualName of yield readdir(directory)) if (upperName === actualName.toUpperCase()) {
+							filePath = path.join(directory, actualName);
+							break;
+						}
+					} catch (err) {
+						console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+					}
+					return filePath;
+				} else if (isUnixExecutable(stats)) return filePath;
+			}
+		}
+		return "";
+	});
+}
+function normalizeSeparators(p) {
+	return p ||= "", IS_WINDOWS$1 ? (p = p.replace(/\//g, "\\"), p.replace(/\\\\+/g, "\\")) : p.replace(/\/\/+/g, "/");
+}
+function isUnixExecutable(stats) {
+	return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io.js
+var __awaiter$4 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+/**
+* Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+* If you check and the tool does not exist, it will throw.
+*
+* @param     tool              name of the tool
+* @param     check             whether to check if tool exists
+* @returns   Promise<string>   path to tool
+*/
+function which(tool, check) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		if (check) {
+			let result = yield which(tool, !1);
+			if (!result) throw Error(IS_WINDOWS$1 ? `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.` : `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+			return result;
+		}
+		let matches = yield findInPath(tool);
+		return matches && matches.length > 0 ? matches[0] : "";
+	});
+}
+/**
+* Returns a list of all occurrences of the given tool on the system path.
+*
+* @returns   Promise<string[]>  the paths of the tool
+*/
+function findInPath(tool) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		let extensions = [];
+		if (IS_WINDOWS$1 && process.env.PATHEXT) for (let extension of process.env.PATHEXT.split(path.delimiter)) extension && extensions.push(extension);
+		if (isRooted(tool)) {
+			let filePath = yield tryGetExecutablePath(tool, extensions);
+			return filePath ? [filePath] : [];
+		}
+		if (tool.includes(path.sep)) return [];
+		let directories = [];
+		if (process.env.PATH) for (let p of process.env.PATH.split(path.delimiter)) p && directories.push(p);
+		let matches = [];
+		for (let directory of directories) {
+			let filePath = yield tryGetExecutablePath(path.join(directory, tool), extensions);
+			filePath && matches.push(filePath);
+		}
+		return matches;
+	});
+}
+process.platform, events.EventEmitter, events.EventEmitter, os.default.platform(), os.default.arch();
+/**
+* The code to exit an action
+*/
+var ExitCode;
+(function(ExitCode) {
+	/**
+	* A code indicating that the action was a failure
+	*/
+	ExitCode[ExitCode.Success = 0] = "Success", ExitCode[ExitCode.Failure = 1] = "Failure";
+})(ExitCode ||= {});
+/**
+* Gets the value of an input.
+* Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
+* Returns an empty string if the value is not defined.
+*
+* @param     name     name of the input to get
+* @param     options  optional. See InputOptions.
+* @returns   string
+*/
+function getInput(name, options) {
+	let val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+	if (options && options.required && !val) throw Error(`Input required and not supplied: ${name}`);
+	return options && options.trimWhitespace === !1 ? val : val.trim();
+}
+//#endregion
 //#region core/lib/general/action-error.ts
 /**
 * Base class for an action's own "intentional" errors — a caught failure
@@ -4451,7 +4915,7 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 		return mod && mod.__esModule ? mod : { default: mod };
 	};
 	Object.defineProperty(exports, "__esModule", { value: !0 }), exports.Updater = void 0;
-	let models_1 = require_dist$4(), debug_1 = __importDefault(require_src()), fs = __importStar(require("fs")), path = __importStar(require("path")), package_json_1 = require_package$1(), config_1 = require_config(), error_1 = require_error$4(), fetcher_1 = require_fetcher(), store_1 = require_store(), url = __importStar(require_url()), log = (0, debug_1.default)("tuf:cache");
+	let models_1 = require_dist$4(), debug_1 = __importDefault(require_src()), fs$1 = __importStar(require("fs")), path$1 = __importStar(require("path")), package_json_1 = require_package$1(), config_1 = require_config(), error_1 = require_error$4(), fetcher_1 = require_fetcher(), store_1 = require_store(), url = __importStar(require_url()), log = (0, debug_1.default)("tuf:cache");
 	exports.Updater = class {
 		dir;
 		metadataBaseUrl;
@@ -4496,25 +4960,25 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 			}
 			let targetFilePath = targetInfo.path;
 			if (this.trustedSet.root.signed.consistentSnapshot && this.config.prefixTargetsWithHash) {
-				let hashes = Object.values(targetInfo.hashes), { dir, base } = path.parse(targetFilePath), filename = `${hashes[0]}.${base}`;
+				let hashes = Object.values(targetInfo.hashes), { dir, base } = path$1.parse(targetFilePath), filename = `${hashes[0]}.${base}`;
 				targetFilePath = dir ? `${dir}/${filename}` : filename;
 			}
 			let targetUrl = url.join(targetBaseUrl, targetFilePath);
 			return await this.fetcher.downloadFile(targetUrl, targetInfo.length, async (fileName) => {
-				await targetInfo.verify(fs.createReadStream(fileName)), log("WRITE %s", targetPath), fs.copyFileSync(fileName, targetPath);
+				await targetInfo.verify(fs$1.createReadStream(fileName)), log("WRITE %s", targetPath), fs$1.copyFileSync(fileName, targetPath);
 			}), targetPath;
 		}
 		async findCachedTarget(targetInfo, filePath) {
 			filePath ||= this.generateTargetPath(targetInfo);
 			try {
-				if (fs.existsSync(filePath)) return await targetInfo.verify(fs.createReadStream(filePath)), filePath;
+				if (fs$1.existsSync(filePath)) return await targetInfo.verify(fs$1.createReadStream(filePath)), filePath;
 			} catch {
 				return;
 			}
 		}
 		loadLocalMetadata(fileName) {
-			let filePath = path.join(this.dir, `${fileName}.json`);
-			return log("READ %s", filePath), fs.readFileSync(filePath);
+			let filePath = path$1.join(this.dir, `${fileName}.json`);
+			return log("READ %s", filePath), fs$1.readFileSync(filePath);
 		}
 		async loadRoot() {
 			let lowerBound = this.trustedSet.root.signed.version + 1, upperBound = lowerBound + this.config.maxRootRotations;
@@ -4603,13 +5067,13 @@ var require_envelope = /* @__PURE__ */ __commonJSMin(((exports) => {
 		generateTargetPath(targetInfo) {
 			if (!this.targetDir) throw new error_1.ValueError("Target directory not set");
 			let filePath = encodeURIComponent(targetInfo.path);
-			return path.join(this.targetDir, filePath);
+			return path$1.join(this.targetDir, filePath);
 		}
 		persistMetadata(metaDataName, bytesData) {
 			let encodedName = encodeURIComponent(metaDataName);
 			try {
-				let filePath = path.join(this.dir, `${encodedName}.json`);
-				log("WRITE %s", filePath), fs.writeFileSync(filePath, bytesData.toString("utf8"));
+				let filePath = path$1.join(this.dir, `${encodedName}.json`);
+				log("WRITE %s", filePath), fs$1.writeFileSync(filePath, bytesData.toString("utf8"));
 			} catch (error) {
 				throw new error_1.PersistError(`Failed to persist metadata ${encodedName} error: ${error}`);
 			}
@@ -7167,7 +7631,7 @@ async function resolveVerifiedImage({ actionRef, actionRepo, proxyEngine }) {
 	};
 }
 async function main() {
-	let env = process.env, actionRef = env.GITHUB_ACTION_REF ?? "", actionRepo = env.GITHUB_ACTION_REPOSITORY ?? "", proxyEngine = resolveProxyEngine(env.INPUT_PROXY_ENGINE);
+	let env = process.env, actionRef = env.GITHUB_ACTION_REF ?? "", actionRepo = env.GITHUB_ACTION_REPOSITORY ?? "", proxyEngine = resolveProxyEngine(getInput("proxy_engine"));
 	console.log(`Proxy engine: ${proxyEngine}`);
 	let { imageRef, pullPolicy } = await resolveVerifiedImage({
 		actionRef,
@@ -7176,15 +7640,15 @@ async function main() {
 	});
 	console.log(`buildcage: image: ${imageRef}`);
 	let rules = buildACLRules({
-		httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-		httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-		ipRulesInput: env.INPUT_ALLOWED_IP_RULES
-	}), knownBlockedRules = parseRulesOrThrow(env.INPUT_KNOWN_BLOCKED_RULES);
+		httpsRulesInput: getInput("allowed_https_rules"),
+		httpRulesInput: getInput("allowed_http_rules"),
+		ipRulesInput: getInput("allowed_ip_rules")
+	}), knownBlockedRules = parseRulesOrThrow(getInput("known_blocked_rules"));
 	console.log("::group::buildcage: Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("Known blocked", knownBlockedRules), console.log("::endgroup::");
-	let builderName = env.INPUT_BUILDER_NAME || "buildcage", projectName = deriveProjectName(builderName), composeEnv = {
+	let builderName = getInput("builder_name") || "buildcage", projectName = deriveProjectName(builderName), composeEnv = {
 		...env,
 		BUILDER_NAME: builderName,
-		PROXY_MODE: env.INPUT_PROXY_MODE || "restrict",
+		PROXY_MODE: getInput("proxy_mode") || "restrict",
 		PROXY_ENGINE: proxyEngine,
 		ALLOWED_HTTPS_RULES: rules.httpsRules.join("\n"),
 		ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),

--- a/setup/dist/post.cjs
+++ b/setup/dist/post.cjs
@@ -1,5 +1,481 @@
 Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-let node_child_process = require("node:child_process"), node_path = require("node:path"), node_url = require("node:url"), node_crypto = require("node:crypto");
+//#region \0rolldown/runtime.js
+var __create = Object.create, __defProp = Object.defineProperty, __getOwnPropDesc = Object.getOwnPropertyDescriptor, __getOwnPropNames = Object.getOwnPropertyNames, __getProtoOf = Object.getPrototypeOf, __hasOwnProp = Object.prototype.hasOwnProperty, __copyProps = (to, from, except, desc) => {
+	if (from && typeof from == "object" || typeof from == "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) key = keys[i], !__hasOwnProp.call(to, key) && key !== except && __defProp(to, key, {
+		get: ((k) => from[k]).bind(null, key),
+		enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+	});
+	return to;
+}, __toESM = (mod, isNodeMode, target) => (target = mod == null ? {} : __create(__getProtoOf(mod)), __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: !0
+}) : target, mod));
+//#endregion
+let node_child_process = require("node:child_process"), node_path = require("node:path"), node_url = require("node:url"), os = require("os");
+os = __toESM(os, 1);
+let fs = require("fs");
+fs = __toESM(fs, 1);
+let path = require("path");
+path = __toESM(path, 1);
+let events = require("events");
+events = __toESM(events, 1);
+let node_crypto = require("node:crypto"), child_process = require("child_process");
+child_process = __toESM(child_process, 1), require("timers");
+//#endregion
+//#region node_modules/.pnpm/@actions+core@3.0.1/node_modules/@actions/core/lib/summary.js
+var __awaiter$6 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { access, appendFile, writeFile } = fs.promises, SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
+new class {
+	constructor() {
+		this._buffer = "";
+	}
+	/**
+	* Finds the summary file path from the environment, rejects if env var is not found or file does not exist
+	* Also checks r/w permissions.
+	*
+	* @returns step summary file path
+	*/
+	filePath() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			if (this._filePath) return this._filePath;
+			let pathFromEnv = process.env[SUMMARY_ENV_VAR];
+			if (!pathFromEnv) throw Error(`Unable to find environment variable for $${SUMMARY_ENV_VAR}. Check if your runtime environment supports job summaries.`);
+			try {
+				yield access(pathFromEnv, fs.constants.R_OK | fs.constants.W_OK);
+			} catch {
+				throw Error(`Unable to access summary file: '${pathFromEnv}'. Check if the file has correct read/write permissions.`);
+			}
+			return this._filePath = pathFromEnv, this._filePath;
+		});
+	}
+	/**
+	* Wraps content in an HTML tag, adding any HTML attributes
+	*
+	* @param {string} tag HTML tag to wrap
+	* @param {string | null} content content within the tag
+	* @param {[attribute: string]: string} attrs key-value list of HTML attributes to add
+	*
+	* @returns {string} content wrapped in HTML element
+	*/
+	wrap(tag, content, attrs = {}) {
+		let htmlAttrs = Object.entries(attrs).map(([key, value]) => ` ${key}="${value}"`).join("");
+		return content ? `<${tag}${htmlAttrs}>${content}</${tag}>` : `<${tag}${htmlAttrs}>`;
+	}
+	/**
+	* Writes text in the buffer to the summary buffer file and empties buffer. Will append by default.
+	*
+	* @param {SummaryWriteOptions} [options] (optional) options for write operation
+	*
+	* @returns {Promise<Summary>} summary instance
+	*/
+	write(options) {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			let overwrite = !!options?.overwrite, filePath = yield this.filePath();
+			return yield (overwrite ? writeFile : appendFile)(filePath, this._buffer, { encoding: "utf8" }), this.emptyBuffer();
+		});
+	}
+	/**
+	* Clears the summary buffer and wipes the summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	clear() {
+		return __awaiter$6(this, void 0, void 0, function* () {
+			return this.emptyBuffer().write({ overwrite: !0 });
+		});
+	}
+	/**
+	* Returns the current summary buffer as a string
+	*
+	* @returns {string} string of summary buffer
+	*/
+	stringify() {
+		return this._buffer;
+	}
+	/**
+	* If the summary buffer is empty
+	*
+	* @returns {boolen} true if the buffer is empty
+	*/
+	isEmptyBuffer() {
+		return this._buffer.length === 0;
+	}
+	/**
+	* Resets the summary buffer without writing to summary file
+	*
+	* @returns {Summary} summary instance
+	*/
+	emptyBuffer() {
+		return this._buffer = "", this;
+	}
+	/**
+	* Adds raw text to the summary buffer
+	*
+	* @param {string} text content to add
+	* @param {boolean} [addEOL=false] (optional) append an EOL to the raw text (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addRaw(text, addEOL = !1) {
+		return this._buffer += text, addEOL ? this.addEOL() : this;
+	}
+	/**
+	* Adds the operating system-specific end-of-line marker to the buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addEOL() {
+		return this.addRaw(os.EOL);
+	}
+	/**
+	* Adds an HTML codeblock to the summary buffer
+	*
+	* @param {string} code content to render within fenced code block
+	* @param {string} lang (optional) language to syntax highlight code
+	*
+	* @returns {Summary} summary instance
+	*/
+	addCodeBlock(code, lang) {
+		let attrs = Object.assign({}, lang && { lang }), element = this.wrap("pre", this.wrap("code", code), attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML list to the summary buffer
+	*
+	* @param {string[]} items list of items to render
+	* @param {boolean} [ordered=false] (optional) if the rendered list should be ordered or not (default: false)
+	*
+	* @returns {Summary} summary instance
+	*/
+	addList(items, ordered = !1) {
+		let tag = ordered ? "ol" : "ul", listItems = items.map((item) => this.wrap("li", item)).join(""), element = this.wrap(tag, listItems);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML table to the summary buffer
+	*
+	* @param {SummaryTableCell[]} rows table rows
+	*
+	* @returns {Summary} summary instance
+	*/
+	addTable(rows) {
+		let tableBody = rows.map((row) => {
+			let cells = row.map((cell) => {
+				if (typeof cell == "string") return this.wrap("td", cell);
+				let { header, data, colspan, rowspan } = cell, tag = header ? "th" : "td", attrs = Object.assign(Object.assign({}, colspan && { colspan }), rowspan && { rowspan });
+				return this.wrap(tag, data, attrs);
+			}).join("");
+			return this.wrap("tr", cells);
+		}).join(""), element = this.wrap("table", tableBody);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds a collapsable HTML details element to the summary buffer
+	*
+	* @param {string} label text for the closed state
+	* @param {string} content collapsable content
+	*
+	* @returns {Summary} summary instance
+	*/
+	addDetails(label, content) {
+		let element = this.wrap("details", this.wrap("summary", label) + content);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML image tag to the summary buffer
+	*
+	* @param {string} src path to the image you to embed
+	* @param {string} alt text description of the image
+	* @param {SummaryImageOptions} options (optional) addition image attributes
+	*
+	* @returns {Summary} summary instance
+	*/
+	addImage(src, alt, options) {
+		let { width, height } = options || {}, attrs = Object.assign(Object.assign({}, width && { width }), height && { height }), element = this.wrap("img", null, Object.assign({
+			src,
+			alt
+		}, attrs));
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML section heading element
+	*
+	* @param {string} text heading text
+	* @param {number | string} [level=1] (optional) the heading level, default: 1
+	*
+	* @returns {Summary} summary instance
+	*/
+	addHeading(text, level) {
+		let tag = `h${level}`, allowedTag = [
+			"h1",
+			"h2",
+			"h3",
+			"h4",
+			"h5",
+			"h6"
+		].includes(tag) ? tag : "h1", element = this.wrap(allowedTag, text);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML thematic break (<hr>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addSeparator() {
+		let element = this.wrap("hr", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML line break (<br>) to the summary buffer
+	*
+	* @returns {Summary} summary instance
+	*/
+	addBreak() {
+		let element = this.wrap("br", null);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML blockquote to the summary buffer
+	*
+	* @param {string} text quote text
+	* @param {string} cite (optional) citation url
+	*
+	* @returns {Summary} summary instance
+	*/
+	addQuote(text, cite) {
+		let attrs = Object.assign({}, cite && { cite }), element = this.wrap("blockquote", text, attrs);
+		return this.addRaw(element).addEOL();
+	}
+	/**
+	* Adds an HTML anchor tag to the summary buffer
+	*
+	* @param {string} text link text/content
+	* @param {string} href hyperlink
+	*
+	* @returns {Summary} summary instance
+	*/
+	addLink(text, href) {
+		let element = this.wrap("a", text, { href });
+		return this.addRaw(element).addEOL();
+	}
+}();
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io-util.js
+var __awaiter$5 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+const { chmod, copyFile, lstat, mkdir, open, readdir, rename, rm, rmdir, stat, symlink, unlink } = fs.promises, IS_WINDOWS$1 = process.platform === "win32";
+fs.constants.O_RDONLY;
+/**
+* On OSX/Linux, true if path starts with '/'. On Windows, true for paths like:
+* \, \hello, \\hello\share, C:, and C:\hello (and corresponding alternate separator cases).
+*/
+function isRooted(p) {
+	if (p = normalizeSeparators(p), !p) throw Error("isRooted() parameter \"p\" cannot be empty");
+	return IS_WINDOWS$1 ? p.startsWith("\\") || /^[A-Z]:/i.test(p) : p.startsWith("/");
+}
+/**
+* Best effort attempt to determine whether a file exists and is executable.
+* @param filePath    file path to check
+* @param extensions  additional file extensions to try
+* @return if file exists and is executable, returns the file path. otherwise empty string.
+*/
+function tryGetExecutablePath(filePath, extensions) {
+	return __awaiter$5(this, void 0, void 0, function* () {
+		let stats;
+		try {
+			stats = yield stat(filePath);
+		} catch (err) {
+			err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+		}
+		if (stats && stats.isFile()) {
+			if (IS_WINDOWS$1) {
+				let upperExt = path.extname(filePath).toUpperCase();
+				if (extensions.some((validExt) => validExt.toUpperCase() === upperExt)) return filePath;
+			} else if (isUnixExecutable(stats)) return filePath;
+		}
+		let originalFilePath = filePath;
+		for (let extension of extensions) {
+			filePath = originalFilePath + extension, stats = void 0;
+			try {
+				stats = yield stat(filePath);
+			} catch (err) {
+				err.code !== "ENOENT" && console.log(`Unexpected error attempting to determine if executable file exists '${filePath}': ${err}`);
+			}
+			if (stats && stats.isFile()) {
+				if (IS_WINDOWS$1) {
+					try {
+						let directory = path.dirname(filePath), upperName = path.basename(filePath).toUpperCase();
+						for (let actualName of yield readdir(directory)) if (upperName === actualName.toUpperCase()) {
+							filePath = path.join(directory, actualName);
+							break;
+						}
+					} catch (err) {
+						console.log(`Unexpected error attempting to determine the actual case of the file '${filePath}': ${err}`);
+					}
+					return filePath;
+				} else if (isUnixExecutable(stats)) return filePath;
+			}
+		}
+		return "";
+	});
+}
+function normalizeSeparators(p) {
+	return p ||= "", IS_WINDOWS$1 ? (p = p.replace(/\//g, "\\"), p.replace(/\\\\+/g, "\\")) : p.replace(/\/\/+/g, "/");
+}
+function isUnixExecutable(stats) {
+	return (stats.mode & 1) > 0 || (stats.mode & 8) > 0 && process.getgid !== void 0 && stats.gid === process.getgid() || (stats.mode & 64) > 0 && process.getuid !== void 0 && stats.uid === process.getuid();
+}
+//#endregion
+//#region node_modules/.pnpm/@actions+io@3.0.2/node_modules/@actions/io/lib/io.js
+var __awaiter$4 = function(thisArg, _arguments, P, generator) {
+	function adopt(value) {
+		return value instanceof P ? value : new P(function(resolve) {
+			resolve(value);
+		});
+	}
+	return new (P ||= Promise)(function(resolve, reject) {
+		function fulfilled(value) {
+			try {
+				step(generator.next(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function rejected(value) {
+			try {
+				step(generator.throw(value));
+			} catch (e) {
+				reject(e);
+			}
+		}
+		function step(result) {
+			result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
+		}
+		step((generator = generator.apply(thisArg, _arguments || [])).next());
+	});
+};
+/**
+* Returns path of a tool had the tool actually been invoked.  Resolves via paths.
+* If you check and the tool does not exist, it will throw.
+*
+* @param     tool              name of the tool
+* @param     check             whether to check if tool exists
+* @returns   Promise<string>   path to tool
+*/
+function which(tool, check) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		if (check) {
+			let result = yield which(tool, !1);
+			if (!result) throw Error(IS_WINDOWS$1 ? `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also verify the file has a valid extension for an executable file.` : `Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
+			return result;
+		}
+		let matches = yield findInPath(tool);
+		return matches && matches.length > 0 ? matches[0] : "";
+	});
+}
+/**
+* Returns a list of all occurrences of the given tool on the system path.
+*
+* @returns   Promise<string[]>  the paths of the tool
+*/
+function findInPath(tool) {
+	return __awaiter$4(this, void 0, void 0, function* () {
+		if (!tool) throw Error("parameter 'tool' is required");
+		let extensions = [];
+		if (IS_WINDOWS$1 && process.env.PATHEXT) for (let extension of process.env.PATHEXT.split(path.delimiter)) extension && extensions.push(extension);
+		if (isRooted(tool)) {
+			let filePath = yield tryGetExecutablePath(tool, extensions);
+			return filePath ? [filePath] : [];
+		}
+		if (tool.includes(path.sep)) return [];
+		let directories = [];
+		if (process.env.PATH) for (let p of process.env.PATH.split(path.delimiter)) p && directories.push(p);
+		let matches = [];
+		for (let directory of directories) {
+			let filePath = yield tryGetExecutablePath(path.join(directory, tool), extensions);
+			filePath && matches.push(filePath);
+		}
+		return matches;
+	});
+}
+process.platform, events.EventEmitter, events.EventEmitter, os.default.platform(), os.default.arch();
+/**
+* The code to exit an action
+*/
+var ExitCode;
+(function(ExitCode) {
+	/**
+	* A code indicating that the action was a failure
+	*/
+	ExitCode[ExitCode.Success = 0] = "Success", ExitCode[ExitCode.Failure = 1] = "Failure";
+})(ExitCode ||= {});
+/**
+* Gets the value of an input.
+* Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
+* Returns an empty string if the value is not defined.
+*
+* @param     name     name of the input to get
+* @param     options  optional. See InputOptions.
+* @returns   string
+*/
+function getInput(name, options) {
+	let val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`] || "";
+	if (options && options.required && !val) throw Error(`Input required and not supplied: ${name}`);
+	return options && options.trimWhitespace === !1 ? val : val.trim();
+}
+//#endregion
 //#region core/lib/docker/container.ts
 /**
 * An explicit, deterministic Compose project name, so concurrent
@@ -21,7 +497,7 @@ function resolveProjectName(builderName, env) {
 	return deriveProjectName(builderName);
 }
 function main() {
-	let builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
+	let builderName = getInput("builder_name") || "buildcage";
 	(0, node_child_process.execFileSync)("docker", [
 		"compose",
 		"-p",

--- a/setup/docker/explicit/Dockerfile
+++ b/setup/docker/explicit/Dockerfile
@@ -36,6 +36,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
 COPY rolldown.scripts.config.js ./
 COPY core/ ./core/
+COPY setup/docker/lib/ ./setup/docker/lib/
 COPY setup/docker/explicit/scripts/ ./setup/docker/explicit/scripts/
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm run build:scripts

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -7,7 +7,7 @@
  * including `buildctl` itself, run inside the container via `docker exec`
  * rather than needing buildctl reachable from the runner.
  */
-import { appendFileSync } from "node:fs";
+import * as core from "@actions/core";
 import { createDocker, type Docker } from "../../../../core/lib/docker/client.ts";
 import { buildReportParameters } from "../../../../core/lib/report/report-parameters.ts";
 import { buildExplicitReportData } from "../../../../core/lib/report/build-explicit-report-data.ts";
@@ -16,6 +16,7 @@ import { renderCommunicationDetails } from "../../../../core/lib/report/command-
 import { emitBlockedOutcome } from "../../../../core/lib/report/emit-blocked-outcome.ts";
 import { errorMessage } from "../../../../core/lib/general/error-message.ts";
 import { wrapLogGroup } from "../../../../core/lib/log/log-entries.ts";
+import { writeStepSummary } from "../../lib/write-step-summary.ts";
 import {
   selectAllRefs,
   parseVertexAllowedLog,
@@ -83,15 +84,18 @@ async function main(): Promise<void> {
     process.env.GITHUB_ACTION_REF || "v2",
   );
 
-  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
-  if (summaryFile) {
-    appendFileSync(summaryFile, markdown);
-  } else {
-    console.log(markdown);
-  }
+  await writeStepSummary(markdown);
 
-  const failOnBlocked = (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
-  emitBlockedOutcome(report, { failOnBlocked, summaryFile });
+  // Several test/dev invocations run this script directly without setting
+  // fail_on_blocked, unlike the real `report` action where action.yml's
+  // own default always supplies it — fall back to that same default.
+  let failOnBlocked: boolean;
+  try {
+    failOnBlocked = core.getBooleanInput("fail_on_blocked");
+  } catch {
+    failOnBlocked = true;
+  }
+  emitBlockedOutcome(report, { failOnBlocked, summaryFile: process.env.GITHUB_STEP_SUMMARY });
 }
 
 main().catch((e) => {

--- a/setup/docker/lib/write-step-summary.ts
+++ b/setup/docker/lib/write-step-summary.ts
@@ -1,0 +1,14 @@
+import * as core from "@actions/core";
+
+/**
+ * Shared by both report-action.node.ts entry points. core.summary.write()
+ * throws if GITHUB_STEP_SUMMARY is unset, so this checks first and falls
+ * back to stdout for local/manual invocations.
+ */
+export async function writeStepSummary(markdown: string): Promise<void> {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await core.summary.addRaw(markdown).write();
+  } else {
+    console.log(markdown);
+  }
+}

--- a/setup/docker/transparent/Dockerfile
+++ b/setup/docker/transparent/Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
 COPY rolldown.scripts.config.js ./
 COPY core/ ./core/
+COPY setup/docker/lib/ ./setup/docker/lib/
 COPY setup/docker/explicit/scripts/ ./setup/docker/explicit/scripts/
 COPY setup/docker/transparent/scripts/ ./setup/docker/transparent/scripts/
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -7,13 +7,14 @@
  * so `report` itself never needs to know this engine's log path or env
  * var names.
  */
-import { appendFileSync } from "node:fs";
+import * as core from "@actions/core";
 import { createDocker } from "../../../../core/lib/docker/client.ts";
 import { buildReportParameters } from "../../../../core/lib/report/report-parameters.ts";
 import { buildTransparentReportData } from "../../../../core/lib/report/build-transparent-report-data.ts";
 import { renderReportMarkdown } from "../../../../core/lib/report/render-report-markdown.ts";
 import { emitBlockedOutcome } from "../../../../core/lib/report/emit-blocked-outcome.ts";
 import { errorMessage } from "../../../../core/lib/general/error-message.ts";
+import { writeStepSummary } from "../../lib/write-step-summary.ts";
 
 const LOG_FILE = "/var/log/haproxy/current";
 
@@ -36,15 +37,18 @@ async function main(): Promise<void> {
     process.env.GITHUB_ACTION_REF || "v2",
   );
 
-  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
-  if (summaryFile) {
-    appendFileSync(summaryFile, markdown);
-  } else {
-    console.log(markdown);
-  }
+  await writeStepSummary(markdown);
 
-  const failOnBlocked = (process.env.INPUT_FAIL_ON_BLOCKED || "true").toLowerCase() === "true";
-  emitBlockedOutcome(report, { failOnBlocked, summaryFile });
+  // Several test/dev invocations run this script directly without setting
+  // fail_on_blocked, unlike the real `report` action where action.yml's
+  // own default always supplies it — fall back to that same default.
+  let failOnBlocked: boolean;
+  try {
+    failOnBlocked = core.getBooleanInput("fail_on_blocked");
+  } catch {
+    failOnBlocked = true;
+  }
+  emitBlockedOutcome(report, { failOnBlocked, summaryFile: process.env.GITHUB_STEP_SUMMARY });
 }
 
 main().catch((e) => {

--- a/setup/src/main.ts
+++ b/setup/src/main.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as core from "@actions/core";
 
 import { SetupError } from "./lib/errors.ts";
 import { ActionError } from "../../core/lib/general/action-error.ts";
@@ -52,7 +53,7 @@ async function main(): Promise<void> {
   const actionRef = env.GITHUB_ACTION_REF ?? "";
   const actionRepo = env.GITHUB_ACTION_REPOSITORY ?? "";
 
-  const proxyEngine = resolveProxyEngine(env.INPUT_PROXY_ENGINE);
+  const proxyEngine = resolveProxyEngine(core.getInput("proxy_engine"));
   console.log(`Proxy engine: ${proxyEngine}`);
 
   const localOverride = LOCAL_IMAGE_OVERRIDE_ENABLED
@@ -73,11 +74,11 @@ async function main(): Promise<void> {
   console.log(`buildcage: image: ${imageRef}`);
 
   const rules = buildACLRules({
-    httpsRulesInput: env.INPUT_ALLOWED_HTTPS_RULES,
-    httpRulesInput: env.INPUT_ALLOWED_HTTP_RULES,
-    ipRulesInput: env.INPUT_ALLOWED_IP_RULES,
+    httpsRulesInput: core.getInput("allowed_https_rules"),
+    httpRulesInput: core.getInput("allowed_http_rules"),
+    ipRulesInput: core.getInput("allowed_ip_rules"),
   });
-  const knownBlockedRules = parseRulesOrThrow(env.INPUT_KNOWN_BLOCKED_RULES);
+  const knownBlockedRules = parseRulesOrThrow(core.getInput("known_blocked_rules"));
 
   console.log("::group::buildcage: Configured ACL Rules");
   logRules("HTTPS", rules.httpsRules);
@@ -89,7 +90,7 @@ async function main(): Promise<void> {
   // "buildcage" here is a fallback for running outside the Actions runtime
   // (action.yml's own `default: 'buildcage'` covers the normal case) — keep
   // both, and report/src/main.ts's copy, in sync.
-  const builderName = env.INPUT_BUILDER_NAME || "buildcage";
+  const builderName = core.getInput("builder_name") || "buildcage";
   // So report can independently derive the same project name from its own
   // builder_name input and find this container via `docker ps --filter`.
   const projectName = deriveProjectName(builderName);
@@ -97,7 +98,7 @@ async function main(): Promise<void> {
   const composeEnv = {
     ...env,
     BUILDER_NAME: builderName,
-    PROXY_MODE: env.INPUT_PROXY_MODE || "restrict",
+    PROXY_MODE: core.getInput("proxy_mode") || "restrict",
     PROXY_ENGINE: proxyEngine,
     ALLOWED_HTTPS_RULES: rules.httpsRules.join("\n"),
     ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),

--- a/setup/src/post.ts
+++ b/setup/src/post.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import * as core from "@actions/core";
 import { deriveProjectName } from "../../core/lib/docker/container.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -19,7 +20,7 @@ export function resolveProjectName(builderName: string, env: NodeJS.ProcessEnv):
 function main(): void {
   // builder_name is a real input, so post.ts can recompute the same project
   // name main.ts used directly, without round-tripping it through GITHUB_STATE.
-  const builderName = process.env.INPUT_BUILDER_NAME || "buildcage";
+  const builderName = core.getInput("builder_name") || "buildcage";
   const projectName = resolveProjectName(builderName, process.env);
 
   execFileSync(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "setup/src/**/*.ts",
     "run/src/**/*.ts",
     "report/src/**/*.ts",
-    "setup/docker/*/scripts/*.node.ts"
+    "setup/docker/*/scripts/*.node.ts",
+    "setup/docker/lib/**/*.ts"
   ],
   "exclude": ["**/dist/**"]
 }


### PR DESCRIPTION
## Summary

Setup/run/report reimplemented several pieces of GitHub Actions runtime behavior by hand — reading `INPUT_*` env vars, writing/reading `GITHUB_STATE`, and appending to `GITHUB_STEP_SUMMARY` — instead of using `@actions/core`. Most of buildcage's other hand-rolled bits are thin enough over Node's own APIs that adopting the toolkit wouldn't earn its keep, but these three had real payoff (safe trimming, safe handling of multi-line state values, and the documented way to write Job Summaries), so this adopts `@actions/core` for just those three concerns.

Per this repo's convention that `core/lib/**` stays free of Actions-specific dependencies, usage is kept to `main`/`post` entrypoints only.

## Changes

- Replace `INPUT_*` env reads with `core.getInput`
  - Across `setup`, `run`, `report`, and both `report-action.node.ts` entry points baked into the Docker images.
- Replace `run`'s `GITHUB_STATE` key=value writes/reads with `core.saveState`/`core.getState`
  - The old `key=value\n` format broke on embedded newlines; `core.saveState` handles this safely.
- Move `run`'s summary write path into `main.ts` and switch to `core.summary`
  - `run/src/lib/report.ts`'s `writeReport()` lived in the "parts" layer yet reached directly into `process.env`. Split into a pure outcome-computation function (kept in `lib/report.ts`) and the actual summary/annotation/exit-code side effects (moved to `main.ts`).
- Switch both `report-action.node.ts` scripts to `core.summary`
  - The actual `GITHUB_STEP_SUMMARY` writer for `setup`/`report` turned out to live here, not in `run`'s own report path. Both scripts now share a small `setup/docker/lib/write-step-summary.ts` helper.
- Use `core.getBooleanInput` for `fail_on_blocked`, falling back to `true` on error
  - Several integration scripts invoke the built actions directly without ever setting this input (a real workflow always has `action.yml`'s own default), which trips `core.getBooleanInput`'s strict YAML 1.2 validation. Catching that and falling back to the same default keeps the strict validation for genuinely bad input while not requiring every test invocation to set it.
- Mark `@actions/http-client`/`undici` side-effect free in the rolldown config
  - `@actions/core` statically imports `@actions/http-client` (for its unused `getIDToken`/OIDC support), which otherwise drags all of `undici` into every bundled dist file.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/ setup/src report/src run/src`
- [x] `make test_unit` (including the QuickJS suite, which required updating both Dockerfiles' scripts-build COPY list)
- [x] `vp run build` — dist rebuilt and committed