### PR TITLE
fix: resolve vp check lint warnings in test-shim.ts

### DIFF
--- a/core/lib/test/test-shim.ts
+++ b/core/lib/test/test-shim.ts
@@ -23,10 +23,10 @@ interface Assert {
 }
 
 interface Shim {
-  describe(name: string, fn: () => void): void;
-  it(name: string, fn: () => void): void;
+  describe(this: void, name: string, fn: () => void): void;
+  it(this: void, name: string, fn: () => void): void;
   assert: Assert;
-  reportResults(): void;
+  reportResults(this: void): void;
 }
 
 async function createNodeShim(): Promise<Shim> {
@@ -58,7 +58,7 @@ async function createQjsShim(): Promise<Shim> {
       passed++;
     } catch (e) {
       failed++;
-      std.err.puts(`FAIL: ${label}\n  ${(e as Error).message || e}\n`);
+      std.err.puts(`FAIL: ${label}\n  ${e instanceof Error ? e.message : String(e)}\n`);
     }
   }
 


### PR DESCRIPTION
## Summary

`vp check` has been carrying 4 lint warnings in `core/lib/test/test-shim.ts` for a while — a `restrict-template-expressions` warning from embedding a caught `unknown` value directly in a template literal, and 3 `unbound-method` warnings from destructuring `describe`/`it`/`reportResults` off the shim object.

## Changes

- Replace `(e as Error).message || e` with an explicit `e instanceof Error ? e.message : String(e)` check, so the QuickJS shim's failure output no longer embeds an `unknown`-typed value in a template literal.
- Annotate `Shim`'s `describe`/`it`/`reportResults` with `this: void`, since none of them use `this` and the destructuring assignment on the last line was tripping `unbound-method`.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check` — 0 warnings, down from 4
- [x] `vp test run core/ setup/src report/src run/src`
- [x] `make test_unit_qjs`