### PR TITLE
refactor: separate pure image-tag/policy logic from provenance's network I/O

### DIFF
--- a/core/lib/provenance/image-tag.test.ts
+++ b/core/lib/provenance/image-tag.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for core/lib/provenance/image-tag.ts
+ *
+ * Run with: vp test run core/lib/provenance/image-tag.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { imageTagFromRef } from "./image-tag.ts";
+
+describe("imageTagFromRef", () => {
+  it("converts a 40-char hex SHA to sha-<sha> by default (no suffix for transparent)", () => {
+    const sha = "a".repeat(40);
+    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}`);
+  });
+
+  it("lowercases the SHA", () => {
+    const sha = "ABCDEF1234".padEnd(40, "0");
+    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}`);
+  });
+
+  it("strips leading 'v' from a version tag", () => {
+    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0");
+  });
+
+  it("strips 'v' from a major-only tag", () => {
+    assert.equal(imageTagFromRef("v2"), "2");
+  });
+
+  it("returns a branch name as-is, with no suffix for the default engine", () => {
+    assert.equal(imageTagFromRef("main"), "main");
+  });
+
+  it("returns empty string for empty input", () => {
+    assert.equal(imageTagFromRef(""), "");
+  });
+
+  it("returns empty string for undefined", () => {
+    assert.equal(imageTagFromRef(undefined), "");
+  });
+
+  it("appends the explicit engine suffix instead when requested", () => {
+    assert.equal(imageTagFromRef("v2.1.0", "explicit"), "2.1.0-explicit");
+    assert.equal(imageTagFromRef("a".repeat(40), "explicit"), `sha-${"a".repeat(40)}-explicit`);
+  });
+});

--- a/core/lib/provenance/image-tag.ts
+++ b/core/lib/provenance/image-tag.ts
@@ -1,0 +1,27 @@
+/**
+ * Convert an action ref into the base Docker image tag, then append the
+ * proxy engine suffix for non-default engines. The `transparent` engine
+ * (default) publishes the plain version tag (e.g. `2.1.0`), matching the
+ * pre-multi-engine tagging scheme; `explicit` (experimental) and `proxy`
+ * (the buildkitd-less network-isolation proxy used by the run action)
+ * each publish under their own suffix (e.g. `2.1.0-explicit`,
+ * `2.1.0-proxy`). All three share the same Sigstore verification identity
+ * (same workflow, same git ref) — only the published Docker tag differs, so
+ * this does not affect verify-policy.ts's buildVerifyOptions.
+ */
+export function imageTagFromRef(
+  actionRef: string | undefined,
+  proxyEngine: string = "transparent",
+): string {
+  if (!actionRef) return "";
+  let base;
+  if (/^[0-9a-f]{40}$/i.test(actionRef)) {
+    base = `sha-${actionRef.toLowerCase()}`;
+  } else if (actionRef.startsWith("v")) {
+    base = actionRef.slice(1);
+  } else {
+    base = actionRef;
+  }
+  if (proxyEngine === "explicit" || proxyEngine === "proxy") return `${base}-${proxyEngine}`;
+  return base;
+}

--- a/core/lib/provenance/signed-digest.test.ts
+++ b/core/lib/provenance/signed-digest.test.ts
@@ -1,17 +1,16 @@
 /**
- * Unit tests for core/lib/sigstore.ts
- *
- * verifyBundle() requires a live TUF network call; that path is covered by
- * end-to-end / integration tests.
+ * Unit tests for core/lib/provenance/signed-digest.ts
  *
  * assertSignedDigest() is pure synchronous logic and is fully unit-tested here.
+ * sigstore.ts's verifyBundle() requires a live TUF network call; that path
+ * is covered by end-to-end / integration tests instead.
  *
- * Run with: vp test run core/lib/provenance/sigstore.test.ts
+ * Run with: vp test run core/lib/provenance/signed-digest.test.ts
  */
 
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { assertSignedDigest } from "./sigstore.ts";
+import { assertSignedDigest } from "./signed-digest.ts";
 import { VerifyImageError } from "./errors.ts";
 
 const DIGEST = "sha256:abc123";

--- a/core/lib/provenance/signed-digest.ts
+++ b/core/lib/provenance/signed-digest.ts
@@ -1,0 +1,83 @@
+import { VerifyImageError } from "./errors.ts";
+
+// Encode a string as DER UTF8String for Fulcio OID extension values.
+// sigstore-js compares the raw OCTET STRING bytes, so we must include
+// the DER tag (0x0C) and length prefix. Assumes len < 128.
+export const derUtf8 = (s: string): string => String.fromCharCode(0x0c, s.length) + s;
+
+export interface DsseBundle {
+  dsseEnvelope?: {
+    payload?: string;
+    payloadType?: string;
+  };
+}
+
+/**
+ * Extract and assert the signed manifest digest from a cosign DSSE bundle.
+ *
+ * Two payload formats are supported depending on the cosign version:
+ *
+ * 1. in-toto Statement v1 (payloadType "application/vnd.in-toto+json")
+ *    Used by cosign --new-bundle-format (v2.4+).
+ *    Digest is stored in subject[].digest.sha256.
+ *
+ * 2. simple-signing (legacy cosign)
+ *    Digest is stored in critical.image.docker-manifest-digest.
+ *
+ * This check closes the gap between Referrers-API attribution (registry
+ * metadata, not cryptographic) and the actual signed content — an attacker
+ * with package-write access could re-attach a valid bundle to a different
+ * image; this assertion prevents accepting such a re-attached bundle.
+ *
+ * Exported for unit testing; callers should use sigstore.ts's verifyBundle()
+ * instead.
+ */
+export function assertSignedDigest(bundleJson: DsseBundle, expectedDigest: string): void {
+  const dsse = bundleJson?.dsseEnvelope;
+  const payload = dsse?.payload;
+  if (!payload) {
+    throw new VerifyImageError(
+      "Bundle is not a DSSE envelope or is missing a signed payload",
+      "VERIFY_FAILED",
+    );
+  }
+
+  try {
+    const sl = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+
+    if (dsse.payloadType === "application/vnd.in-toto+json") {
+      // in-toto Statement v1: subject[].digest.sha256 holds the manifest digest.
+      const subjects: { digest?: { sha256?: string } }[] = sl?.subject ?? [];
+      const matched = subjects.some(
+        (s) => s?.digest?.sha256 && `sha256:${s.digest.sha256}` === expectedDigest,
+      );
+      if (!matched) {
+        const found =
+          subjects
+            .map((s) => (s?.digest?.sha256 ? `sha256:${s.digest.sha256}` : null))
+            .filter(Boolean)
+            .join(", ") || "missing";
+        throw new VerifyImageError(
+          `Signed digest (${found}) does not match ` +
+            `fetched digest (${expectedDigest}). ` +
+            `The bundle may have been re-attached to a different image.`,
+          "VERIFY_FAILED",
+        );
+      }
+    } else {
+      // simple-signing format: critical.image.docker-manifest-digest.
+      const signedDigest = sl?.critical?.image?.["docker-manifest-digest"];
+      if (!signedDigest || signedDigest !== expectedDigest) {
+        throw new VerifyImageError(
+          `Signed digest (${signedDigest ?? "missing"}) does not match ` +
+            `fetched digest (${expectedDigest}). ` +
+            `The bundle may have been re-attached to a different image.`,
+          "VERIFY_FAILED",
+        );
+      }
+    }
+  } catch (err) {
+    if (err instanceof VerifyImageError) throw err;
+    throw new VerifyImageError("Failed to parse signed payload from bundle", "VERIFY_FAILED");
+  }
+}

--- a/core/lib/provenance/sigstore.ts
+++ b/core/lib/provenance/sigstore.ts
@@ -9,18 +9,7 @@ import {
 } from "@sigstore/verify";
 import { VerifyImageError } from "./errors.ts";
 import { errorMessage } from "../general/error-message.ts";
-
-// Encode a string as DER UTF8String for Fulcio OID extension values.
-// sigstore-js compares the raw OCTET STRING bytes, so we must include
-// the DER tag (0x0C) and length prefix. Assumes len < 128.
-export const derUtf8 = (s: string): string => String.fromCharCode(0x0c, s.length) + s;
-
-export interface DsseBundle {
-  dsseEnvelope?: {
-    payload?: string;
-    payloadType?: string;
-  };
-}
+import { assertSignedDigest, type DsseBundle } from "./signed-digest.ts";
 
 export interface VerifyBundleOptions {
   certificateIssuer?: string;
@@ -28,75 +17,6 @@ export interface VerifyBundleOptions {
   certificateOIDs?: Record<string, string>;
   tlogThreshold?: number;
   ctLogThreshold?: number;
-}
-
-/**
- * Extract and assert the signed manifest digest from a cosign DSSE bundle.
- *
- * Two payload formats are supported depending on the cosign version:
- *
- * 1. in-toto Statement v1 (payloadType "application/vnd.in-toto+json")
- *    Used by cosign --new-bundle-format (v2.4+).
- *    Digest is stored in subject[].digest.sha256.
- *
- * 2. simple-signing (legacy cosign)
- *    Digest is stored in critical.image.docker-manifest-digest.
- *
- * This check closes the gap between Referrers-API attribution (registry
- * metadata, not cryptographic) and the actual signed content — an attacker
- * with package-write access could re-attach a valid bundle to a different
- * image; this assertion prevents accepting such a re-attached bundle.
- *
- * Exported for unit testing; callers should use verifyBundle() instead.
- */
-export function assertSignedDigest(bundleJson: DsseBundle, expectedDigest: string): void {
-  const dsse = bundleJson?.dsseEnvelope;
-  const payload = dsse?.payload;
-  if (!payload) {
-    throw new VerifyImageError(
-      "Bundle is not a DSSE envelope or is missing a signed payload",
-      "VERIFY_FAILED",
-    );
-  }
-
-  try {
-    const sl = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
-
-    if (dsse.payloadType === "application/vnd.in-toto+json") {
-      // in-toto Statement v1: subject[].digest.sha256 holds the manifest digest.
-      const subjects: { digest?: { sha256?: string } }[] = sl?.subject ?? [];
-      const matched = subjects.some(
-        (s) => s?.digest?.sha256 && `sha256:${s.digest.sha256}` === expectedDigest,
-      );
-      if (!matched) {
-        const found =
-          subjects
-            .map((s) => (s?.digest?.sha256 ? `sha256:${s.digest.sha256}` : null))
-            .filter(Boolean)
-            .join(", ") || "missing";
-        throw new VerifyImageError(
-          `Signed digest (${found}) does not match ` +
-            `fetched digest (${expectedDigest}). ` +
-            `The bundle may have been re-attached to a different image.`,
-          "VERIFY_FAILED",
-        );
-      }
-    } else {
-      // simple-signing format: critical.image.docker-manifest-digest.
-      const signedDigest = sl?.critical?.image?.["docker-manifest-digest"];
-      if (!signedDigest || signedDigest !== expectedDigest) {
-        throw new VerifyImageError(
-          `Signed digest (${signedDigest ?? "missing"}) does not match ` +
-            `fetched digest (${expectedDigest}). ` +
-            `The bundle may have been re-attached to a different image.`,
-          "VERIFY_FAILED",
-        );
-      }
-    }
-  } catch (err) {
-    if (err instanceof VerifyImageError) throw err;
-    throw new VerifyImageError("Failed to parse signed payload from bundle", "VERIFY_FAILED");
-  }
 }
 
 /**

--- a/core/lib/provenance/verify-image.test.ts
+++ b/core/lib/provenance/verify-image.test.ts
@@ -1,193 +1,20 @@
 /**
- * Unit tests for core/lib/verify-image.ts
+ * Unit tests for core/lib/provenance/verify-image.ts
  *
- * Tests focus on buildcage-specific pure functions: imageTagFromRef and
- * buildVerifyOptions.  I/O functions (getManifestDigest, fetchRegistryToken,
- * fetchBundle) are tested in lib/oci-registry.test.ts.
- *
- * verifyBundle and verifyImageDigest require a live TUF network call; those
- * paths are covered by end-to-end / integration tests.
+ * Covers the orchestration-level pure functions only (toProvenanceError,
+ * requireDigest) — imageTagFromRef and buildVerifyOptions have their own
+ * test files (image-tag.test.ts, verify-policy.test.ts). I/O functions
+ * (verifyImageDigest, verifyImageDigestOrThrow, and the registry/sigstore
+ * calls they make) require a live network/TUF call and are covered by
+ * end-to-end / integration tests instead.
  *
  * Run with: vp test run core/lib/provenance/verify-image.test.ts
  */
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import {
-  imageTagFromRef,
-  buildVerifyOptions,
-  toProvenanceError,
-  requireDigest,
-} from "./verify-image.ts";
+import { toProvenanceError, requireDigest } from "./verify-image.ts";
 import { ProvenanceError, VerifyImageError } from "./errors.ts";
-import type { VerifyBundleOptions } from "./sigstore.ts";
-
-// ── Constants mirrored from verify-image.ts (for assertion readability) ──────
-
-const EXPECTED_ISSUER = "https://token.actions.githubusercontent.com";
-const RELEASE_WORKFLOW = ".github/workflows/docker-publish.yml";
-const OID_SOURCE_REPO_DIGEST = "1.3.6.1.4.1.57264.1.13";
-const REPO = "dash14/buildcage";
-
-/** Build a sample SAN URI as Fulcio would embed it. */
-function makeSAN(ref: string) {
-  return `https://github.com/${REPO}/${RELEASE_WORKFLOW}@${ref}`;
-}
-
-// ── imageTagFromRef ───────────────────────────────────────────────────────────
-
-describe("imageTagFromRef", () => {
-  it("converts a 40-char hex SHA to sha-<sha> by default (no suffix for transparent)", () => {
-    const sha = "a".repeat(40);
-    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}`);
-  });
-
-  it("lowercases the SHA", () => {
-    const sha = "ABCDEF1234".padEnd(40, "0");
-    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}`);
-  });
-
-  it("strips leading 'v' from a version tag", () => {
-    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0");
-  });
-
-  it("strips 'v' from a major-only tag", () => {
-    assert.equal(imageTagFromRef("v2"), "2");
-  });
-
-  it("returns a branch name as-is, with no suffix for the default engine", () => {
-    assert.equal(imageTagFromRef("main"), "main");
-  });
-
-  it("returns empty string for empty input", () => {
-    assert.equal(imageTagFromRef(""), "");
-  });
-
-  it("returns empty string for undefined", () => {
-    assert.equal(imageTagFromRef(undefined), "");
-  });
-
-  it("appends the explicit engine suffix instead when requested", () => {
-    assert.equal(imageTagFromRef("v2.1.0", "explicit"), "2.1.0-explicit");
-    assert.equal(imageTagFromRef("a".repeat(40), "explicit"), `sha-${"a".repeat(40)}-explicit`);
-  });
-});
-
-// ── buildVerifyOptions ────────────────────────────────────────────────────────
-//
-// We test the generated options by converting certificateIdentityURI to a
-// RegExp and matching sample SAN strings — the same test cosign would apply.
-
-describe("buildVerifyOptions — version tag", () => {
-  function getOpts(ref: string): VerifyBundleOptions {
-    const opts = buildVerifyOptions({ actionRef: ref, actionRepo: REPO });
-    assert.ok(opts, `expected non-null options for ref "${ref}"`);
-    return opts!;
-  }
-  function matchesSAN(opts: VerifyBundleOptions, san: string) {
-    return new RegExp(opts.certificateIdentityURI!).test(san);
-  }
-
-  it("sets certificateIssuer", () => {
-    const opts = getOpts("v2.1.0");
-    assert.equal(opts.certificateIssuer, EXPECTED_ISSUER);
-  });
-
-  it("matches exact full version @v2.1.0 against cert SAN v2.1.0", () => {
-    const opts = getOpts("v2.1.0");
-    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.1.0")));
-  });
-
-  it("matches floating minor @v2.1 against cert SAN v2.1.3", () => {
-    const opts = getOpts("v2.1");
-    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.1.3")));
-  });
-
-  it("matches floating major @v2 against cert SAN v2.99.0", () => {
-    const opts = getOpts("v2");
-    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.99.0")));
-  });
-
-  // ── v2.1 / v2.10 boundary ───────────────────────────────────────────────────
-  it("does NOT match @v2.1 against cert SAN v2.10.0 (boundary check)", () => {
-    const opts = getOpts("v2.1");
-    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v2.10.0")), "@v2.1 must not match v2.10.0");
-  });
-
-  it("does NOT match @v2 against cert SAN v20.0.0 (boundary check)", () => {
-    const opts = getOpts("v2");
-    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v20.0.0")), "@v2 must not match v20.0.0");
-  });
-
-  it("does NOT match @v2.1.0 against cert SAN v2.1.1", () => {
-    const opts = getOpts("v2.1.0");
-    assert.ok(
-      !matchesSAN(opts, makeSAN("refs/tags/v2.1.1")),
-      "exact pin must not match different patch",
-    );
-  });
-
-  it("does NOT match @v2.1 against cert SAN v2.2.0", () => {
-    const opts = getOpts("v2.1");
-    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v2.2.0")), "@v2.1 must not match v2.2.0");
-  });
-
-  it("has no certificateOIDs for version tags", () => {
-    const opts = getOpts("v2.1.0");
-    assert.equal(opts.certificateOIDs, undefined);
-  });
-});
-
-describe("buildVerifyOptions — SHA pin", () => {
-  const pinSha = "a".repeat(40);
-
-  it("sets certificateIssuer", () => {
-    const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
-    assert.equal(opts.certificateIssuer, EXPECTED_ISSUER);
-  });
-
-  it("sets certificateOIDs for OID 1.13 with DER UTF8String-encoded SHA", () => {
-    const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
-    assert.ok(opts.certificateOIDs, "certificateOIDs must be present for SHA pin");
-    const oidValue = opts.certificateOIDs![OID_SOURCE_REPO_DIGEST];
-    assert.ok(oidValue !== undefined, `OID ${OID_SOURCE_REPO_DIGEST} must be set`);
-
-    // DER UTF8String: [0x0C, len, ...utf8bytes]
-    const expected = Buffer.concat([
-      Buffer.from([0x0c, pinSha.length]),
-      Buffer.from(pinSha, "utf8"),
-    ]);
-    assert.deepEqual(Buffer.from(oidValue, "binary"), expected);
-  });
-
-  it("lowercases the SHA in the OID value", () => {
-    const opts = buildVerifyOptions({ actionRef: pinSha.toUpperCase(), actionRepo: REPO })!;
-    const oidValue = opts.certificateOIDs![OID_SOURCE_REPO_DIGEST];
-    assert.ok(oidValue.includes(pinSha.toLowerCase()), "SHA must be lowercased");
-  });
-
-  it("certificateIdentityURI accepts any version tag SAN (SHA checked via OID)", () => {
-    const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
-    const regexp = new RegExp(opts.certificateIdentityURI!);
-    // should match some version tags (the SHA in OID is what pins to the commit)
-    assert.ok(regexp.test(makeSAN("refs/tags/v2.1.0")));
-    assert.ok(regexp.test(makeSAN("refs/tags/v3.0.0")));
-  });
-});
-
-describe("buildVerifyOptions — unverifiable refs", () => {
-  it("returns null for a branch ref", () => {
-    assert.equal(buildVerifyOptions({ actionRef: "main", actionRepo: REPO }), null);
-  });
-
-  it("returns null for a local ./setup ref", () => {
-    assert.equal(buildVerifyOptions({ actionRef: "./setup", actionRepo: REPO }), null);
-  });
-
-  it("returns null for an empty ref", () => {
-    assert.equal(buildVerifyOptions({ actionRef: "", actionRepo: REPO }), null);
-  });
-});
 
 // The network/sigstore-calling success path is covered by end-to-end /
 // integration tests instead (see the file header).

--- a/core/lib/provenance/verify-image.ts
+++ b/core/lib/provenance/verify-image.ts
@@ -15,24 +15,14 @@ import {
   fetchBundle,
   readGhcrBasicAuth,
 } from "./oci-registry.ts";
-import { derUtf8, verifyBundle, type VerifyBundleOptions, type DsseBundle } from "./sigstore.ts";
+import { verifyBundle } from "./sigstore.ts";
+import type { DsseBundle } from "./signed-digest.ts";
+import { imageTagFromRef } from "./image-tag.ts";
+import { buildVerifyOptions, type VerifyImageIdentity } from "./verify-policy.ts";
 import { ProvenanceError, VerifyImageError } from "./errors.ts";
 import { errorMessage } from "../general/error-message.ts";
 
 const REGISTRY = "ghcr.io";
-const EXPECTED_ISSUER = "https://token.actions.githubusercontent.com";
-const RELEASE_WORKFLOW = ".github/workflows/docker-publish.yml";
-
-// Fulcio OID: Source Repository Digest — the commit SHA of the build source.
-// Value encoding: DER UTF8String ([0x0C, len, ...utf8bytes]) inside OCTET STRING.
-const OID_SOURCE_REPO_DIGEST = "1.3.6.1.4.1.57264.1.13";
-
-const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-export interface VerifyImageIdentity {
-  actionRef: string;
-  actionRepo: string;
-}
 
 export interface VerifyImageDigestOptions extends VerifyImageIdentity {
   proxyEngine?: string;
@@ -42,80 +32,6 @@ export interface VerifyImageDigestOptions extends VerifyImageIdentity {
 export interface ResolvedImage {
   imageRef: string;
   pullPolicy: "always";
-}
-
-/**
- * Convert an action ref into the base Docker image tag, then append the
- * proxy engine suffix for non-default engines. The `transparent` engine
- * (default) publishes the plain version tag (e.g. `2.1.0`), matching the
- * pre-multi-engine tagging scheme; `explicit` (experimental) and `proxy`
- * (the buildkitd-less network-isolation proxy used by the run action)
- * each publish under their own suffix (e.g. `2.1.0-explicit`,
- * `2.1.0-proxy`). All three share the same Sigstore verification identity
- * (same workflow, same git ref) — only the published Docker tag differs, so
- * this does not affect buildVerifyOptions below.
- */
-export function imageTagFromRef(
-  actionRef: string | undefined,
-  proxyEngine: string = "transparent",
-): string {
-  if (!actionRef) return "";
-  let base;
-  if (/^[0-9a-f]{40}$/i.test(actionRef)) {
-    base = `sha-${actionRef.toLowerCase()}`;
-  } else if (actionRef.startsWith("v")) {
-    base = actionRef.slice(1);
-  } else {
-    base = actionRef;
-  }
-  if (proxyEngine === "explicit" || proxyEngine === "proxy") return `${base}-${proxyEngine}`;
-  return base;
-}
-
-/**
- * Build verify options encoding the expected certificate identity.
- *
- * The SAN URI pattern uses `(\.|$)` boundary anchors for version tags so that
- * e.g. @v2.1 matches v2.1.0 and v2.1.3 but NOT v2.10.0.
- *
- * For SHA pins, OID 1.13 (Source Repository Digest) pins the exact commit
- * while the SAN accepts any release tag.
- *
- * Returns null for unverifiable refs (branch names, local paths).
- */
-export function buildVerifyOptions({
-  actionRef,
-  actionRepo,
-}: VerifyImageIdentity): VerifyBundleOptions | null {
-  const sanPrefix = `^${escapeRegex(`https://github.com/${actionRepo}/${RELEASE_WORKFLOW}@refs/tags/`)}`;
-  const base = {
-    certificateIssuer: EXPECTED_ISSUER,
-    tlogThreshold: 1,
-    ctLogThreshold: 1,
-  };
-
-  // SHA pin: the SAN accepts any v*-prefixed release tag — the exact commit is
-  // pinned by OID 1.13 (Source Repository Digest), which enforces a strict byte
-  // match against the pinned SHA and cannot be satisfied by any other commit.
-  if (/^[0-9a-f]{40}$/i.test(actionRef)) {
-    return {
-      ...base,
-      certificateIdentityURI: `${sanPrefix}v`,
-      certificateOIDs: {
-        [OID_SOURCE_REPO_DIGEST]: derUtf8(actionRef.toLowerCase()),
-      },
-    };
-  }
-
-  // Version tag: SAN ref must match this version (boundary-safe via (\.|$)).
-  if (actionRef.startsWith("v")) {
-    return {
-      ...base,
-      certificateIdentityURI: `${sanPrefix}${escapeRegex(actionRef)}(\\.|$)`,
-    };
-  }
-
-  return null; // branch name, local ./setup, etc. — no verifiable release bundle
 }
 
 /**

--- a/core/lib/provenance/verify-policy.property.test.ts
+++ b/core/lib/provenance/verify-policy.property.test.ts
@@ -1,13 +1,13 @@
 /**
- * Property-based tests for verify-image.ts helpers.
+ * Property-based tests for verify-policy.ts helpers.
  *
- * Run with: vp test run core/lib/provenance/verify-image.property.test.ts
+ * Run with: vp test run core/lib/provenance/verify-policy.property.test.ts
  */
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 
-import { buildVerifyOptions } from "./verify-image.ts";
+import { buildVerifyOptions } from "./verify-policy.ts";
 
 // ---------------------------------------------------------------------------
 // buildVerifyOptions

--- a/core/lib/provenance/verify-policy.test.ts
+++ b/core/lib/provenance/verify-policy.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for core/lib/provenance/verify-policy.ts
+ *
+ * Run with: vp test run core/lib/provenance/verify-policy.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { buildVerifyOptions } from "./verify-policy.ts";
+import type { VerifyBundleOptions } from "./sigstore.ts";
+
+// ── Constants mirrored from verify-policy.ts (for assertion readability) ──────
+
+const EXPECTED_ISSUER = "https://token.actions.githubusercontent.com";
+const RELEASE_WORKFLOW = ".github/workflows/docker-publish.yml";
+const OID_SOURCE_REPO_DIGEST = "1.3.6.1.4.1.57264.1.13";
+const REPO = "dash14/buildcage";
+
+/** Build a sample SAN URI as Fulcio would embed it. */
+function makeSAN(ref: string) {
+  return `https://github.com/${REPO}/${RELEASE_WORKFLOW}@${ref}`;
+}
+
+// ── buildVerifyOptions ────────────────────────────────────────────────────────
+//
+// We test the generated options by converting certificateIdentityURI to a
+// RegExp and matching sample SAN strings — the same test cosign would apply.
+
+describe("buildVerifyOptions — version tag", () => {
+  function getOpts(ref: string): VerifyBundleOptions {
+    const opts = buildVerifyOptions({ actionRef: ref, actionRepo: REPO });
+    assert.ok(opts, `expected non-null options for ref "${ref}"`);
+    return opts!;
+  }
+  function matchesSAN(opts: VerifyBundleOptions, san: string) {
+    return new RegExp(opts.certificateIdentityURI!).test(san);
+  }
+
+  it("sets certificateIssuer", () => {
+    const opts = getOpts("v2.1.0");
+    assert.equal(opts.certificateIssuer, EXPECTED_ISSUER);
+  });
+
+  it("matches exact full version @v2.1.0 against cert SAN v2.1.0", () => {
+    const opts = getOpts("v2.1.0");
+    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.1.0")));
+  });
+
+  it("matches floating minor @v2.1 against cert SAN v2.1.3", () => {
+    const opts = getOpts("v2.1");
+    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.1.3")));
+  });
+
+  it("matches floating major @v2 against cert SAN v2.99.0", () => {
+    const opts = getOpts("v2");
+    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.99.0")));
+  });
+
+  // ── v2.1 / v2.10 boundary ───────────────────────────────────────────────────
+  it("does NOT match @v2.1 against cert SAN v2.10.0 (boundary check)", () => {
+    const opts = getOpts("v2.1");
+    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v2.10.0")), "@v2.1 must not match v2.10.0");
+  });
+
+  it("does NOT match @v2 against cert SAN v20.0.0 (boundary check)", () => {
+    const opts = getOpts("v2");
+    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v20.0.0")), "@v2 must not match v20.0.0");
+  });
+
+  it("does NOT match @v2.1.0 against cert SAN v2.1.1", () => {
+    const opts = getOpts("v2.1.0");
+    assert.ok(
+      !matchesSAN(opts, makeSAN("refs/tags/v2.1.1")),
+      "exact pin must not match different patch",
+    );
+  });
+
+  it("does NOT match @v2.1 against cert SAN v2.2.0", () => {
+    const opts = getOpts("v2.1");
+    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v2.2.0")), "@v2.1 must not match v2.2.0");
+  });
+
+  it("has no certificateOIDs for version tags", () => {
+    const opts = getOpts("v2.1.0");
+    assert.equal(opts.certificateOIDs, undefined);
+  });
+});
+
+describe("buildVerifyOptions — SHA pin", () => {
+  const pinSha = "a".repeat(40);
+
+  it("sets certificateIssuer", () => {
+    const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
+    assert.equal(opts.certificateIssuer, EXPECTED_ISSUER);
+  });
+
+  it("sets certificateOIDs for OID 1.13 with DER UTF8String-encoded SHA", () => {
+    const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
+    assert.ok(opts.certificateOIDs, "certificateOIDs must be present for SHA pin");
+    const oidValue = opts.certificateOIDs![OID_SOURCE_REPO_DIGEST];
+    assert.ok(oidValue !== undefined, `OID ${OID_SOURCE_REPO_DIGEST} must be set`);
+
+    // DER UTF8String: [0x0C, len, ...utf8bytes]
+    const expected = Buffer.concat([
+      Buffer.from([0x0c, pinSha.length]),
+      Buffer.from(pinSha, "utf8"),
+    ]);
+    assert.deepEqual(Buffer.from(oidValue, "binary"), expected);
+  });
+
+  it("lowercases the SHA in the OID value", () => {
+    const opts = buildVerifyOptions({ actionRef: pinSha.toUpperCase(), actionRepo: REPO })!;
+    const oidValue = opts.certificateOIDs![OID_SOURCE_REPO_DIGEST];
+    assert.ok(oidValue.includes(pinSha.toLowerCase()), "SHA must be lowercased");
+  });
+
+  it("certificateIdentityURI accepts any version tag SAN (SHA checked via OID)", () => {
+    const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
+    const regexp = new RegExp(opts.certificateIdentityURI!);
+    // should match some version tags (the SHA in OID is what pins to the commit)
+    assert.ok(regexp.test(makeSAN("refs/tags/v2.1.0")));
+    assert.ok(regexp.test(makeSAN("refs/tags/v3.0.0")));
+  });
+});
+
+describe("buildVerifyOptions — unverifiable refs", () => {
+  it("returns null for a branch ref", () => {
+    assert.equal(buildVerifyOptions({ actionRef: "main", actionRepo: REPO }), null);
+  });
+
+  it("returns null for a local ./setup ref", () => {
+    assert.equal(buildVerifyOptions({ actionRef: "./setup", actionRepo: REPO }), null);
+  });
+
+  it("returns null for an empty ref", () => {
+    assert.equal(buildVerifyOptions({ actionRef: "", actionRepo: REPO }), null);
+  });
+});

--- a/core/lib/provenance/verify-policy.ts
+++ b/core/lib/provenance/verify-policy.ts
@@ -1,0 +1,62 @@
+import type { VerifyBundleOptions } from "./sigstore.ts";
+import { derUtf8 } from "./signed-digest.ts";
+
+const EXPECTED_ISSUER = "https://token.actions.githubusercontent.com";
+const RELEASE_WORKFLOW = ".github/workflows/docker-publish.yml";
+
+// Fulcio OID: Source Repository Digest — the commit SHA of the build source.
+// Value encoding: DER UTF8String ([0x0C, len, ...utf8bytes]) inside OCTET STRING.
+const OID_SOURCE_REPO_DIGEST = "1.3.6.1.4.1.57264.1.13";
+
+const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export interface VerifyImageIdentity {
+  actionRef: string;
+  actionRepo: string;
+}
+
+/**
+ * Build verify options encoding the expected certificate identity.
+ *
+ * The SAN URI pattern uses `(\.|$)` boundary anchors for version tags so that
+ * e.g. @v2.1 matches v2.1.0 and v2.1.3 but NOT v2.10.0.
+ *
+ * For SHA pins, OID 1.13 (Source Repository Digest) pins the exact commit
+ * while the SAN accepts any release tag.
+ *
+ * Returns null for unverifiable refs (branch names, local paths).
+ */
+export function buildVerifyOptions({
+  actionRef,
+  actionRepo,
+}: VerifyImageIdentity): VerifyBundleOptions | null {
+  const sanPrefix = `^${escapeRegex(`https://github.com/${actionRepo}/${RELEASE_WORKFLOW}@refs/tags/`)}`;
+  const base = {
+    certificateIssuer: EXPECTED_ISSUER,
+    tlogThreshold: 1,
+    ctLogThreshold: 1,
+  };
+
+  // SHA pin: the SAN accepts any v*-prefixed release tag — the exact commit is
+  // pinned by OID 1.13 (Source Repository Digest), which enforces a strict byte
+  // match against the pinned SHA and cannot be satisfied by any other commit.
+  if (/^[0-9a-f]{40}$/i.test(actionRef)) {
+    return {
+      ...base,
+      certificateIdentityURI: `${sanPrefix}v`,
+      certificateOIDs: {
+        [OID_SOURCE_REPO_DIGEST]: derUtf8(actionRef.toLowerCase()),
+      },
+    };
+  }
+
+  // Version tag: SAN ref must match this version (boundary-safe via (\.|$)).
+  if (actionRef.startsWith("v")) {
+    return {
+      ...base,
+      certificateIdentityURI: `${sanPrefix}${escapeRegex(actionRef)}(\\.|$)`,
+    };
+  }
+
+  return null; // branch name, local ./setup, etc. — no verifiable release bundle
+}

--- a/run/dist/main.cjs
+++ b/run/dist/main.cjs
@@ -7437,7 +7437,8 @@ const derUtf8 = (s) => String.fromCharCode(12, s.length) + s;
 * with package-write access could re-attach a valid bundle to a different
 * image; this assertion prevents accepting such a re-attached bundle.
 *
-* Exported for unit testing; callers should use verifyBundle() instead.
+* Exported for unit testing; callers should use sigstore.ts's verifyBundle()
+* instead.
 */
 function assertSignedDigest(bundleJson, expectedDigest) {
 	let dsse = bundleJson?.dsseEnvelope, payload = dsse?.payload;
@@ -7455,6 +7456,8 @@ function assertSignedDigest(bundleJson, expectedDigest) {
 		throw err instanceof VerifyImageError ? err : new VerifyImageError("Failed to parse signed payload from bundle", "VERIFY_FAILED");
 	}
 }
+//#endregion
+//#region core/lib/provenance/sigstore.ts
 /**
 * Cryptographically verify a Sigstore Bundle (DSSE format) against a policy,
 * then assert that the bundle's signed manifest digest matches the fetched digest.
@@ -7490,18 +7493,7 @@ async function verifyBundle(bundleJson, options, expectedDigest) {
 	assertSignedDigest(bundleJson, expectedDigest);
 }
 //#endregion
-//#region core/lib/provenance/verify-image.ts
-/**
-* verify-image.ts — Image provenance verification helpers
-*
-* Verifies the Docker image's Sigstore provenance bundle.
-*
-* Fail-closed policy:
-*   - Any failure for a verifiable ref (version tag / 40-char SHA) → throws
-*     VerifyImageError; the caller (main) is responsible for printing ::error::.
-*   - Unverifiable ref (branch / local ./setup) → returns null.
-*/
-const REGISTRY = "ghcr.io", escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+//#region core/lib/provenance/image-tag.ts
 /**
 * Convert an action ref into the base Docker image tag, then append the
 * proxy engine suffix for non-default engines. The `transparent` engine
@@ -7511,13 +7503,16 @@ const REGISTRY = "ghcr.io", escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g
 * each publish under their own suffix (e.g. `2.1.0-explicit`,
 * `2.1.0-proxy`). All three share the same Sigstore verification identity
 * (same workflow, same git ref) — only the published Docker tag differs, so
-* this does not affect buildVerifyOptions below.
+* this does not affect verify-policy.ts's buildVerifyOptions.
 */
 function imageTagFromRef(actionRef, proxyEngine = "transparent") {
 	if (!actionRef) return "";
 	let base;
 	return base = /^[0-9a-f]{40}$/i.test(actionRef) ? `sha-${actionRef.toLowerCase()}` : actionRef.startsWith("v") ? actionRef.slice(1) : actionRef, proxyEngine === "explicit" || proxyEngine === "proxy" ? `${base}-${proxyEngine}` : base;
 }
+//#endregion
+//#region core/lib/provenance/verify-policy.ts
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 /**
 * Build verify options encoding the expected certificate identity.
 *
@@ -7544,6 +7539,19 @@ function buildVerifyOptions({ actionRef, actionRepo }) {
 		certificateIdentityURI: `${sanPrefix}${escapeRegex(actionRef)}(\\.|$)`
 	} : null;
 }
+//#endregion
+//#region core/lib/provenance/verify-image.ts
+/**
+* verify-image.ts — Image provenance verification helpers
+*
+* Verifies the Docker image's Sigstore provenance bundle.
+*
+* Fail-closed policy:
+*   - Any failure for a verifiable ref (version tag / 40-char SHA) → throws
+*     VerifyImageError; the caller (main) is responsible for printing ::error::.
+*   - Unverifiable ref (branch / local ./setup) → returns null.
+*/
+const REGISTRY = "ghcr.io";
 /**
 * Verify image provenance and return the verified manifest digest.
 *
@@ -8740,7 +8748,7 @@ const composeFile = (0, node_path.join)((0, node_path.dirname)((0, node_url.file
 /**
 * Verifies image provenance and resolves the digest-pinned image ref for
 * the run action's (buildkitd-less) proxy image, published under the `-proxy`
-* tag suffix (see imageTagFromRef in core/lib/provenance/verify-image.ts).
+* tag suffix (see image-tag.ts's imageTagFromRef).
 */
 async function resolveVerifiedImage({ actionRef, actionRepo }) {
 	let digest = await verifyImageDigestOrThrow({

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -7,9 +7,9 @@ import * as core from "@actions/core";
 import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
 import {
   verifyImageDigestOrThrow,
-  type VerifyImageIdentity,
   type ResolvedImage,
 } from "../../core/lib/provenance/verify-image.ts";
+import type { VerifyImageIdentity } from "../../core/lib/provenance/verify-policy.ts";
 import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
 import { createAnnotation, type Annotation } from "../../core/lib/actions/annotation.ts";
 import { logRules } from "../../core/lib/actions/log-rules.ts";
@@ -52,7 +52,7 @@ const LOCAL_IMAGE_OVERRIDE_ENABLED = process.env.BUILDCAGE_BUILD_TEST_HOOKS === 
 /**
  * Verifies image provenance and resolves the digest-pinned image ref for
  * the run action's (buildkitd-less) proxy image, published under the `-proxy`
- * tag suffix (see imageTagFromRef in core/lib/provenance/verify-image.ts).
+ * tag suffix (see image-tag.ts's imageTagFromRef).
  */
 async function resolveVerifiedImage({
   actionRef,

--- a/setup/dist/main.cjs
+++ b/setup/dist/main.cjs
@@ -7408,7 +7408,8 @@ const derUtf8 = (s) => String.fromCharCode(12, s.length) + s;
 * with package-write access could re-attach a valid bundle to a different
 * image; this assertion prevents accepting such a re-attached bundle.
 *
-* Exported for unit testing; callers should use verifyBundle() instead.
+* Exported for unit testing; callers should use sigstore.ts's verifyBundle()
+* instead.
 */
 function assertSignedDigest(bundleJson, expectedDigest) {
 	let dsse = bundleJson?.dsseEnvelope, payload = dsse?.payload;
@@ -7426,6 +7427,8 @@ function assertSignedDigest(bundleJson, expectedDigest) {
 		throw err instanceof VerifyImageError ? err : new VerifyImageError("Failed to parse signed payload from bundle", "VERIFY_FAILED");
 	}
 }
+//#endregion
+//#region core/lib/provenance/sigstore.ts
 /**
 * Cryptographically verify a Sigstore Bundle (DSSE format) against a policy,
 * then assert that the bundle's signed manifest digest matches the fetched digest.
@@ -7461,18 +7464,7 @@ async function verifyBundle(bundleJson, options, expectedDigest) {
 	assertSignedDigest(bundleJson, expectedDigest);
 }
 //#endregion
-//#region core/lib/provenance/verify-image.ts
-/**
-* verify-image.ts — Image provenance verification helpers
-*
-* Verifies the Docker image's Sigstore provenance bundle.
-*
-* Fail-closed policy:
-*   - Any failure for a verifiable ref (version tag / 40-char SHA) → throws
-*     VerifyImageError; the caller (main) is responsible for printing ::error::.
-*   - Unverifiable ref (branch / local ./setup) → returns null.
-*/
-const REGISTRY = "ghcr.io", escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+//#region core/lib/provenance/image-tag.ts
 /**
 * Convert an action ref into the base Docker image tag, then append the
 * proxy engine suffix for non-default engines. The `transparent` engine
@@ -7482,13 +7474,16 @@ const REGISTRY = "ghcr.io", escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g
 * each publish under their own suffix (e.g. `2.1.0-explicit`,
 * `2.1.0-proxy`). All three share the same Sigstore verification identity
 * (same workflow, same git ref) — only the published Docker tag differs, so
-* this does not affect buildVerifyOptions below.
+* this does not affect verify-policy.ts's buildVerifyOptions.
 */
 function imageTagFromRef(actionRef, proxyEngine = "transparent") {
 	if (!actionRef) return "";
 	let base;
 	return base = /^[0-9a-f]{40}$/i.test(actionRef) ? `sha-${actionRef.toLowerCase()}` : actionRef.startsWith("v") ? actionRef.slice(1) : actionRef, proxyEngine === "explicit" || proxyEngine === "proxy" ? `${base}-${proxyEngine}` : base;
 }
+//#endregion
+//#region core/lib/provenance/verify-policy.ts
+const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 /**
 * Build verify options encoding the expected certificate identity.
 *
@@ -7515,6 +7510,19 @@ function buildVerifyOptions({ actionRef, actionRepo }) {
 		certificateIdentityURI: `${sanPrefix}${escapeRegex(actionRef)}(\\.|$)`
 	} : null;
 }
+//#endregion
+//#region core/lib/provenance/verify-image.ts
+/**
+* verify-image.ts — Image provenance verification helpers
+*
+* Verifies the Docker image's Sigstore provenance bundle.
+*
+* Fail-closed policy:
+*   - Any failure for a verifiable ref (version tag / 40-char SHA) → throws
+*     VerifyImageError; the caller (main) is responsible for printing ::error::.
+*   - Unverifiable ref (branch / local ./setup) → returns null.
+*/
+const REGISTRY = "ghcr.io";
 /**
 * Verify image provenance and return the verified manifest digest.
 *
@@ -7729,7 +7737,7 @@ async function main() {
 * Resolve and validate the proxy_engine input.
 * Only "transparent" (default) and "explicit" are accepted — each maps to a
 * separately published, separately tagged Docker image (see
-* lib/verify-image.ts's imageTagFromRef).
+* provenance/image-tag.ts's imageTagFromRef).
 */
 function resolveProxyEngine(input) {
 	let engine = input?.trim() || "transparent";

--- a/setup/src/main.property.test.ts
+++ b/setup/src/main.property.test.ts
@@ -7,7 +7,7 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 
-import { imageTagFromRef } from "../../core/lib/provenance/verify-image.ts";
+import { imageTagFromRef } from "../../core/lib/provenance/image-tag.ts";
 import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
 import { buildACLRules, resolveProxyEngine } from "./main.ts";
 

--- a/setup/src/main.ts
+++ b/setup/src/main.ts
@@ -138,7 +138,7 @@ async function main(): Promise<void> {
  * Resolve and validate the proxy_engine input.
  * Only "transparent" (default) and "explicit" are accepted — each maps to a
  * separately published, separately tagged Docker image (see
- * lib/verify-image.ts's imageTagFromRef).
+ * provenance/image-tag.ts's imageTagFromRef).
  */
 export function resolveProxyEngine(input: string | undefined): "transparent" | "explicit" {
   const engine = input?.trim() || "transparent";


### PR DESCRIPTION
## Summary

`core/lib/provenance/verify-image.ts` and `sigstore.ts` each mixed pure, unit-testable logic with network I/O (registry/TUF calls) — a mismatch already visible in their own test files' header comments ("Tests focus on ... pure functions ... I/O functions are covered by end-to-end tests"). Splits each along that existing boundary:

- `core/lib/provenance/image-tag.ts` — `imageTagFromRef` (pure)
- `core/lib/provenance/verify-policy.ts` — `buildVerifyOptions` and the certificate-identity constants it uses (pure)
- `core/lib/provenance/verify-image.ts` — orchestration only: `verifyImageDigest`, `verifyImageDigestOrThrow`, `toProvenanceError`, `requireDigest` (network I/O + the two thin error helpers around it)
- `core/lib/provenance/signed-digest.ts` — `assertSignedDigest`, `derUtf8` (pure DSSE payload validation)
- `core/lib/provenance/sigstore.ts` — `verifyBundle` only (TUF network call)

`local-image-override.ts` is untouched — it's excluded from every normal build via a build-time dynamic-import gate (`BUILDCAGE_BUILD_TEST_HOOKS`), and merging it into another file would pull it into the always-bundled graph and break that tree-shaking.

Pure move — no logic changes. Test files split along the same boundary (each new module gets its own file, unchanged assertions).

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/lib run/src setup/src report/src` (46 files, 444 tests)
- [x] `make test_unit` (incl. QuickJS scripts build)
- [x] `vp run build` — `setup/dist/main.cjs`, `run/dist/main.cjs` rebuilt and committed