### PR TITLE
refactor: split core/lib/report into type/render/build/outcome layers

### DIFF
--- a/core/lib/report/build/explicit.test.ts
+++ b/core/lib/report/build/explicit.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { buildExplicitReportData } from "./build-explicit-report-data.ts";
-import type { GenReportParameters } from "./report-data.ts";
-import type { VertexAllowedEntry } from "../log/vertex-log.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { buildExplicitReportData } from "./explicit.ts";
+import type { GenReportParameters } from "../types.ts";
+import type { VertexAllowedEntry } from "../../log/vertex-log.ts";
 
 function params(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {

--- a/core/lib/report/build/explicit.ts
+++ b/core/lib/report/build/explicit.ts
@@ -1,7 +1,7 @@
-import { scanBuildkitdLog } from "../log/buildkitd-log-parser.ts";
-import { aggregateAllowedHosts, type VertexAllowedEntry } from "../log/vertex-log.ts";
-import { annotateKnownBlocked } from "./known-blocked.ts";
-import type { GenReportParameters, ExplicitReportData } from "./report-data.ts";
+import { scanBuildkitdLog } from "../../log/buildkitd-log-parser.ts";
+import { aggregateAllowedHosts, type VertexAllowedEntry } from "../../log/vertex-log.ts";
+import { annotateKnownBlocked } from "../outcome/annotate-known-blocked.ts";
+import type { GenReportParameters, ExplicitReportData } from "../types.ts";
 
 /** Pure — no I/O; callers fetch lines/builds/parameters themselves. */
 export async function buildExplicitReportData(

--- a/core/lib/report/build/transparent.test.ts
+++ b/core/lib/report/build/transparent.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { buildTransparentReportData } from "./build-transparent-report-data.ts";
-import type { GenReportParameters } from "./report-data.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { buildTransparentReportData } from "./transparent.ts";
+import type { GenReportParameters } from "../types.ts";
 
 function params(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {

--- a/core/lib/report/build/transparent.ts
+++ b/core/lib/report/build/transparent.ts
@@ -1,6 +1,6 @@
-import { scanHaproxyLog } from "../log/haproxy-log-parser.ts";
-import { annotateKnownBlocked } from "./known-blocked.ts";
-import type { GenReportParameters, TransparentReportData } from "./report-data.ts";
+import { scanHaproxyLog } from "../../log/haproxy-log-parser.ts";
+import { annotateKnownBlocked } from "../outcome/annotate-known-blocked.ts";
+import type { GenReportParameters, TransparentReportData } from "../types.ts";
 
 /**
  * Pure — no I/O; callers (report-action.node.ts, run/src/lib/report.ts)

--- a/core/lib/report/outcome/annotate-known-blocked.test.ts
+++ b/core/lib/report/outcome/annotate-known-blocked.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { annotateKnownBlocked } from "./annotate-known-blocked.ts";
+
+describe("annotateKnownBlocked", () => {
+  const row = (overrides = {}) => ({
+    host: "evil.example.com",
+    port: "443",
+    ruleType: "HTTPS",
+    reason: "not in allowlist",
+    count: 3,
+    ...overrides,
+  });
+
+  it("marks all rows as not expected when no rules are given", () => {
+    const result = annotateKnownBlocked([row()], []);
+    assert.equal(result[0].expected, false);
+  });
+
+  it("marks a row as expected on an exact host:port match", () => {
+    const result = annotateKnownBlocked([row()], ["evil.example.com:443"]);
+    assert.equal(result[0].expected, true);
+  });
+
+  it("marks a row as expected on a wildcard match", () => {
+    const result = annotateKnownBlocked([row()], ["*.example.com:443"]);
+    assert.equal(result[0].expected, true);
+  });
+
+  it("marks a row as expected on a ~regex match", () => {
+    const result = annotateKnownBlocked([row()], ["~^evil\\.example\\.com:443$"]);
+    assert.equal(result[0].expected, true);
+  });
+
+  it("does not match when the port differs", () => {
+    const result = annotateKnownBlocked([row({ port: "80" })], ["evil.example.com:443"]);
+    assert.equal(result[0].expected, false);
+  });
+
+  it("preserves the original row fields", () => {
+    const result = annotateKnownBlocked([row()], []);
+    assert.equal(result[0].host, "evil.example.com");
+    assert.equal(result[0].port, "443");
+    assert.equal(result[0].ruleType, "HTTPS");
+    assert.equal(result[0].reason, "not in allowlist");
+    assert.equal(result[0].count, 3);
+  });
+
+  it("annotates each row independently across a mixed list", () => {
+    const result = annotateKnownBlocked(
+      [row({ host: "known.example.com" }), row({ host: "unknown.example.com" })],
+      ["known.example.com:443"],
+    );
+    assert.equal(result[0].expected, true);
+    assert.equal(result[1].expected, false);
+  });
+});
+
+reportResults();

--- a/core/lib/report/outcome/annotate-known-blocked.ts
+++ b/core/lib/report/outcome/annotate-known-blocked.ts
@@ -1,0 +1,29 @@
+import { convertRule } from "../../acl/wildcard-rules.ts";
+import type { AggregatedEntry } from "../../log/aggregate.ts";
+
+export type BlockedRow = AggregatedEntry;
+
+export interface AnnotatedBlockedRow extends BlockedRow {
+  expected: boolean;
+}
+
+export interface ExpectedFlag {
+  expected: boolean;
+}
+
+/**
+ * Tag each aggregated blocked-hosts row with `expected: boolean` — true iff
+ * its `host:port` matches at least one known_blocked_rules pattern.
+ *
+ * knownBlockedRules is as returned by parseAndValidateRules.
+ */
+export function annotateKnownBlocked(
+  blockedRows: BlockedRow[],
+  knownBlockedRules: string[],
+): AnnotatedBlockedRow[] {
+  const matchers = knownBlockedRules.map((rule) => new RegExp(convertRule(rule)));
+  return blockedRows.map((row) => ({
+    ...row,
+    expected: matchers.some((re) => re.test(`${row.host}:${row.port}`)),
+  }));
+}

--- a/core/lib/report/outcome/blocked-outcome.test.ts
+++ b/core/lib/report/outcome/blocked-outcome.test.ts
@@ -1,64 +1,9 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
 import {
-  annotateKnownBlocked,
   determineBlockedOutcome,
   buildBlockedMessage,
   describeBlockedOutcome,
-} from "./known-blocked.ts";
-
-describe("annotateKnownBlocked", () => {
-  const row = (overrides = {}) => ({
-    host: "evil.example.com",
-    port: "443",
-    ruleType: "HTTPS",
-    reason: "not in allowlist",
-    count: 3,
-    ...overrides,
-  });
-
-  it("marks all rows as not expected when no rules are given", () => {
-    const result = annotateKnownBlocked([row()], []);
-    assert.equal(result[0].expected, false);
-  });
-
-  it("marks a row as expected on an exact host:port match", () => {
-    const result = annotateKnownBlocked([row()], ["evil.example.com:443"]);
-    assert.equal(result[0].expected, true);
-  });
-
-  it("marks a row as expected on a wildcard match", () => {
-    const result = annotateKnownBlocked([row()], ["*.example.com:443"]);
-    assert.equal(result[0].expected, true);
-  });
-
-  it("marks a row as expected on a ~regex match", () => {
-    const result = annotateKnownBlocked([row()], ["~^evil\\.example\\.com:443$"]);
-    assert.equal(result[0].expected, true);
-  });
-
-  it("does not match when the port differs", () => {
-    const result = annotateKnownBlocked([row({ port: "80" })], ["evil.example.com:443"]);
-    assert.equal(result[0].expected, false);
-  });
-
-  it("preserves the original row fields", () => {
-    const result = annotateKnownBlocked([row()], []);
-    assert.equal(result[0].host, "evil.example.com");
-    assert.equal(result[0].port, "443");
-    assert.equal(result[0].ruleType, "HTTPS");
-    assert.equal(result[0].reason, "not in allowlist");
-    assert.equal(result[0].count, 3);
-  });
-
-  it("annotates each row independently across a mixed list", () => {
-    const result = annotateKnownBlocked(
-      [row({ host: "known.example.com" }), row({ host: "unknown.example.com" })],
-      ["known.example.com:443"],
-    );
-    assert.equal(result[0].expected, true);
-    assert.equal(result[1].expected, false);
-  });
-});
+} from "./blocked-outcome.ts";
 
 describe("determineBlockedOutcome", () => {
   it("returns none when there are no blocked connections", () => {

--- a/core/lib/report/outcome/blocked-outcome.ts
+++ b/core/lib/report/outcome/blocked-outcome.ts
@@ -1,47 +1,13 @@
-/**
- * Shared logic for `known_blocked_rules`: domains expected to be blocked,
- * so a matching blocked connection doesn't fail the step even when
- * fail_on_blocked is true. Never sent to the container's ACL — only
- * affects this action's pass/fail decision and Job Summary rendering.
- */
-import { convertRule } from "../acl/wildcard-rules.ts";
-import type { AggregatedEntry } from "../log/aggregate.ts";
-
-export type BlockedRow = AggregatedEntry;
-
-export interface AnnotatedBlockedRow extends BlockedRow {
-  expected: boolean;
-}
-
-export interface ExpectedFlag {
-  expected: boolean;
-}
-
-/**
- * Tag each aggregated blocked-hosts row with `expected: boolean` — true iff
- * its `host:port` matches at least one known_blocked_rules pattern.
- *
- * knownBlockedRules is as returned by parseAndValidateRules.
- */
-export function annotateKnownBlocked(
-  blockedRows: BlockedRow[],
-  knownBlockedRules: string[],
-): AnnotatedBlockedRow[] {
-  const matchers = knownBlockedRules.map((rule) => new RegExp(convertRule(rule)));
-  return blockedRows.map((row) => ({
-    ...row,
-    expected: matchers.some((re) => re.test(`${row.host}:${row.port}`)),
-  }));
-}
+import type { ExpectedFlag } from "./annotate-known-blocked.ts";
 
 /**
  * Decide whether blocked connections should fail the step.
  *
  * `blockedRows` must already be annotated via annotateKnownBlocked. Uses
  * per-row matching rather than count arithmetic because `blockedCount`'s
- * meaning differs by proxy engine (see report-data.ts), so subtracting
- * summed row counts from it isn't reliable. An empty `blockedRows` with a
- * nonzero `blockedCount` is treated as unexpected too (fail closed).
+ * meaning differs by proxy engine, so subtracting summed row counts from it
+ * isn't reliable. An empty `blockedRows` with a nonzero `blockedCount` is
+ * treated as unexpected too (fail closed).
  */
 export interface BlockedOutcome {
   level: "none" | "notice" | "error";
@@ -53,7 +19,7 @@ export interface DetermineBlockedOutcomeOptions {
   failOnBlocked: boolean;
   blockedCount: number;
   blockedRows: ExpectedFlag[];
-  /** See report-data.ts's ReportDataCommon.logLooksPlausible. */
+  /** See ReportDataCommon.logLooksPlausible. */
   logLooksPlausible: boolean;
 }
 

--- a/core/lib/report/outcome/emit-blocked-outcome.test.ts
+++ b/core/lib/report/outcome/emit-blocked-outcome.test.ts
@@ -2,8 +2,8 @@ import { describe, it, beforeEach, afterEach, vi } from "vitest";
 import assert from "node:assert/strict";
 
 import { emitBlockedOutcome } from "./emit-blocked-outcome.ts";
-import { annotateKnownBlocked } from "./known-blocked.ts";
-import type { ReportDataCommon, GenReportParameters } from "./report-data.ts";
+import { annotateKnownBlocked } from "./annotate-known-blocked.ts";
+import type { ReportDataCommon, GenReportParameters } from "../types.ts";
 
 let prevExitCode: number | string | null | undefined;
 

--- a/core/lib/report/outcome/emit-blocked-outcome.ts
+++ b/core/lib/report/outcome/emit-blocked-outcome.ts
@@ -1,7 +1,7 @@
 /** Emits an annotation and sets the exit code for a blocked-connection outcome. */
-import { createAnnotation } from "../actions/annotation.ts";
-import { describeBlockedOutcome } from "./known-blocked.ts";
-import type { ReportDataCommon } from "./report-data.ts";
+import { createAnnotation } from "../../actions/annotation.ts";
+import { describeBlockedOutcome } from "./blocked-outcome.ts";
+import type { ReportDataCommon } from "../types.ts";
 
 export interface EmitBlockedOutcomeOptions {
   failOnBlocked: boolean;

--- a/core/lib/report/parameters.test.ts
+++ b/core/lib/report/parameters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { buildReportParameters } from "./report-parameters.ts";
+import { buildReportParameters } from "./parameters.ts";
 
 describe("buildReportParameters", () => {
   it("tokenizes each rules field and passes mode through", () => {

--- a/core/lib/report/parameters.ts
+++ b/core/lib/report/parameters.ts
@@ -1,11 +1,10 @@
 import { splitRuleTokens } from "../acl/wildcard-rules.ts";
-import type { GenReportParameters } from "./report-data.ts";
+import type { GenReportParameters } from "./types.ts";
 
 /**
  * Builds GenReportParameters from a container's own env (as read via
- * docker inspect, see core/lib/docker/container-env.ts) or, for run, from
- * an equivalent env-shaped record it already holds in memory. Same env var
- * names for both engines.
+ * docker inspect) or, for run, from an equivalent env-shaped record it
+ * already holds in memory. Same env var names for both engines.
  */
 export function buildReportParameters(
   env: Record<string, string | undefined>,

--- a/core/lib/report/render/build-example.test.ts
+++ b/core/lib/report/render/build-example.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
 import { buildRestrictExample } from "./build-example.ts";
 
 const REPO = "dash14/buildcage";

--- a/core/lib/report/render/build-example.ts
+++ b/core/lib/report/render/build-example.ts
@@ -1,4 +1,4 @@
-import type { AggregatedEntry } from "../log/aggregate.ts";
+import type { AggregatedEntry } from "../../log/aggregate.ts";
 
 const ruleTypeToParam: Record<string, string> = {
   HTTPS: "allowed_https_rules",

--- a/core/lib/report/render/communication-details.test.ts
+++ b/core/lib/report/render/communication-details.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
-import { renderCommunicationDetails } from "./command-log.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { renderCommunicationDetails } from "./communication-details.ts";
 
 function wrap(body: string) {
   return "\n<details>\n<summary>💬 Communication details</summary>\n\n" + body + "</details>\n";

--- a/core/lib/report/render/communication-details.ts
+++ b/core/lib/report/render/communication-details.ts
@@ -1,5 +1,5 @@
-import type { AllowedRequest, VertexAllowedEntry } from "../log/vertex-log.ts";
-import type { DeniedEntry } from "./report-data.ts";
+import type { AllowedRequest, VertexAllowedEntry } from "../../log/vertex-log.ts";
+import type { DeniedEntry } from "../types.ts";
 
 /**
  * Render the explicit engine's communication detail as a collapsed markdown

--- a/core/lib/report/render/host-table.test.ts
+++ b/core/lib/report/render/host-table.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
 import { renderHostTable } from "./host-table.ts";
 
 describe("renderHostTable", () => {

--- a/core/lib/report/render/host-table.ts
+++ b/core/lib/report/render/host-table.ts
@@ -1,5 +1,5 @@
-import { markdownTable, type ColumnFormat } from "../general/markdown-table.ts";
-import type { AggregatedEntry } from "../log/aggregate.ts";
+import { markdownTable, type ColumnFormat } from "../../general/markdown-table.ts";
+import type { AggregatedEntry } from "../../log/aggregate.ts";
 
 export interface HostTableRow extends Omit<AggregatedEntry, "reason"> {
   reason?: string;

--- a/core/lib/report/render/render-report-markdown.test.ts
+++ b/core/lib/report/render/render-report-markdown.test.ts
@@ -1,10 +1,6 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
 import { renderReportMarkdown } from "./render-report-markdown.ts";
-import type {
-  GenReportParameters,
-  TransparentReportData,
-  ExplicitReportData,
-} from "./report-data.ts";
+import type { GenReportParameters, TransparentReportData, ExplicitReportData } from "../types.ts";
 
 function params(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {

--- a/core/lib/report/render/render-report-markdown.ts
+++ b/core/lib/report/render/render-report-markdown.ts
@@ -1,7 +1,7 @@
 import { renderHostTable } from "./host-table.ts";
 import { buildRestrictExample } from "./build-example.ts";
-import { renderCommunicationDetails } from "./command-log.ts";
-import type { ReportData } from "./report-data.ts";
+import { renderCommunicationDetails } from "./communication-details.ts";
+import type { ReportData } from "../types.ts";
 
 export interface RenderReportMarkdownOptions {
   /** Full heading text, e.g. "Outbound Traffic Report during Docker Build"

--- a/core/lib/report/types.ts
+++ b/core/lib/report/types.ts
@@ -1,5 +1,5 @@
-import type { HostTableRow } from "./host-table.ts";
-import type { AnnotatedBlockedRow } from "./known-blocked.ts";
+import type { HostTableRow } from "./render/host-table.ts";
+import type { AnnotatedBlockedRow } from "./outcome/annotate-known-blocked.ts";
 import type { VertexAllowedEntry } from "../log/vertex-log.ts";
 
 /** Echoed back verbatim rather than re-derived — only the container's own
@@ -31,8 +31,8 @@ export interface ReportDataCommon {
   /** False iff the log looks structurally implausible for a real run (no
    *  non-buildcage/non-denial content at all) — see haproxy-log-parser.ts's
    *  hasNonBuildcageContent / buildkitd-log-parser.ts's hasNonDenialContent.
-   *  Used by known-blocked.ts to fail closed on a suspiciously empty log
-   *  instead of treating it as "nothing was blocked". */
+   *  Used to fail closed on a suspiciously empty log instead of treating it
+   *  as "nothing was blocked". */
   logLooksPlausible: boolean;
 }
 

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8356,26 +8356,7 @@ function createDocker(run = defaultRunCommand, spawnDocker = defaultSpawnCommand
 	};
 }
 //#endregion
-//#region core/lib/report/known-blocked.ts
-/**
-* Shared logic for `known_blocked_rules`: domains expected to be blocked,
-* so a matching blocked connection doesn't fail the step even when
-* fail_on_blocked is true. Never sent to the container's ACL — only
-* affects this action's pass/fail decision and Job Summary rendering.
-*/
-/**
-* Tag each aggregated blocked-hosts row with `expected: boolean` — true iff
-* its `host:port` matches at least one known_blocked_rules pattern.
-*
-* knownBlockedRules is as returned by parseAndValidateRules.
-*/
-function annotateKnownBlocked(blockedRows, knownBlockedRules) {
-	let matchers = knownBlockedRules.map((rule) => new RegExp(convertRule(rule)));
-	return blockedRows.map((row) => ({
-		...row,
-		expected: matchers.some((re) => re.test(`${row.host}:${row.port}`))
-	}));
-}
+//#region core/lib/report/outcome/blocked-outcome.ts
 function determineBlockedOutcome({ isAudit, failOnBlocked, blockedCount, blockedRows, logLooksPlausible }) {
 	if (!blockedCount) return logLooksPlausible ? {
 		level: "none",
@@ -8447,7 +8428,7 @@ function markdownTable(formats, rows) {
 	return lines.join("\n");
 }
 //#endregion
-//#region core/lib/report/host-table.ts
+//#region core/lib/report/render/host-table.ts
 /**
 * Render aggregated host rows as a GitHub-flavored markdown table.
 */
@@ -8479,7 +8460,7 @@ function renderHostTable(rows, { showReason = !1, showExpected = !1 } = {}) {
 	})));
 }
 //#endregion
-//#region core/lib/report/build-example.ts
+//#region core/lib/report/render/build-example.ts
 const ruleTypeToParam = {
 	HTTPS: "allowed_https_rules",
 	HTTP: "allowed_http_rules",
@@ -8513,7 +8494,7 @@ function buildRestrictExample(auditedRows, actionRepo, actionRef, { actionName =
 	return md += "<summary>🛡️ Switch to restrict mode</summary>\n\n", md += "```yaml\n", md += yaml, md += "```\n\n", md += "</details>\n", md;
 }
 //#endregion
-//#region core/lib/report/command-log.ts
+//#region core/lib/report/render/communication-details.ts
 /**
 * Render the explicit engine's communication detail as a collapsed markdown
 * section, or "" if there's nothing to show. Allowed Urls is listed before
@@ -8567,7 +8548,7 @@ function formatDuration(started, completed) {
 	return `${((Date.parse(completed) - Date.parse(started)) / 1e3).toFixed(3)}s`;
 }
 //#endregion
-//#region core/lib/report/render-report-markdown.ts
+//#region core/lib/report/render/render-report-markdown.ts
 /** Branches on `report.engine`/`report.parameters.mode` rather than being
 *  duplicated per engine. actionRepo/actionRef are real values, not
 *  placeholders — this runs on the runner, with process.env available. */
@@ -8650,7 +8631,22 @@ async function scanHaproxyLog(lines, isAudit) {
 	};
 }
 //#endregion
-//#region core/lib/report/build-transparent-report-data.ts
+//#region core/lib/report/outcome/annotate-known-blocked.ts
+/**
+* Tag each aggregated blocked-hosts row with `expected: boolean` — true iff
+* its `host:port` matches at least one known_blocked_rules pattern.
+*
+* knownBlockedRules is as returned by parseAndValidateRules.
+*/
+function annotateKnownBlocked(blockedRows, knownBlockedRules) {
+	let matchers = knownBlockedRules.map((rule) => new RegExp(convertRule(rule)));
+	return blockedRows.map((row) => ({
+		...row,
+		expected: matchers.some((re) => re.test(`${row.host}:${row.port}`))
+	}));
+}
+//#endregion
+//#region core/lib/report/build/transparent.ts
 /**
 * Pure — no I/O; callers (report-action.node.ts, run/src/lib/report.ts)
 * fetch lines/parameters themselves. An empty input naturally yields
@@ -8732,7 +8728,8 @@ async function resolveVerifiedImage({ actionRef, actionRepo }) {
 	};
 }
 /**
-* Never sent to the container's ACL — see core/lib/report/known-blocked.ts.
+* Never sent to the container's ACL — used only for report-time annotation
+* of expected vs. unexpected blocked connections.
 */
 function readKnownBlockedRules(input) {
 	return parseRulesOrThrow(input);

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -2,8 +2,8 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { computeReportOutcome, type Report, type ComputeReportOutcomeOptions } from "./report.ts";
-import { annotateKnownBlocked } from "../../../core/lib/report/known-blocked.ts";
-import type { GenReportParameters } from "../../../core/lib/report/report-data.ts";
+import { annotateKnownBlocked } from "../../../core/lib/report/outcome/annotate-known-blocked.ts";
+import type { GenReportParameters } from "../../../core/lib/report/types.ts";
 
 function parameters(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {
@@ -23,8 +23,8 @@ function options(
 }
 
 // blocked rows are already expected to be annotated by the time a Report
-// reaches computeReportOutcome (see build-transparent-report-data.ts) —
-// this mirrors that, applying parameters.knownBlockedRules the same way.
+// reaches computeReportOutcome — this mirrors that, applying
+// parameters.knownBlockedRules the same way.
 function report(overrides: Partial<Report> = {}): Report {
   const params = overrides.parameters ?? parameters();
   return {

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -1,11 +1,8 @@
 import { createDocker } from "../../../core/lib/docker/client.ts";
-import { describeBlockedOutcome } from "../../../core/lib/report/known-blocked.ts";
-import { renderReportMarkdown } from "../../../core/lib/report/render-report-markdown.ts";
-import { buildTransparentReportData } from "../../../core/lib/report/build-transparent-report-data.ts";
-import type {
-  GenReportParameters,
-  TransparentReportData,
-} from "../../../core/lib/report/report-data.ts";
+import { describeBlockedOutcome } from "../../../core/lib/report/outcome/blocked-outcome.ts";
+import { renderReportMarkdown } from "../../../core/lib/report/render/render-report-markdown.ts";
+import { buildTransparentReportData } from "../../../core/lib/report/build/transparent.ts";
+import type { GenReportParameters, TransparentReportData } from "../../../core/lib/report/types.ts";
 
 export type Report = TransparentReportData;
 

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -68,7 +68,8 @@ async function resolveVerifiedImage({
 }
 
 /**
- * Never sent to the container's ACL — see core/lib/report/known-blocked.ts.
+ * Never sent to the container's ACL — used only for report-time annotation
+ * of expected vs. unexpected blocked connections.
  */
 export function readKnownBlockedRules(input: string | undefined): string[] {
   return parseRulesOrThrow(input);

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -9,11 +9,11 @@
  */
 import * as core from "@actions/core";
 import { createDocker, type Docker } from "../../../../core/lib/docker/client.ts";
-import { buildReportParameters } from "../../../../core/lib/report/report-parameters.ts";
-import { buildExplicitReportData } from "../../../../core/lib/report/build-explicit-report-data.ts";
-import { renderReportMarkdown } from "../../../../core/lib/report/render-report-markdown.ts";
-import { renderCommunicationDetails } from "../../../../core/lib/report/command-log.ts";
-import { emitBlockedOutcome } from "../../../../core/lib/report/emit-blocked-outcome.ts";
+import { buildReportParameters } from "../../../../core/lib/report/parameters.ts";
+import { buildExplicitReportData } from "../../../../core/lib/report/build/explicit.ts";
+import { renderReportMarkdown } from "../../../../core/lib/report/render/render-report-markdown.ts";
+import { renderCommunicationDetails } from "../../../../core/lib/report/render/communication-details.ts";
+import { emitBlockedOutcome } from "../../../../core/lib/report/outcome/emit-blocked-outcome.ts";
 import { errorMessage } from "../../../../core/lib/general/error-message.ts";
 import { wrapLogGroup } from "../../../../core/lib/actions/log-group.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -9,10 +9,10 @@
  */
 import * as core from "@actions/core";
 import { createDocker } from "../../../../core/lib/docker/client.ts";
-import { buildReportParameters } from "../../../../core/lib/report/report-parameters.ts";
-import { buildTransparentReportData } from "../../../../core/lib/report/build-transparent-report-data.ts";
-import { renderReportMarkdown } from "../../../../core/lib/report/render-report-markdown.ts";
-import { emitBlockedOutcome } from "../../../../core/lib/report/emit-blocked-outcome.ts";
+import { buildReportParameters } from "../../../../core/lib/report/parameters.ts";
+import { buildTransparentReportData } from "../../../../core/lib/report/build/transparent.ts";
+import { renderReportMarkdown } from "../../../../core/lib/report/render/render-report-markdown.ts";
+import { emitBlockedOutcome } from "../../../../core/lib/report/outcome/emit-blocked-outcome.ts";
 import { errorMessage } from "../../../../core/lib/general/error-message.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
 


### PR DESCRIPTION
## Summary

- Splits the flat `core/lib/report/` directory into four layers so the directory structure reflects the pipeline: `types.ts`/`parameters.ts` (shared shapes and input parsing), `render/` (markdown rendering), `build/` (log-scan → report-data assembly per engine), `outcome/` (pass/fail decision and annotation).
- `known-blocked.ts` is further split into `outcome/annotate-known-blocked.ts` (per-row expected-flag tagging) and `outcome/blocked-outcome.ts` (the pass/fail decision matrix and message text), since those were two distinct concerns sharing one file.
- Pure file moves and import-path updates; no behavioral changes.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/lib/report` (10 files, 97 tests)
- [x] `vp test run run/src`, `vp test run setup/src`
- [x] `make test_unit` (incl. QuickJS scripts build)
- [x] `vp run build` — `run/dist/main.cjs` rebuilt and committed