### PR TITLE
refactor: extract proxy start/stop and sandboxed-command steps from run's main()

### DIFF
--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -8786,6 +8786,98 @@ async function withGroup(label, fn) {
 		console.log("::endgroup::");
 	}
 }
+/** Starts this step's own throwaway proxy container via `docker compose up`. */
+async function startSandboxProxy({ composeFile, projectName, pullPolicy, composeEnv }) {
+	await withGroup("buildcage: starting sandbox proxy", () => {
+		try {
+			(0, node_child_process.execFileSync)("docker", buildComposeUpArgs({
+				composeFile,
+				projectName,
+				pullPolicy
+			}), {
+				stdio: "inherit",
+				env: composeEnv
+			});
+		} catch (e) {
+			throw new SandboxError(describeDockerFailure(e, { operation: "docker compose up" }), "DOCKER_UNAVAILABLE");
+		}
+	});
+}
+/** Stops this step's proxy container via `docker compose down`. Reports
+*  failure as a warning rather than throwing — this runs in main()'s
+*  finally block, after the sandboxed command has already completed. */
+async function stopSandboxProxy({ composeFile, projectName, composeEnv, annotation }) {
+	await withGroup("buildcage: stopping sandbox proxy", () => {
+		try {
+			(0, node_child_process.execFileSync)("docker", buildComposeDownArgs({
+				composeFile,
+				projectName
+			}), {
+				stdio: "inherit",
+				env: composeEnv
+			});
+		} catch (e) {
+			annotation.warning(`Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`);
+		}
+	});
+}
+/**
+* Extracts runc/gen-seccomp-profile from the proxy container, builds the
+* OCI bundle, and runs the user's command inside it via run-isolated.sh.
+* Returns the isolated command's exit code.
+*/
+function runSandboxedCommand({ containerName, proxyPid, runInput, writablePaths, env }) {
+	let dns = "172.20.0.1";
+	return withScratchDir((dir) => {
+		let runcPath, seccompProfile, baseSpec;
+		try {
+			({runcPath, seccompProfile, baseSpec} = extractRuncBootstrap({
+				containerName,
+				destDir: dir
+			}));
+		} catch (e) {
+			throw new SandboxError(`Failed to extract runc/gen-seccomp-profile from the proxy image: ${errorMessage(e)}`, "RUNC_EXTRACT_FAILED");
+		}
+		let workdir = env.GITHUB_WORKSPACE || "", home = env.HOME || "", netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-"), rootfsBindDir = (0, node_path.join)(dir, "rootfs"), config;
+		try {
+			let resolvConfPath = writeResolvConf(dns, dir), scriptPath = writeRunScript(runInput, dir), hostMounts = listHostMounts();
+			config = buildOciConfig(baseSpec, {
+				identity: {
+					uid: process.getuid(),
+					gid: process.getgid()
+				},
+				writable: {
+					workdir,
+					home,
+					runnerTemp: env.RUNNER_TEMP || "",
+					writablePaths
+				},
+				runtime: {
+					netnsPath: `/var/run/netns/${netnsName}`,
+					rootfsBindDir,
+					resolvConfPath,
+					seccompProfile,
+					scriptPath,
+					hostMounts
+				},
+				env
+			});
+		} catch (e) {
+			throw new SandboxError(`Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`, "OCI_CONFIG_BUILD_FAILED");
+		}
+		return writeOciConfig(config, dir), runIsolated({
+			runcPath,
+			proxyPid,
+			bundleDir: dir,
+			containerId: containerName,
+			netnsName,
+			rootfsBindDir,
+			gateway: "172.20.0.1",
+			dns,
+			targetIp: "172.20.0.101"
+		});
+	}, containerName);
+}
 /**
 * Side-effecting half of the report step: computeReportOutcome() decides
 * what to say, this writes it to the Job Summary/annotations/exit code.
@@ -8822,74 +8914,23 @@ async function main() {
 		ALLOWED_IP_RULES: rules.ipRules.join("\n"),
 		BUILDCAGE_PROXY_IMAGE_REF: imageRef
 	};
-	await withGroup("buildcage: starting sandbox proxy", () => {
-		try {
-			(0, node_child_process.execFileSync)("docker", buildComposeUpArgs({
-				composeFile,
-				projectName,
-				pullPolicy
-			}), {
-				stdio: "inherit",
-				env: composeEnv
-			});
-		} catch (e) {
-			throw new SandboxError(describeDockerFailure(e, { operation: "docker compose up" }), "DOCKER_UNAVAILABLE");
-		}
+	await startSandboxProxy({
+		composeFile,
+		projectName,
+		pullPolicy,
+		composeEnv
 	});
 	let exitCode = 1;
 	try {
 		let proxyPid = getContainerPid(containerName);
 		if (proxyPid === null) throw new SandboxError(`Sandbox proxy container ${containerName} is not running.`, "PROXY_NOT_RUNNING");
-		let dns = "172.20.0.1";
-		exitCode = withScratchDir((dir) => {
-			let runcPath, seccompProfile, baseSpec;
-			try {
-				({runcPath, seccompProfile, baseSpec} = extractRuncBootstrap({
-					containerName,
-					destDir: dir
-				}));
-			} catch (e) {
-				throw new SandboxError(`Failed to extract runc/gen-seccomp-profile from the proxy image: ${errorMessage(e)}`, "RUNC_EXTRACT_FAILED");
-			}
-			let workdir = env.GITHUB_WORKSPACE || "", home = env.HOME || "", netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-"), rootfsBindDir = (0, node_path.join)(dir, "rootfs"), config;
-			try {
-				let resolvConfPath = writeResolvConf(dns, dir), scriptPath = writeRunScript(runInput, dir), hostMounts = listHostMounts();
-				config = buildOciConfig(baseSpec, {
-					identity: {
-						uid: process.getuid(),
-						gid: process.getgid()
-					},
-					writable: {
-						workdir,
-						home,
-						runnerTemp: env.RUNNER_TEMP || "",
-						writablePaths
-					},
-					runtime: {
-						netnsPath: `/var/run/netns/${netnsName}`,
-						rootfsBindDir,
-						resolvConfPath,
-						seccompProfile,
-						scriptPath,
-						hostMounts
-					},
-					env
-				});
-			} catch (e) {
-				throw new SandboxError(`Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`, "OCI_CONFIG_BUILD_FAILED");
-			}
-			return writeOciConfig(config, dir), runIsolated({
-				runcPath,
-				proxyPid,
-				bundleDir: dir,
-				containerId: containerName,
-				netnsName,
-				rootfsBindDir,
-				gateway: "172.20.0.1",
-				dns,
-				targetIp: "172.20.0.101"
-			});
-		}, containerName);
+		exitCode = runSandboxedCommand({
+			containerName,
+			proxyPid,
+			runInput,
+			writablePaths,
+			env
+		});
 	} finally {
 		try {
 			let report = await fetchReport(containerName, {
@@ -8914,18 +8955,11 @@ async function main() {
 		} catch (e) {
 			annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);
 		}
-		await withGroup("buildcage: stopping sandbox proxy", () => {
-			try {
-				(0, node_child_process.execFileSync)("docker", buildComposeDownArgs({
-					composeFile,
-					projectName
-				}), {
-					stdio: "inherit",
-					env: composeEnv
-				});
-			} catch (e) {
-				annotation.warning(`Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`);
-			}
+		await stopSandboxProxy({
+			composeFile,
+			projectName,
+			composeEnv,
+			annotation
 		});
 	}
 	exitCode !== 0 && (process.exitCode = exitCode);

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -106,6 +106,169 @@ async function withGroup<T>(label: string, fn: () => T | Promise<T>): Promise<T>
   }
 }
 
+interface StartSandboxProxyOptions {
+  composeFile: string;
+  projectName: string;
+  pullPolicy: string;
+  composeEnv: NodeJS.ProcessEnv;
+}
+
+/** Starts this step's own throwaway proxy container via `docker compose up`. */
+async function startSandboxProxy({
+  composeFile,
+  projectName,
+  pullPolicy,
+  composeEnv,
+}: StartSandboxProxyOptions): Promise<void> {
+  await withGroup("buildcage: starting sandbox proxy", () => {
+    try {
+      execFileSync("docker", buildComposeUpArgs({ composeFile, projectName, pullPolicy }), {
+        stdio: "inherit",
+        env: composeEnv,
+      });
+    } catch (e) {
+      throw new SandboxError(
+        describeDockerFailure(e, { operation: "docker compose up" }),
+        "DOCKER_UNAVAILABLE",
+      );
+    }
+  });
+}
+
+interface StopSandboxProxyOptions {
+  composeFile: string;
+  projectName: string;
+  composeEnv: NodeJS.ProcessEnv;
+  annotation: Annotation;
+}
+
+/** Stops this step's proxy container via `docker compose down`. Reports
+ *  failure as a warning rather than throwing — this runs in main()'s
+ *  finally block, after the sandboxed command has already completed. */
+async function stopSandboxProxy({
+  composeFile,
+  projectName,
+  composeEnv,
+  annotation,
+}: StopSandboxProxyOptions): Promise<void> {
+  await withGroup("buildcage: stopping sandbox proxy", () => {
+    try {
+      execFileSync("docker", buildComposeDownArgs({ composeFile, projectName }), {
+        stdio: "inherit",
+        env: composeEnv,
+      });
+    } catch (e) {
+      annotation.warning(
+        `Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`,
+      );
+    }
+  });
+}
+
+interface RunSandboxedCommandOptions {
+  containerName: string;
+  proxyPid: number;
+  runInput: string;
+  writablePaths: string[];
+  env: NodeJS.ProcessEnv;
+}
+
+/**
+ * Extracts runc/gen-seccomp-profile from the proxy container, builds the
+ * OCI bundle, and runs the user's command inside it via run-isolated.sh.
+ * Returns the isolated command's exit code.
+ */
+function runSandboxedCommand({
+  containerName,
+  proxyPid,
+  runInput,
+  writablePaths,
+  env,
+}: RunSandboxedCommandOptions): number {
+  // Fixed addressing for the direct veth link to the proxy's sandbox0 interface.
+  const gateway = "172.20.0.1";
+  const dns = "172.20.0.1";
+  const targetIp = "172.20.0.101";
+
+  return withScratchDir((dir) => {
+    let runcPath, seccompProfile, baseSpec;
+    try {
+      // Extracted into this run's own scratch dir — see extractRuncBootstrap.
+      // Run natively on the runner host (not `docker exec`, which would
+      // resolve against the container's kernel/arch instead of the real
+      // one) — see gen-seccomp-profile/main.go.
+      ({ runcPath, seccompProfile, baseSpec } = extractRuncBootstrap({
+        containerName,
+        destDir: dir,
+      }));
+    } catch (e) {
+      throw new SandboxError(
+        `Failed to extract runc/gen-seccomp-profile from the proxy image: ${errorMessage(e)}`,
+        "RUNC_EXTRACT_FAILED",
+      );
+    }
+
+    const workdir = env.GITHUB_WORKSPACE || "";
+    const home = env.HOME || "";
+    // Distinct from the Docker container name/Compose project name
+    // (different ID namespace — `ip netns`/runc container IDs), but
+    // derived from it to keep `ip netns`/`docker ps` output correlated
+    // per step, same reasoning as deriveProjectName.
+    const netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-");
+    const rootfsBindDir = join(dir, "rootfs");
+
+    let config;
+    try {
+      const resolvConfPath = writeResolvConf(dns, dir);
+      const scriptPath = writeRunScript(runInput, dir);
+      // Real host mount table, read now (before run-isolated.sh's `mount
+      // --rbind /` duplicates it into rootfsBindDir) so buildOciConfig can
+      // force every real submount read-only individually -- root.readonly
+      // alone only covers the top-level rootfs mount (see
+      // computeReadonlyHostMounts).
+      const hostMounts = listHostMounts();
+      config = buildOciConfig(baseSpec, {
+        identity: { uid: process.getuid!(), gid: process.getgid!() },
+        writable: {
+          workdir,
+          home,
+          // Standard writable runner scratch; not always under $HOME on
+          // self-hosted runners, so covered explicitly (see buildOciConfig).
+          runnerTemp: env.RUNNER_TEMP || "",
+          writablePaths,
+        },
+        runtime: {
+          netnsPath: `/var/run/netns/${netnsName}`,
+          rootfsBindDir,
+          resolvConfPath,
+          seccompProfile,
+          scriptPath,
+          hostMounts,
+        },
+        env,
+      });
+    } catch (e) {
+      throw new SandboxError(
+        `Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`,
+        "OCI_CONFIG_BUILD_FAILED",
+      );
+    }
+    writeOciConfig(config, dir);
+
+    return runIsolated({
+      runcPath,
+      proxyPid,
+      bundleDir: dir,
+      containerId: containerName,
+      netnsName,
+      rootfsBindDir,
+      gateway,
+      dns,
+      targetIp,
+    });
+  }, containerName);
+}
+
 /**
  * Side-effecting half of the report step: computeReportOutcome() decides
  * what to say, this writes it to the Job Summary/annotations/exit code.
@@ -208,19 +371,7 @@ async function main(): Promise<void> {
     BUILDCAGE_PROXY_IMAGE_REF: imageRef,
   };
 
-  await withGroup("buildcage: starting sandbox proxy", () => {
-    try {
-      execFileSync("docker", buildComposeUpArgs({ composeFile, projectName, pullPolicy }), {
-        stdio: "inherit",
-        env: composeEnv,
-      });
-    } catch (e) {
-      throw new SandboxError(
-        describeDockerFailure(e, { operation: "docker compose up" }),
-        "DOCKER_UNAVAILABLE",
-      );
-    }
-  });
+  await startSandboxProxy({ composeFile, projectName, pullPolicy, composeEnv });
 
   let exitCode = 1;
   try {
@@ -232,88 +383,7 @@ async function main(): Promise<void> {
       );
     }
 
-    // Fixed addressing for the direct veth link to the proxy's sandbox0 interface.
-    const gateway = "172.20.0.1";
-    const dns = "172.20.0.1";
-    const targetIp = "172.20.0.101";
-
-    exitCode = withScratchDir((dir) => {
-      let runcPath, seccompProfile, baseSpec;
-      try {
-        // Extracted into this run's own scratch dir — see extractRuncBootstrap.
-        // Run natively on the runner host (not `docker exec`, which would
-        // resolve against the container's kernel/arch instead of the real
-        // one) — see gen-seccomp-profile/main.go.
-        ({ runcPath, seccompProfile, baseSpec } = extractRuncBootstrap({
-          containerName,
-          destDir: dir,
-        }));
-      } catch (e) {
-        throw new SandboxError(
-          `Failed to extract runc/gen-seccomp-profile from the proxy image: ${errorMessage(e)}`,
-          "RUNC_EXTRACT_FAILED",
-        );
-      }
-
-      const workdir = env.GITHUB_WORKSPACE || "";
-      const home = env.HOME || "";
-      // Distinct from the Docker container name/Compose project name
-      // (different ID namespace — `ip netns`/runc container IDs), but
-      // derived from it to keep `ip netns`/`docker ps` output correlated
-      // per step, same reasoning as deriveProjectName.
-      const netnsName = containerName.replace(/^buildcage-proxy-/, "buildcage-sandbox-");
-      const rootfsBindDir = join(dir, "rootfs");
-
-      let config;
-      try {
-        const resolvConfPath = writeResolvConf(dns, dir);
-        const scriptPath = writeRunScript(runInput, dir);
-        // Real host mount table, read now (before run-isolated.sh's `mount
-        // --rbind /` duplicates it into rootfsBindDir) so buildOciConfig can
-        // force every real submount read-only individually -- root.readonly
-        // alone only covers the top-level rootfs mount (see
-        // computeReadonlyHostMounts).
-        const hostMounts = listHostMounts();
-        config = buildOciConfig(baseSpec, {
-          identity: { uid: process.getuid!(), gid: process.getgid!() },
-          writable: {
-            workdir,
-            home,
-            // Standard writable runner scratch; not always under $HOME on
-            // self-hosted runners, so covered explicitly (see buildOciConfig).
-            runnerTemp: env.RUNNER_TEMP || "",
-            writablePaths,
-          },
-          runtime: {
-            netnsPath: `/var/run/netns/${netnsName}`,
-            rootfsBindDir,
-            resolvConfPath,
-            seccompProfile,
-            scriptPath,
-            hostMounts,
-          },
-          env,
-        });
-      } catch (e) {
-        throw new SandboxError(
-          `Failed to build the sandbox's OCI bundle: ${errorMessage(e)}`,
-          "OCI_CONFIG_BUILD_FAILED",
-        );
-      }
-      writeOciConfig(config, dir);
-
-      return runIsolated({
-        runcPath,
-        proxyPid,
-        bundleDir: dir,
-        containerId: containerName,
-        netnsName,
-        rootfsBindDir,
-        gateway,
-        dns,
-        targetIp,
-      });
-    }, containerName);
+    exitCode = runSandboxedCommand({ containerName, proxyPid, runInput, writablePaths, env });
   } finally {
     try {
       const report = await fetchReport(containerName, {
@@ -342,18 +412,7 @@ async function main(): Promise<void> {
     } catch (e) {
       annotation.warning(`Failed to fetch sandbox report: ${errorMessage(e)}`);
     }
-    await withGroup("buildcage: stopping sandbox proxy", () => {
-      try {
-        execFileSync("docker", buildComposeDownArgs({ composeFile, projectName }), {
-          stdio: "inherit",
-          env: composeEnv,
-        });
-      } catch (e) {
-        annotation.warning(
-          `Failed to stop the sandbox proxy container: ${describeDockerFailure(e, { operation: "docker compose down" })}`,
-        );
-      }
-    });
+    await stopSandboxProxy({ composeFile, projectName, composeEnv, annotation });
   }
 
   if (exitCode !== 0) {


### PR DESCRIPTION
## Summary

- Extracts three named functions out of `run/src/main.ts`'s ~225-line `main()`: `startSandboxProxy` (`docker compose up`), `runSandboxedCommand` (extract runc bootstrap → build OCI bundle → `runIsolated`), and `stopSandboxProxy` (`docker compose down`), mirroring the file's existing style of top-level helper functions (`resolveVerifiedImage`, `withGroup`, `writeReportSummary`, etc).
- `main()` now reads as a sequence of named steps instead of one large nested block; no new files, no import changes elsewhere, no behavioral changes.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run run/src core/lib setup/src report/src` (44 files, 444 tests)
- [x] `make test_unit` (incl. QuickJS scripts build)
- [x] `vp run build` — `run/dist/main.cjs` rebuilt and committed