### PR TITLE
refactor: unify report markdown rendering between run and report actions

### DIFF
--- a/core/lib/report/render-report-markdown.test.ts
+++ b/core/lib/report/render-report-markdown.test.ts
@@ -44,9 +44,9 @@ describe("renderReportMarkdown — transparent", () => {
 
   it("renders the restrict-mode heading and Allowed Hosts table", () => {
     const md = renderReportMarkdown({ ...base, passed: [allowedRow] }, "dash14/buildcage", "v2", {
-      heading: "during Docker Build",
+      headingSuffix: " during Docker Build",
     });
-    assert.match(md, /## Outbound Traffic Report — during Docker Build \(restrict mode\)/);
+    assert.match(md, /## Outbound Traffic Report during Docker Build \(restrict mode\)/);
     assert.match(md, /### ✅ Allowed Hosts/);
     assert.match(md, /good\.com/);
   });
@@ -104,8 +104,10 @@ describe("renderReportMarkdown — transparent", () => {
     assertNotMatch(blockedMd, /_\(no communication\)_/);
   });
 
-  it("puts the heading option after an em dash instead of a bare heading", () => {
-    const md = renderReportMarkdown(base, "dash14/buildcage", "v2", { heading: "npm install" });
+  it("appends headingSuffix verbatim, e.g. a run step's em-dash label", () => {
+    const md = renderReportMarkdown(base, "dash14/buildcage", "v2", {
+      headingSuffix: " — npm install",
+    });
     assert.match(md, /^## Outbound Traffic Report — npm install \(restrict mode\)/);
   });
 

--- a/core/lib/report/render-report-markdown.test.ts
+++ b/core/lib/report/render-report-markdown.test.ts
@@ -43,8 +43,10 @@ describe("renderReportMarkdown — transparent", () => {
   };
 
   it("renders the restrict-mode heading and Allowed Hosts table", () => {
-    const md = renderReportMarkdown({ ...base, passed: [allowedRow] }, "dash14/buildcage", "v2");
-    assert.match(md, /## Outbound Traffic Report during Docker Build \(restrict mode\)/);
+    const md = renderReportMarkdown({ ...base, passed: [allowedRow] }, "dash14/buildcage", "v2", {
+      heading: "during Docker Build",
+    });
+    assert.match(md, /## Outbound Traffic Report — during Docker Build \(restrict mode\)/);
     assert.match(md, /### ✅ Allowed Hosts/);
     assert.match(md, /good\.com/);
   });
@@ -100,6 +102,36 @@ describe("renderReportMarkdown — transparent", () => {
       "v2",
     );
     assertNotMatch(blockedMd, /_\(no communication\)_/);
+  });
+
+  it("puts the heading option after an em dash instead of a bare heading", () => {
+    const md = renderReportMarkdown(base, "dash14/buildcage", "v2", { heading: "npm install" });
+    assert.match(md, /^## Outbound Traffic Report — npm install \(restrict mode\)/);
+  });
+
+  it("shows a run-flavored restrict-mode example including the run: command", () => {
+    const md = renderReportMarkdown(
+      { ...base, parameters: params({ mode: "audit" }), passed: [allowedRow] },
+      "dash14/buildcage",
+      "v2",
+      { actionName: "run", runCommand: "npm install" },
+    );
+    assert.match(md, /uses: dash14\/buildcage\/run@v2/);
+    assert.match(md, /run: \|\n\s+npm install/);
+  });
+
+  it("adds an Expected column marking known_blocked_rules matches when set", () => {
+    const md = renderReportMarkdown(
+      { ...base, parameters: params({ knownBlockedRules: ["bad.com:80"] }), blocked: [blockedRow] },
+      "dash14/buildcage",
+      "v2",
+    );
+    assert.match(md, /\| Host \| Rule \| Reason \| Count \| Expected \|/);
+  });
+
+  it("omits the Expected column when known_blocked_rules is not set", () => {
+    const md = renderReportMarkdown({ ...base, blocked: [blockedRow] }, "dash14/buildcage", "v2");
+    assertNotMatch(md, /Expected/);
   });
 });
 

--- a/core/lib/report/render-report-markdown.test.ts
+++ b/core/lib/report/render-report-markdown.test.ts
@@ -44,7 +44,7 @@ describe("renderReportMarkdown — transparent", () => {
 
   it("renders the restrict-mode heading and Allowed Hosts table", () => {
     const md = renderReportMarkdown({ ...base, passed: [allowedRow] }, "dash14/buildcage", "v2", {
-      headingSuffix: " during Docker Build",
+      title: "Outbound Traffic Report during Docker Build",
     });
     assert.match(md, /## Outbound Traffic Report during Docker Build \(restrict mode\)/);
     assert.match(md, /### ✅ Allowed Hosts/);
@@ -104,9 +104,9 @@ describe("renderReportMarkdown — transparent", () => {
     assertNotMatch(blockedMd, /_\(no communication\)_/);
   });
 
-  it("appends headingSuffix verbatim, e.g. a run step's em-dash label", () => {
+  it("uses the title option verbatim, e.g. a run step's em-dash label", () => {
     const md = renderReportMarkdown(base, "dash14/buildcage", "v2", {
-      headingSuffix: " — npm install",
+      title: "Outbound Traffic Report — npm install",
     });
     assert.match(md, /^## Outbound Traffic Report — npm install \(restrict mode\)/);
   });

--- a/core/lib/report/render-report-markdown.ts
+++ b/core/lib/report/render-report-markdown.ts
@@ -3,6 +3,16 @@ import { buildRestrictExample } from "./build-example.ts";
 import { renderCommunicationDetails } from "./command-log.ts";
 import type { ReportData } from "./report-data.ts";
 
+export interface RenderReportMarkdownOptions {
+  /** Shown after an em dash in the heading, e.g. a run step's label or
+   *  "during Docker Build". Omitted entirely for a bare heading. */
+  heading?: string;
+  /** Which action's restrict-mode example to show in audit mode. */
+  actionName?: "setup" | "run";
+  /** The `run:` input, included in the example only when actionName is "run". */
+  runCommand?: string;
+}
+
 /** Branches on `report.engine`/`report.parameters.mode` rather than being
  *  duplicated per engine. actionRepo/actionRef are real values, not
  *  placeholders — this runs on the runner, with process.env available. */
@@ -10,18 +20,23 @@ export function renderReportMarkdown(
   report: ReportData,
   actionRepo: string,
   actionRef: string,
+  { heading: stepHeading, actionName, runCommand }: RenderReportMarkdownOptions = {},
 ): string {
   const isAudit = report.parameters.mode === "audit";
   const showExpected = report.parameters.knownBlockedRules.length > 0;
   const heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts";
 
-  let markdown = `## Outbound Traffic Report during Docker Build (${report.parameters.mode} mode)\n\n`;
+  const title = `Outbound Traffic Report${stepHeading ? ` — ${stepHeading}` : ""}`;
+  let markdown = `## ${title} (${report.parameters.mode} mode)\n\n`;
 
   if (report.passed.length > 0) {
     markdown += `### ${heading}\n\n` + renderHostTable(report.passed) + "\n";
   }
   if (isAudit) {
-    markdown += buildRestrictExample(report.passed, actionRepo, actionRef);
+    markdown += buildRestrictExample(report.passed, actionRepo, actionRef, {
+      actionName,
+      runCommand,
+    });
   }
   if (report.blocked.length > 0) {
     if (report.passed.length > 0) markdown += "\n";

--- a/core/lib/report/render-report-markdown.ts
+++ b/core/lib/report/render-report-markdown.ts
@@ -4,9 +4,10 @@ import { renderCommunicationDetails } from "./command-log.ts";
 import type { ReportData } from "./report-data.ts";
 
 export interface RenderReportMarkdownOptions {
-  /** Shown after an em dash in the heading, e.g. a run step's label or
-   *  "during Docker Build". Omitted entirely for a bare heading. */
-  heading?: string;
+  /** Appended to "Outbound Traffic Report" verbatim, including any leading
+   *  separator — e.g. " during Docker Build" or " — npm install". Omit for
+   *  a bare heading. */
+  headingSuffix?: string;
   /** Which action's restrict-mode example to show in audit mode. */
   actionName?: "setup" | "run";
   /** The `run:` input, included in the example only when actionName is "run". */
@@ -20,13 +21,13 @@ export function renderReportMarkdown(
   report: ReportData,
   actionRepo: string,
   actionRef: string,
-  { heading: stepHeading, actionName, runCommand }: RenderReportMarkdownOptions = {},
+  { headingSuffix, actionName, runCommand }: RenderReportMarkdownOptions = {},
 ): string {
   const isAudit = report.parameters.mode === "audit";
   const showExpected = report.parameters.knownBlockedRules.length > 0;
   const heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts";
 
-  const title = `Outbound Traffic Report${stepHeading ? ` — ${stepHeading}` : ""}`;
+  const title = `Outbound Traffic Report${headingSuffix ?? ""}`;
   let markdown = `## ${title} (${report.parameters.mode} mode)\n\n`;
 
   if (report.passed.length > 0) {

--- a/core/lib/report/render-report-markdown.ts
+++ b/core/lib/report/render-report-markdown.ts
@@ -4,10 +4,10 @@ import { renderCommunicationDetails } from "./command-log.ts";
 import type { ReportData } from "./report-data.ts";
 
 export interface RenderReportMarkdownOptions {
-  /** Appended to "Outbound Traffic Report" verbatim, including any leading
-   *  separator — e.g. " during Docker Build" or " — npm install". Omit for
-   *  a bare heading. */
-  headingSuffix?: string;
+  /** Full heading text, e.g. "Outbound Traffic Report during Docker Build"
+   *  or "Outbound Traffic Report — npm install". Defaults to a bare
+   *  "Outbound Traffic Report". */
+  title?: string;
   /** Which action's restrict-mode example to show in audit mode. */
   actionName?: "setup" | "run";
   /** The `run:` input, included in the example only when actionName is "run". */
@@ -21,13 +21,12 @@ export function renderReportMarkdown(
   report: ReportData,
   actionRepo: string,
   actionRef: string,
-  { headingSuffix, actionName, runCommand }: RenderReportMarkdownOptions = {},
+  { title = "Outbound Traffic Report", actionName, runCommand }: RenderReportMarkdownOptions = {},
 ): string {
   const isAudit = report.parameters.mode === "audit";
   const showExpected = report.parameters.knownBlockedRules.length > 0;
   const heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts";
 
-  const title = `Outbound Traffic Report${headingSuffix ?? ""}`;
   let markdown = `## ${title} (${report.parameters.mode} mode)\n\n`;
 
   if (report.passed.length > 0) {

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8356,40 +8356,6 @@ function createDocker(run = defaultRunCommand, spawnDocker = defaultSpawnCommand
 	};
 }
 //#endregion
-//#region core/lib/report/build-example.ts
-const ruleTypeToParam = {
-	HTTPS: "allowed_https_rules",
-	HTTP: "allowed_http_rules",
-	IP: "allowed_ip_rules"
-};
-/**
-* Build a restrict-mode YAML configuration example from audited rows.
-* Returns a markdown string wrapped in <details> tags, or "" if no rows.
-*
-* actionRef is the ref (tag or commit SHA) this action was invoked with.
-*/
-function buildRestrictExample(auditedRows, actionRepo, actionRef, { actionName = "setup", runCommand } = {}) {
-	if (!auditedRows || auditedRows.length === 0) return "";
-	let ref = /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef, groups = /* @__PURE__ */ new Map();
-	for (let r of auditedRows) {
-		let param = ruleTypeToParam[r.ruleType];
-		param && (groups.has(param) || groups.set(param, []), groups.get(param).push(`${r.host}:${r.port}`));
-	}
-	if (groups.size === 0) return "";
-	let yaml = "";
-	if (yaml += "- name: Start Buildcage in restrict mode\n", yaml += `  uses: ${actionRepo}/${actionName}@${ref}\n`, yaml += "  with:\n", actionName === "run" && runCommand) {
-		yaml += "    run: |\n";
-		for (let line of runCommand.replace(/\r?\n$/, "").split(/\r?\n/)) yaml += `      ${line}\n`;
-	}
-	yaml += "    proxy_mode: restrict\n";
-	for (let [param, rules] of groups) {
-		yaml += `    ${param}: >-\n`;
-		for (let rule of rules) yaml += `      ${rule}\n`;
-	}
-	let md = "\n<details>\n";
-	return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", md += yaml, md += "```\n\n", md += "</details>\n", md;
-}
-//#endregion
 //#region core/lib/report/known-blocked.ts
 /**
 * Shared logic for `known_blocked_rules`: domains expected to be blocked,
@@ -8513,6 +8479,109 @@ function renderHostTable(rows, { showReason = !1, showExpected = !1 } = {}) {
 	})));
 }
 //#endregion
+//#region core/lib/report/build-example.ts
+const ruleTypeToParam = {
+	HTTPS: "allowed_https_rules",
+	HTTP: "allowed_http_rules",
+	IP: "allowed_ip_rules"
+};
+/**
+* Build a restrict-mode YAML configuration example from audited rows.
+* Returns a markdown string wrapped in <details> tags, or "" if no rows.
+*
+* actionRef is the ref (tag or commit SHA) this action was invoked with.
+*/
+function buildRestrictExample(auditedRows, actionRepo, actionRef, { actionName = "setup", runCommand } = {}) {
+	if (!auditedRows || auditedRows.length === 0) return "";
+	let ref = /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef, groups = /* @__PURE__ */ new Map();
+	for (let r of auditedRows) {
+		let param = ruleTypeToParam[r.ruleType];
+		param && (groups.has(param) || groups.set(param, []), groups.get(param).push(`${r.host}:${r.port}`));
+	}
+	if (groups.size === 0) return "";
+	let yaml = "";
+	if (yaml += "- name: Start Buildcage in restrict mode\n", yaml += `  uses: ${actionRepo}/${actionName}@${ref}\n`, yaml += "  with:\n", actionName === "run" && runCommand) {
+		yaml += "    run: |\n";
+		for (let line of runCommand.replace(/\r?\n$/, "").split(/\r?\n/)) yaml += `      ${line}\n`;
+	}
+	yaml += "    proxy_mode: restrict\n";
+	for (let [param, rules] of groups) {
+		yaml += `    ${param}: >-\n`;
+		for (let rule of rules) yaml += `      ${rule}\n`;
+	}
+	let md = "\n<details>\n";
+	return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", md += yaml, md += "```\n\n", md += "</details>\n", md;
+}
+//#endregion
+//#region core/lib/report/command-log.ts
+/**
+* Render the explicit engine's communication detail as a collapsed markdown
+* section, or "" if there's nothing to show. Allowed Urls is listed before
+* Blocked Urls, matching the Allowed Hosts / Blocked Hosts tables above.
+*
+* Blocked entries aren't attributed to a specific RUN step — buildkitd's
+* denial log carries no vertex/span identifier to attribute it with. A
+* "Build N" item separates builds only when there's more than one, since
+* step labels like "[2/15] RUN ..." repeat across builds.
+*
+* Command text is escaped since it's embedded directly in markdown; request
+* lines go inside a fenced code block instead, where escaping isn't needed.
+*/
+function renderCommunicationDetails(builds, deniedTimeline) {
+	let nonEmptyBuilds = (builds || []).filter((b) => b && b.length > 0), hasVertexLog = nonEmptyBuilds.length > 0, hasDenied = deniedTimeline && deniedTimeline.length > 0;
+	if (!hasVertexLog && !hasDenied) return "";
+	let md = "\n<details>\n<summary>💬 Communication details</summary>\n\n";
+	if (hasVertexLog) {
+		md += "* **✅ Allowed Urls**\n\n";
+		let showBuildHeadings = nonEmptyBuilds.length > 1;
+		nonEmptyBuilds.forEach((vertices, i) => {
+			let indent = showBuildHeadings ? "      " : "   ";
+			showBuildHeadings && (md += `   * Build ${i + 1}\n\n`);
+			for (let vertex of vertices) md += renderVertexItem(vertex, indent);
+		});
+	}
+	if (hasDenied) {
+		md += "* **🚫 Blocked Urls**\n\n";
+		for (let { url, timestamp } of deniedTimeline) md += `   - (${formatSeconds(timestamp)}) ${escapeMarkdown(url)}\n`;
+		md += "\n";
+	}
+	return md += "</details>\n", md;
+}
+function renderVertexItem({ command, started, completed, entries }, indent) {
+	let inner = indent + "   ", s = `${indent}* ${escapeMarkdown(command)}\n\n`;
+	if (s += `${inner}(${formatSeconds(started)} · duration ${formatDuration(started, completed)})\n\n`, s += `${inner}\`\`\`\n`, entries.length === 0) s += `${inner}(no communication)\n`;
+	else for (let entry of entries) s += `${inner}${renderRequestLine(entry)}\n`;
+	return s += `${inner}\`\`\`\n\n`, s;
+}
+function renderRequestLine({ method, url, status }) {
+	let line = `- ${escapeMarkdown(method)} ${escapeMarkdown(url)}`;
+	return status === void 0 ? line : `${line} -> ${status}`;
+}
+function escapeMarkdown(text) {
+	return text.replace(/([\\`*_[\]<>])/g, "\\$1");
+}
+function formatSeconds(iso) {
+	return new Date(iso).toISOString().slice(11, 19) + "Z";
+}
+function formatDuration(started, completed) {
+	return `${((Date.parse(completed) - Date.parse(started)) / 1e3).toFixed(3)}s`;
+}
+//#endregion
+//#region core/lib/report/render-report-markdown.ts
+/** Branches on `report.engine`/`report.parameters.mode` rather than being
+*  duplicated per engine. actionRepo/actionRef are real values, not
+*  placeholders — this runs on the runner, with process.env available. */
+function renderReportMarkdown(report, actionRepo, actionRef, { heading: stepHeading, actionName, runCommand } = {}) {
+	let isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts", markdown = `## ${`Outbound Traffic Report${stepHeading ? ` — ${stepHeading}` : ""}`} (${report.parameters.mode} mode)\n\n`;
+	return report.passed.length > 0 && (markdown += `### ${heading}\n\n` + renderHostTable(report.passed) + "\n"), isAudit && (markdown += buildRestrictExample(report.passed, actionRepo, actionRef, {
+		actionName,
+		runCommand
+	})), report.blocked.length > 0 && (report.passed.length > 0 && (markdown += "\n"), markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(report.blocked, {
+		showReason: !0,
+		showExpected
+	}) + "\n"), report.passed.length === 0 && report.blocked.length === 0 && (markdown += "_(no communication)_\n\n"), report.engine === "explicit" ? markdown += renderCommunicationDetails(report.proxyLogs.builds, report.proxyLogs.denied) : markdown += "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n", markdown += `\n*Reported by [Buildcage](https://github.com/${actionRepo})*\n`, markdown;
+}
+//#endregion
 //#region core/lib/log/aggregate.ts
 function compareAggregated(a, b) {
 	return b.count - a.count || (a.host < b.host ? -1 : +(a.host > b.host)) || Number(a.port) - Number(b.port);
@@ -8606,25 +8675,12 @@ async function buildTransparentReportData(lines, parameters) {
 function fetchReport(containerName, parameters) {
 	return buildTransparentReportData(createDocker().readFileLines(containerName, "/var/log/haproxy/current"), parameters);
 }
-function buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand } = {}) {
-	let heading = `Outbound Traffic Report${stepLabel ? ` — ${stepLabel}` : ""}`, isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, markdown = `## ${heading} (${report.parameters.mode} mode)\n\n`;
-	return isAudit ? (report.passed.length > 0 && (markdown += "### 📋 Audited Hosts\n\n" + renderHostTable(report.passed) + "\n\n"), actionRepo && (markdown += buildRestrictExample(report.passed, actionRepo, actionRef, {
-		actionName: "run",
-		runCommand
-	})), report.blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(report.blocked, {
-		showReason: !0,
-		showExpected
-	}) + "\n\n")) : (report.passed.length > 0 && (markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(report.passed) + "\n\n"), report.blocked.length > 0 && (markdown += "### 🚫 Blocked Hosts\n\n" + renderHostTable(report.blocked, {
-		showReason: !0,
-		showExpected
-	}) + "\n\n")), markdown;
-}
 /**
 * Pure decision + rendering step, kept free of process.env/file I/O so it's
 * testable without touching the filesystem — see main.ts's writeReportSummary
 * for the side-effecting half (actual summary/annotation output).
 */
-function computeReportOutcome(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand } = {}) {
+function computeReportOutcome(report, { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand }) {
 	let { level, message, shouldFail } = describeBlockedOutcome({
 		isAudit: report.parameters.mode === "audit",
 		failOnBlocked: failOnBlocked ?? !1,
@@ -8634,10 +8690,9 @@ function computeReportOutcome(report, { stepLabel, failOnBlocked, actionRepo, ac
 		engineLabel: "sandbox"
 	});
 	return {
-		markdown: buildReportMarkdown(report, {
-			stepLabel,
-			actionRepo,
-			actionRef,
+		markdown: renderReportMarkdown(report, actionRepo, actionRef, {
+			heading: stepLabel,
+			actionName: "run",
 			runCommand
 		}),
 		message,

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8571,8 +8571,8 @@ function formatDuration(started, completed) {
 /** Branches on `report.engine`/`report.parameters.mode` rather than being
 *  duplicated per engine. actionRepo/actionRef are real values, not
 *  placeholders — this runs on the runner, with process.env available. */
-function renderReportMarkdown(report, actionRepo, actionRef, { headingSuffix, actionName, runCommand } = {}) {
-	let isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts", markdown = `## ${`Outbound Traffic Report${headingSuffix ?? ""}`} (${report.parameters.mode} mode)\n\n`;
+function renderReportMarkdown(report, actionRepo, actionRef, { title = "Outbound Traffic Report", actionName, runCommand } = {}) {
+	let isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts", markdown = `## ${title} (${report.parameters.mode} mode)\n\n`;
 	return report.passed.length > 0 && (markdown += `### ${heading}\n\n` + renderHostTable(report.passed) + "\n"), isAudit && (markdown += buildRestrictExample(report.passed, actionRepo, actionRef, {
 		actionName,
 		runCommand
@@ -8691,7 +8691,7 @@ function computeReportOutcome(report, { stepLabel, failOnBlocked, actionRepo, ac
 	});
 	return {
 		markdown: renderReportMarkdown(report, actionRepo, actionRef, {
-			headingSuffix: stepLabel ? ` — ${stepLabel}` : void 0,
+			title: stepLabel ? `Outbound Traffic Report — ${stepLabel}` : void 0,
 			actionName: "run",
 			runCommand
 		}),

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8571,8 +8571,8 @@ function formatDuration(started, completed) {
 /** Branches on `report.engine`/`report.parameters.mode` rather than being
 *  duplicated per engine. actionRepo/actionRef are real values, not
 *  placeholders — this runs on the runner, with process.env available. */
-function renderReportMarkdown(report, actionRepo, actionRef, { heading: stepHeading, actionName, runCommand } = {}) {
-	let isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts", markdown = `## ${`Outbound Traffic Report${stepHeading ? ` — ${stepHeading}` : ""}`} (${report.parameters.mode} mode)\n\n`;
+function renderReportMarkdown(report, actionRepo, actionRef, { headingSuffix, actionName, runCommand } = {}) {
+	let isAudit = report.parameters.mode === "audit", showExpected = report.parameters.knownBlockedRules.length > 0, heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts", markdown = `## ${`Outbound Traffic Report${headingSuffix ?? ""}`} (${report.parameters.mode} mode)\n\n`;
 	return report.passed.length > 0 && (markdown += `### ${heading}\n\n` + renderHostTable(report.passed) + "\n"), isAudit && (markdown += buildRestrictExample(report.passed, actionRepo, actionRef, {
 		actionName,
 		runCommand
@@ -8691,7 +8691,7 @@ function computeReportOutcome(report, { stepLabel, failOnBlocked, actionRepo, ac
 	});
 	return {
 		markdown: renderReportMarkdown(report, actionRepo, actionRef, {
-			heading: stepLabel,
+			headingSuffix: stepLabel ? ` — ${stepLabel}` : void 0,
 			actionName: "run",
 			runCommand
 		}),

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import { computeReportOutcome, buildReportMarkdown, type Report } from "./report.ts";
+import { computeReportOutcome, type Report, type ComputeReportOutcomeOptions } from "./report.ts";
 import { annotateKnownBlocked } from "../../../core/lib/report/known-blocked.ts";
 import type { GenReportParameters } from "../../../core/lib/report/report-data.ts";
 
@@ -16,9 +16,15 @@ function parameters(overrides: Partial<GenReportParameters> = {}): GenReportPara
   };
 }
 
+function options(
+  overrides: Partial<ComputeReportOutcomeOptions> = {},
+): ComputeReportOutcomeOptions {
+  return { actionRepo: "dash14/buildcage", actionRef: "v2", ...overrides };
+}
+
 // blocked rows are already expected to be annotated by the time a Report
-// reaches computeReportOutcome/buildReportMarkdown (see build-transparent-report-data.ts)
-// — this mirrors that, applying parameters.knownBlockedRules the same way.
+// reaches computeReportOutcome (see build-transparent-report-data.ts) —
+// this mirrors that, applying parameters.knownBlockedRules the same way.
 function report(overrides: Partial<Report> = {}): Report {
   const params = overrides.parameters ?? parameters();
   return {
@@ -34,10 +40,14 @@ function report(overrides: Partial<Report> = {}): Report {
 
 // The decision matrix itself is tested elsewhere; these only verify
 // shouldFail and the rendered markdown combine correctly.
+// The decision matrix itself is tested elsewhere; these only verify
+// shouldFail and the rendered markdown combine correctly. Markdown content
+// itself is covered by render-report-markdown.test.ts, which
+// computeReportOutcome delegates to.
 describe("computeReportOutcome", () => {
   it("does not fail when there are no blocked connections", () => {
     const r = report({ blockedCount: 0 });
-    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, false);
+    assert.equal(computeReportOutcome(r, options({ failOnBlocked: true })).shouldFail, false);
   });
 
   it("fails when blocked connections are detected and failOnBlocked is true", () => {
@@ -56,7 +66,7 @@ describe("computeReportOutcome", () => {
         [],
       ),
     });
-    assert.equal(computeReportOutcome(r, { failOnBlocked: true }).shouldFail, true);
+    assert.equal(computeReportOutcome(r, options({ failOnBlocked: true })).shouldFail, true);
   });
 
   // Audit's outcome never depends on known_blocked_rules matching, so the
@@ -71,118 +81,24 @@ describe("computeReportOutcome", () => {
         knownBlockedRules,
       ),
     });
-    const outcome = computeReportOutcome(r, { failOnBlocked: true });
+    const outcome = computeReportOutcome(r, options({ failOnBlocked: true }));
     assert.equal(outcome.level, "notice");
     assert.equal(outcome.message, "2 blocked connection(s) detected by buildcage sandbox");
   });
-});
 
-describe("buildReportMarkdown", () => {
-  it("includes a restrict-mode example (as a `run` step) in audit mode with audited hosts", () => {
+  it("passes stepLabel/runCommand through to the rendered markdown", () => {
     const r = report({
       parameters: parameters({ mode: "audit" }),
       passed: [
         { host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", reason: "-", count: 3 },
       ],
     });
-    const markdown = buildReportMarkdown(r, {
-      actionRepo: "dash14/buildcage",
-      actionRef: "v2",
-      runCommand: "npm install",
-    });
-    assert.match(markdown, /Switch to restrict mode/);
+    const { markdown } = computeReportOutcome(
+      r,
+      options({ stepLabel: "npm install", runCommand: "npm install" }),
+    );
+    assert.match(markdown, /^## Outbound Traffic Report — npm install \(audit mode\)/);
     assert.match(markdown, /uses: dash14\/buildcage\/run@v2/);
     assert.match(markdown, /run: \|\n\s+npm install/);
-    assert.match(markdown, /allowed_https_rules: >-\n\s+registry\.npmjs\.org:443/);
-  });
-
-  it("omits the restrict-mode example in restrict mode", () => {
-    const r = report({
-      passed: [
-        { host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", reason: "-", count: 3 },
-      ],
-    });
-    const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
-    assert.doesNotMatch(markdown, /Switch to restrict mode/);
-  });
-
-  it("omits the restrict-mode example in audit mode with no audited hosts", () => {
-    const r = report({ parameters: parameters({ mode: "audit" }) });
-    const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
-    assert.doesNotMatch(markdown, /Switch to restrict mode/);
-  });
-
-  it("uses a level-2 heading matching the report action's wording", () => {
-    const markdown = buildReportMarkdown(report(), {
-      actionRepo: "dash14/buildcage",
-      actionRef: "v2",
-    });
-    assert.match(markdown, /^## Outbound Traffic Report \(restrict mode\)\n/);
-  });
-
-  it("appends stepLabel to the heading to tell steps apart", () => {
-    const markdown = buildReportMarkdown(report(), {
-      actionRepo: "dash14/buildcage",
-      actionRef: "v2",
-      stepLabel: "npm install",
-    });
-    assert.match(markdown, /^## Outbound Traffic Report — npm install \(restrict mode\)\n/);
-  });
-
-  it("renders just the heading, no tables, when nothing passed or was blocked", () => {
-    const markdown = buildReportMarkdown(report(), { stepLabel: "npm install" });
-    assert.match(markdown, /^## Outbound Traffic Report — npm install \(restrict mode\)\n\n$/);
-  });
-
-  it("adds an Expected column marking known_blocked_rules matches when set", () => {
-    const knownBlockedRules = ["known-bad.example.com:443"];
-    const blocked = annotateKnownBlocked(
-      [
-        {
-          host: "known-bad.example.com",
-          port: "443",
-          ruleType: "HTTPS",
-          reason: "not in allowlist",
-          count: 1,
-        },
-        {
-          host: "unexpected.example.com",
-          port: "443",
-          ruleType: "HTTPS",
-          reason: "not in allowlist",
-          count: 1,
-        },
-      ],
-      knownBlockedRules,
-    );
-    const r = report({ parameters: parameters({ knownBlockedRules }), blocked, blockedCount: 2 });
-    const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
-    assert.match(markdown, /\| Host \| Rule \| Reason \| Count \| Expected \|/);
-    assert.match(
-      markdown,
-      /\| known-bad\.example\.com:443 \| HTTPS \| not in allowlist \| 1 \| ✅ \|/,
-    );
-    assert.match(
-      markdown,
-      /\| unexpected\.example\.com:443 \| HTTPS \| not in allowlist \| 1 \| {2}\|/,
-    );
-  });
-
-  it("omits the Expected column when known_blocked_rules is not set", () => {
-    const blocked = annotateKnownBlocked(
-      [
-        {
-          host: "evil.example.com",
-          port: "443",
-          ruleType: "HTTPS",
-          reason: "not in allowlist",
-          count: 1,
-        },
-      ],
-      [],
-    );
-    const r = report({ blocked, blockedCount: 1 });
-    const markdown = buildReportMarkdown(r, { actionRepo: "dash14/buildcage", actionRef: "v2" });
-    assert.doesNotMatch(markdown, /Expected/);
   });
 });

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -1,7 +1,6 @@
 import { createDocker } from "../../../core/lib/docker/client.ts";
-import { buildRestrictExample } from "../../../core/lib/report/build-example.ts";
 import { describeBlockedOutcome } from "../../../core/lib/report/known-blocked.ts";
-import { renderHostTable } from "../../../core/lib/report/host-table.ts";
+import { renderReportMarkdown } from "../../../core/lib/report/render-report-markdown.ts";
 import { buildTransparentReportData } from "../../../core/lib/report/build-transparent-report-data.ts";
 import type {
   GenReportParameters,
@@ -27,51 +26,11 @@ export function fetchReport(
   );
 }
 
-export interface ReportRenderContext {
+export interface ComputeReportOutcomeOptions {
   stepLabel?: string;
-  actionRepo?: string;
-  actionRef?: string;
+  actionRepo: string;
+  actionRef: string;
   runCommand?: string;
-}
-
-export function buildReportMarkdown(
-  report: Report,
-  { stepLabel, actionRepo, actionRef, runCommand }: ReportRenderContext = {},
-): string {
-  // Mirrors report/src/main.ts's heading, so both actions read alike.
-  const heading = `Outbound Traffic Report${stepLabel ? ` — ${stepLabel}` : ""}`;
-  const isAudit = report.parameters.mode === "audit";
-  const showExpected = report.parameters.knownBlockedRules.length > 0;
-  let markdown = `## ${heading} (${report.parameters.mode} mode)\n\n`;
-
-  if (isAudit) {
-    if (report.passed.length > 0)
-      markdown += "### 📋 Audited Hosts\n\n" + renderHostTable(report.passed) + "\n\n";
-    if (actionRepo) {
-      markdown += buildRestrictExample(report.passed, actionRepo, actionRef, {
-        actionName: "run",
-        runCommand,
-      });
-    }
-    if (report.blocked.length > 0)
-      markdown +=
-        "### 🚫 Blocked Hosts\n\n" +
-        renderHostTable(report.blocked, { showReason: true, showExpected }) +
-        "\n\n";
-  } else {
-    if (report.passed.length > 0)
-      markdown += "### ✅ Allowed Hosts\n\n" + renderHostTable(report.passed) + "\n\n";
-    if (report.blocked.length > 0)
-      markdown +=
-        "### 🚫 Blocked Hosts\n\n" +
-        renderHostTable(report.blocked, { showReason: true, showExpected }) +
-        "\n\n";
-  }
-
-  return markdown;
-}
-
-export interface ComputeReportOutcomeOptions extends ReportRenderContext {
   failOnBlocked?: boolean;
 }
 
@@ -89,7 +48,7 @@ export interface ReportOutcome {
  */
 export function computeReportOutcome(
   report: Report,
-  { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand }: ComputeReportOutcomeOptions = {},
+  { stepLabel, failOnBlocked, actionRepo, actionRef, runCommand }: ComputeReportOutcomeOptions,
 ): ReportOutcome {
   const { level, message, shouldFail } = describeBlockedOutcome({
     isAudit: report.parameters.mode === "audit",
@@ -99,7 +58,11 @@ export function computeReportOutcome(
     logLooksPlausible: report.logLooksPlausible,
     engineLabel: "sandbox",
   });
-  const markdown = buildReportMarkdown(report, { stepLabel, actionRepo, actionRef, runCommand });
+  const markdown = renderReportMarkdown(report, actionRepo, actionRef, {
+    heading: stepLabel,
+    actionName: "run",
+    runCommand,
+  });
 
   return { markdown, message, level, shouldFail };
 }

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -59,7 +59,7 @@ export function computeReportOutcome(
     engineLabel: "sandbox",
   });
   const markdown = renderReportMarkdown(report, actionRepo, actionRef, {
-    heading: stepLabel,
+    headingSuffix: stepLabel ? ` — ${stepLabel}` : undefined,
     actionName: "run",
     runCommand,
   });

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -59,7 +59,7 @@ export function computeReportOutcome(
     engineLabel: "sandbox",
   });
   const markdown = renderReportMarkdown(report, actionRepo, actionRef, {
-    headingSuffix: stepLabel ? ` — ${stepLabel}` : undefined,
+    title: stepLabel ? `Outbound Traffic Report — ${stepLabel}` : undefined,
     actionName: "run",
     runCommand,
   });

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage",
     process.env.GITHUB_ACTION_REF || "v2",
-    { heading: "during Docker Build" },
+    { headingSuffix: " during Docker Build" },
   );
 
   await writeStepSummary(markdown);

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -82,6 +82,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage",
     process.env.GITHUB_ACTION_REF || "v2",
+    { heading: "during Docker Build" },
   );
 
   await writeStepSummary(markdown);

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -82,7 +82,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage",
     process.env.GITHUB_ACTION_REF || "v2",
-    { headingSuffix: " during Docker Build" },
+    { title: "Outbound Traffic Report during Docker Build" },
   );
 
   await writeStepSummary(markdown);

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage",
     process.env.GITHUB_ACTION_REF || "v2",
-    { headingSuffix: " during Docker Build" },
+    { title: "Outbound Traffic Report during Docker Build" },
   );
 
   await writeStepSummary(markdown);

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage",
     process.env.GITHUB_ACTION_REF || "v2",
-    { heading: "during Docker Build" },
+    { headingSuffix: " during Docker Build" },
   );
 
   await writeStepSummary(markdown);

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -35,6 +35,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "dash14/buildcage",
     process.env.GITHUB_ACTION_REF || "v2",
+    { heading: "during Docker Build" },
   );
 
   await writeStepSummary(markdown);


### PR DESCRIPTION
## Summary

`renderReportMarkdown` (used by the setup/report actions) and `run`'s own `buildReportMarkdown` rendered nearly the same Job Summary markdown independently, with a few features only on one side: `renderReportMarkdown` added a "(no communication)" note, an engine-specific caveat (SNI note or per-command communication details), and a footer, none of which `run`'s reports had.

This unifies both onto `renderReportMarkdown`, and brings `run`'s Job Summary output in line with setup/report's — it now also gets the SNI caveat (accurate for `run` too: its proxy image is transparent's network stack with buildkitd removed, so the detection method is identical), the no-communication note, and the footer.

Each caller passes the full heading `title` string rather than a fragment to be concatenated, so there's no shared separator logic to get subtly wrong: setup/report keep their original "Outbound Traffic Report during Docker Build" text unchanged, and `run` still shows its per-step label as "Outbound Traffic Report — npm install" only when one is set, or the bare default otherwise (`run` runs an arbitrary command, not a Docker build, so it never gets that wording). An `actionName` option makes the restrict-mode example point at the right action.

## Changes

- Add `title`/`actionName`/`runCommand` options to `renderReportMarkdown`, covering the run-specific cases the old `buildReportMarkdown` handled.
- Point both `report-action.node.ts` scripts at the new `title` option (previously hardcoded into the function itself).
- Remove `run/src/lib/report.ts`'s own `buildReportMarkdown` and `ReportRenderContext`; `computeReportOutcome` now calls the shared `renderReportMarkdown` directly. `actionRepo`/`actionRef` are now required (every real caller already supplied them).
- Move the run-specific markdown assertions (restrict-mode example with a `run:` command, stepLabel heading, Expected column) into `render-report-markdown.test.ts`, alongside the equivalent report-action coverage.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/ setup/src report/src run/src`
- [x] `make test_unit` (including the QuickJS suite)
- [x] `vp run build` / `pnpm run build:scripts` — dist rebuilt and committed
- [x] Manually verified the three heading variants (setup/report, run without a label, run with a label) render as expected