### PR TITLE
refactor: introduce #core/* import alias for deep relative paths into core/lib

### DIFF
--- a/core/lib/report/build/aggregate.test.ts
+++ b/core/lib/report/build/aggregate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { annotateKnownBlocked, aggregateAllowedHosts } from "./aggregate.ts";
 
 describe("annotateKnownBlocked", () => {

--- a/core/lib/report/build/aggregate.ts
+++ b/core/lib/report/build/aggregate.ts
@@ -1,7 +1,7 @@
-import { convertRule } from "../../acl/wildcard-rules.ts";
-import { parseIdentifier } from "../../log/parse-identifier.ts";
-import { aggregate, type AggregatedEntry } from "../../log/aggregate.ts";
-import type { AllowedRequest } from "../../log/proxy-request-text.ts";
+import { convertRule } from "#core/lib/acl/wildcard-rules.ts";
+import { parseIdentifier } from "#core/lib/log/parse-identifier.ts";
+import { aggregate, type AggregatedEntry } from "#core/lib/log/aggregate.ts";
+import type { AllowedRequest } from "#core/lib/log/proxy-request-text.ts";
 
 export type BlockedRow = AggregatedEntry;
 

--- a/core/lib/report/build/explicit.test.ts
+++ b/core/lib/report/build/explicit.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { buildExplicitReportData } from "./explicit.ts";
 import type { GenReportParameters } from "../types.ts";
-import type { VertexAllowedEntry } from "../../log/vertex.ts";
+import type { VertexAllowedEntry } from "#core/lib/log/vertex.ts";
 
 function params(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {

--- a/core/lib/report/build/explicit.ts
+++ b/core/lib/report/build/explicit.ts
@@ -1,6 +1,6 @@
-import { scanBuildkitdLog } from "../../log/buildkitd.ts";
+import { scanBuildkitdLog } from "#core/lib/log/buildkitd.ts";
 import { aggregateAllowedHosts, annotateKnownBlocked } from "./aggregate.ts";
-import type { VertexAllowedEntry } from "../../log/vertex.ts";
+import type { VertexAllowedEntry } from "#core/lib/log/vertex.ts";
 import type { GenReportParameters, ExplicitReportData } from "../types.ts";
 
 /** Pure — no I/O; callers fetch lines/builds/parameters themselves. */

--- a/core/lib/report/build/transparent.test.ts
+++ b/core/lib/report/build/transparent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { buildTransparentReportData } from "./transparent.ts";
 import type { GenReportParameters } from "../types.ts";
 

--- a/core/lib/report/build/transparent.ts
+++ b/core/lib/report/build/transparent.ts
@@ -1,4 +1,4 @@
-import { scanHaproxyLog } from "../../log/haproxy.ts";
+import { scanHaproxyLog } from "#core/lib/log/haproxy.ts";
 import { annotateKnownBlocked } from "./aggregate.ts";
 import type { GenReportParameters, TransparentReportData } from "../types.ts";
 

--- a/core/lib/report/outcome/annotate.ts
+++ b/core/lib/report/outcome/annotate.ts
@@ -1,4 +1,4 @@
-import type { Annotation } from "../../actions/annotation.ts";
+import type { Annotation } from "#core/lib/actions/annotation.ts";
 
 export interface OutcomeEmission {
   level: "none" | "notice" | "error";

--- a/core/lib/report/outcome/blocked-outcome.test.ts
+++ b/core/lib/report/outcome/blocked-outcome.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import {
   determineBlockedOutcome,
   buildBlockedMessage,

--- a/core/lib/report/outcome/emit.ts
+++ b/core/lib/report/outcome/emit.ts
@@ -1,5 +1,5 @@
 /** Emits an annotation and sets the exit code for a blocked-connection outcome. */
-import { createAnnotation } from "../../actions/annotation.ts";
+import { createAnnotation } from "#core/lib/actions/annotation.ts";
 import { describeBlockedOutcome } from "./blocked-outcome.ts";
 import { applyOutcomeAnnotation } from "./annotate.ts";
 import type { ReportDataCommon } from "../types.ts";

--- a/core/lib/report/render/build-example.test.ts
+++ b/core/lib/report/render/build-example.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { buildRestrictExample } from "./build-example.ts";
 
 const REPO = "dash14/buildcage";

--- a/core/lib/report/render/build-example.ts
+++ b/core/lib/report/render/build-example.ts
@@ -1,4 +1,4 @@
-import type { AggregatedEntry } from "../../log/aggregate.ts";
+import type { AggregatedEntry } from "#core/lib/log/aggregate.ts";
 
 const ruleTypeToParam: Record<string, string> = {
   HTTPS: "allowed_https_rules",

--- a/core/lib/report/render/communication-details.test.ts
+++ b/core/lib/report/render/communication-details.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { renderCommunicationDetails } from "./communication-details.ts";
 
 function wrap(body: string) {

--- a/core/lib/report/render/communication-details.ts
+++ b/core/lib/report/render/communication-details.ts
@@ -1,5 +1,5 @@
-import type { AllowedRequest } from "../../log/proxy-request-text.ts";
-import type { VertexAllowedEntry } from "../../log/vertex.ts";
+import type { AllowedRequest } from "#core/lib/log/proxy-request-text.ts";
+import type { VertexAllowedEntry } from "#core/lib/log/vertex.ts";
 import type { DeniedEntry } from "../types.ts";
 
 /**

--- a/core/lib/report/render/host-table.test.ts
+++ b/core/lib/report/render/host-table.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { renderHostTable } from "./host-table.ts";
 
 describe("renderHostTable", () => {

--- a/core/lib/report/render/host-table.ts
+++ b/core/lib/report/render/host-table.ts
@@ -1,5 +1,5 @@
 import { markdownTable, type ColumnFormat } from "./markdown-table.ts";
-import type { AggregatedEntry } from "../../log/aggregate.ts";
+import type { AggregatedEntry } from "#core/lib/log/aggregate.ts";
 
 export interface HostTableRow extends Omit<AggregatedEntry, "reason"> {
   reason?: string;

--- a/core/lib/report/render/render-report-markdown.test.ts
+++ b/core/lib/report/render/render-report-markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../../test/test-shim.ts";
+import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
 import { renderReportMarkdown } from "./render-report-markdown.ts";
 import type { GenReportParameters, TransparentReportData, ExplicitReportData } from "../types.ts";
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "buildcage",
   "private": true,
   "type": "module",
+  "imports": {
+    "#core/*": "./core/*"
+  },
   "scripts": {
     "build": "rolldown -c",
     "build:qjs": "BUILD_TARGET=qjs rolldown -c rolldown.scripts.config.js",

--- a/report/src/lib/errors.ts
+++ b/report/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import { ActionError } from "../../../core/lib/errors.ts";
+import { ActionError } from "#core/lib/errors.ts";
 
 /**
  * ReportError — intentional error in the report action's own logic. Invalid

--- a/report/src/main.ts
+++ b/report/src/main.ts
@@ -5,14 +5,11 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
 
-import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
-import { resolveProjectName } from "../../core/lib/docker/compose-project-name.ts";
-import { createDocker } from "../../core/lib/docker/client.ts";
-import {
-  REPORT_ACTION_SCRIPT_PATH,
-  REPORT_SOURCE_LABEL,
-} from "../../core/lib/docker/report-source.ts";
-import { ActionError, errorMessage } from "../../core/lib/errors.ts";
+import { describeDockerFailure } from "#core/lib/actions/docker-error.ts";
+import { resolveProjectName } from "#core/lib/docker/compose-project-name.ts";
+import { createDocker } from "#core/lib/docker/client.ts";
+import { REPORT_ACTION_SCRIPT_PATH, REPORT_SOURCE_LABEL } from "#core/lib/docker/report-source.ts";
+import { ActionError, errorMessage } from "#core/lib/errors.ts";
 import { ReportError } from "./lib/errors.ts";
 
 // Gates the COMPOSE_PROJECT_NAME override to this repo's own CI/dev testing.

--- a/run/src/lib/container.test.ts
+++ b/run/src/lib/container.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { generateContainerName, getContainerPid, isContainerNotFoundError } from "./container.ts";
-import { deriveProjectName } from "../../../core/lib/docker/compose-project-name.ts";
+import { deriveProjectName } from "#core/lib/docker/compose-project-name.ts";
 import { SandboxError } from "./errors.ts";
 
 describe("generateContainerName", () => {

--- a/run/src/lib/container.ts
+++ b/run/src/lib/container.ts
@@ -1,10 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 
-import {
-  describeDockerFailure,
-  type DockerErrorLike,
-} from "../../../core/lib/actions/docker-error.ts";
+import { describeDockerFailure, type DockerErrorLike } from "#core/lib/actions/docker-error.ts";
 import { SandboxError } from "./errors.ts";
 
 /**

--- a/run/src/lib/errors.ts
+++ b/run/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import { ActionError } from "../../../core/lib/errors.ts";
+import { ActionError } from "#core/lib/errors.ts";
 
 /**
  * SandboxError — intentional error in the run action's own logic. Image

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -2,8 +2,8 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { computeReportOutcome, type Report, type ComputeReportOutcomeOptions } from "./report.ts";
-import { annotateKnownBlocked } from "../../../core/lib/report/build/aggregate.ts";
-import type { GenReportParameters } from "../../../core/lib/report/types.ts";
+import { annotateKnownBlocked } from "#core/lib/report/build/aggregate.ts";
+import type { GenReportParameters } from "#core/lib/report/types.ts";
 
 function parameters(overrides: Partial<GenReportParameters> = {}): GenReportParameters {
   return {

--- a/run/src/lib/report.ts
+++ b/run/src/lib/report.ts
@@ -1,8 +1,8 @@
-import { createDocker } from "../../../core/lib/docker/client.ts";
-import { describeBlockedOutcome } from "../../../core/lib/report/outcome/blocked-outcome.ts";
-import { renderReportMarkdown } from "../../../core/lib/report/render/render-report-markdown.ts";
-import { buildTransparentReportData } from "../../../core/lib/report/build/transparent.ts";
-import type { GenReportParameters, TransparentReportData } from "../../../core/lib/report/types.ts";
+import { createDocker } from "#core/lib/docker/client.ts";
+import { describeBlockedOutcome } from "#core/lib/report/outcome/blocked-outcome.ts";
+import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
+import { buildTransparentReportData } from "#core/lib/report/build/transparent.ts";
+import type { GenReportParameters, TransparentReportData } from "#core/lib/report/types.ts";
 
 export type Report = TransparentReportData;
 

--- a/run/src/lib/sandbox/runc-bootstrap.ts
+++ b/run/src/lib/sandbox/runc-bootstrap.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, chmodSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { buildDockerCpArgs } from "../../../../core/lib/docker/args.ts";
+import { buildDockerCpArgs } from "#core/lib/docker/args.ts";
 import type { OciSpec } from "./types.ts";
 
 /**

--- a/run/src/lib/sandbox/scratch-dir.ts
+++ b/run/src/lib/sandbox/scratch-dir.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { errorMessage } from "../../../../core/lib/errors.ts";
+import { errorMessage } from "#core/lib/errors.ts";
 import { parseMountinfo } from "./mountinfo.ts";
 
 // Base directory for each run's scratch dir (OCI bundle + the host-`/`

--- a/run/src/lib/sudo-preflight.ts
+++ b/run/src/lib/sudo-preflight.ts
@@ -6,7 +6,7 @@ import {
   SLIM_RUNNER_DETECTED_PREFIX,
   isLikelySlimRunner,
   type DockerErrorLike,
-} from "../../../core/lib/actions/docker-error.ts";
+} from "#core/lib/actions/docker-error.ts";
 
 const REQUIREMENT =
   "The run action requires a Linux runner with passwordless sudo for the isolation setup itself " +

--- a/run/src/main.test.ts
+++ b/run/src/main.test.ts
@@ -7,7 +7,7 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
 import { buildACLRules, parseWritablePaths, readKnownBlockedRules } from "./main.ts";
-import { InvalidRulesError } from "../../core/lib/acl/rules.ts";
+import { InvalidRulesError } from "#core/lib/acl/rules.ts";
 
 describe("buildACLRules", () => {
   it("parses whitespace-separated HTTPS rules", () => {

--- a/run/src/main.ts
+++ b/run/src/main.ts
@@ -4,22 +4,19 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
 
-import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
-import {
-  verifyImageDigestOrThrow,
-  type ResolvedImage,
-} from "../../core/lib/provenance/verify-image.ts";
-import type { VerifyImageIdentity } from "../../core/lib/provenance/verify-policy.ts";
-import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
-import { createAnnotation, type Annotation } from "../../core/lib/actions/annotation.ts";
-import { logRules } from "../../core/lib/actions/log.ts";
-import { ActionError, errorMessage } from "../../core/lib/errors.ts";
-import { buildACLRules, parseRulesOrThrow } from "../../core/lib/acl/rules.ts";
+import { resolveBuildcageImageRef } from "#core/lib/provenance/image-ref.ts";
+import { verifyImageDigestOrThrow, type ResolvedImage } from "#core/lib/provenance/verify-image.ts";
+import type { VerifyImageIdentity } from "#core/lib/provenance/verify-policy.ts";
+import { describeDockerFailure } from "#core/lib/actions/docker-error.ts";
+import { createAnnotation, type Annotation } from "#core/lib/actions/annotation.ts";
+import { logRules } from "#core/lib/actions/log.ts";
+import { ActionError, errorMessage } from "#core/lib/errors.ts";
+import { buildACLRules, parseRulesOrThrow } from "#core/lib/acl/rules.ts";
 import { SandboxError } from "./lib/errors.ts";
 import { checkPasswordlessSudo } from "./lib/sudo-preflight.ts";
 import { generateContainerName, getContainerPid } from "./lib/container.ts";
-import { deriveProjectName } from "../../core/lib/docker/compose-project-name.ts";
-import { buildComposeUpArgs, buildComposeDownArgs } from "../../core/lib/docker/args.ts";
+import { deriveProjectName } from "#core/lib/docker/compose-project-name.ts";
+import { buildComposeUpArgs, buildComposeDownArgs } from "#core/lib/docker/args.ts";
 import { extractRuncBootstrap } from "./lib/sandbox/runc-bootstrap.ts";
 import {
   writeRunScript,
@@ -37,7 +34,7 @@ import {
   type ComputeReportOutcomeOptions,
 } from "./lib/report.ts";
 import { writeStepSummary } from "../../setup/docker/lib/write-step-summary.ts";
-import { applyOutcomeAnnotation } from "../../core/lib/report/outcome/annotate.ts";
+import { applyOutcomeAnnotation } from "#core/lib/report/outcome/annotate.ts";
 
 export { buildACLRules };
 

--- a/run/src/post.ts
+++ b/run/src/post.ts
@@ -4,9 +4,9 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
 
-import { buildComposeDownArgs } from "../../core/lib/docker/args.ts";
+import { buildComposeDownArgs } from "#core/lib/docker/args.ts";
 import { cleanupScratchDir, scratchDirFor } from "./lib/sandbox/scratch-dir.ts";
-import { errorMessage } from "../../core/lib/errors.ts";
+import { errorMessage } from "#core/lib/errors.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/setup/docker/explicit/scripts/gen-source-policy.qjs.ts
+++ b/setup/docker/explicit/scripts/gen-source-policy.qjs.ts
@@ -5,7 +5,7 @@
  * Usage: qjs --std -m gen-source-policy.js <proxy_mode> <https_rules> <http_rules> <ip_rules>
  */
 import * as std from "qjs:std";
-import { buildSourcePolicy } from "../../../../core/lib/acl/source-policy.js";
+import { buildSourcePolicy } from "#core/lib/acl/source-policy.js";
 
 const [proxyMode, httpsRulesInput, httpRulesInput, ipRulesInput] = scriptArgs.slice(1);
 

--- a/setup/docker/explicit/scripts/report-action.node.ts
+++ b/setup/docker/explicit/scripts/report-action.node.ts
@@ -8,17 +8,17 @@
  * rather than needing buildctl reachable from the runner.
  */
 import * as core from "@actions/core";
-import { createDocker, type Docker } from "../../../../core/lib/docker/client.ts";
-import { buildReportParameters } from "../../../../core/lib/report/parameters.ts";
-import { buildExplicitReportData } from "../../../../core/lib/report/build/explicit.ts";
-import { renderReportMarkdown } from "../../../../core/lib/report/render/render-report-markdown.ts";
-import { renderCommunicationDetails } from "../../../../core/lib/report/render/communication-details.ts";
-import { emitBlockedOutcome } from "../../../../core/lib/report/outcome/emit.ts";
-import { errorMessage } from "../../../../core/lib/errors.ts";
-import { wrapLogGroup } from "../../../../core/lib/actions/log.ts";
+import { createDocker, type Docker } from "#core/lib/docker/client.ts";
+import { buildReportParameters } from "#core/lib/report/parameters.ts";
+import { buildExplicitReportData } from "#core/lib/report/build/explicit.ts";
+import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
+import { renderCommunicationDetails } from "#core/lib/report/render/communication-details.ts";
+import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
+import { errorMessage } from "#core/lib/errors.ts";
+import { wrapLogGroup } from "#core/lib/actions/log.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
-import { selectAllRefs } from "../../../../core/lib/log/build-histories.ts";
-import { parseVertexAllowedLog, type VertexAllowedEntry } from "../../../../core/lib/log/vertex.ts";
+import { selectAllRefs } from "#core/lib/log/build-histories.ts";
+import { parseVertexAllowedLog, type VertexAllowedEntry } from "#core/lib/log/vertex.ts";
 
 const LOG_FILE = "/var/log/buildkitd/current";
 

--- a/setup/docker/transparent/scripts/report-action.node.ts
+++ b/setup/docker/transparent/scripts/report-action.node.ts
@@ -8,12 +8,12 @@
  * var names.
  */
 import * as core from "@actions/core";
-import { createDocker } from "../../../../core/lib/docker/client.ts";
-import { buildReportParameters } from "../../../../core/lib/report/parameters.ts";
-import { buildTransparentReportData } from "../../../../core/lib/report/build/transparent.ts";
-import { renderReportMarkdown } from "../../../../core/lib/report/render/render-report-markdown.ts";
-import { emitBlockedOutcome } from "../../../../core/lib/report/outcome/emit.ts";
-import { errorMessage } from "../../../../core/lib/errors.ts";
+import { createDocker } from "#core/lib/docker/client.ts";
+import { buildReportParameters } from "#core/lib/report/parameters.ts";
+import { buildTransparentReportData } from "#core/lib/report/build/transparent.ts";
+import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
+import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
+import { errorMessage } from "#core/lib/errors.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
 
 const LOG_FILE = "/var/log/haproxy/current";

--- a/setup/src/lib/errors.ts
+++ b/setup/src/lib/errors.ts
@@ -1,4 +1,4 @@
-import { ActionError } from "../../../core/lib/errors.ts";
+import { ActionError } from "#core/lib/errors.ts";
 
 /**
  * SetupError — intentional error in the setup action's own logic. Image

--- a/setup/src/main.property.test.ts
+++ b/setup/src/main.property.test.ts
@@ -7,8 +7,8 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import fc from "fast-check";
 
-import { imageTagFromRef } from "../../core/lib/provenance/image-tag.ts";
-import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
+import { imageTagFromRef } from "#core/lib/provenance/image-tag.ts";
+import { resolveBuildcageImageRef } from "#core/lib/provenance/image-ref.ts";
 import { buildACLRules, resolveProxyEngine } from "./main.ts";
 
 // ---------------------------------------------------------------------------

--- a/setup/src/main.test.ts
+++ b/setup/src/main.test.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 
-import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
+import { resolveBuildcageImageRef } from "#core/lib/provenance/image-ref.ts";
 import { buildACLRules, resolveProxyEngine } from "./main.ts";
 
 // ---------------------------------------------------------------------------

--- a/setup/src/main.ts
+++ b/setup/src/main.ts
@@ -4,18 +4,18 @@ import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
 
 import { SetupError } from "./lib/errors.ts";
-import { ActionError, errorMessage } from "../../core/lib/errors.ts";
-import { buildACLRules, parseRulesOrThrow } from "../../core/lib/acl/rules.ts";
+import { ActionError, errorMessage } from "#core/lib/errors.ts";
+import { buildACLRules, parseRulesOrThrow } from "#core/lib/acl/rules.ts";
 import {
   verifyImageDigestOrThrow,
   type VerifyImageDigestOptions,
   type ResolvedImage,
-} from "../../core/lib/provenance/verify-image.ts";
-import { resolveBuildcageImageRef } from "../../core/lib/provenance/image-ref.ts";
-import { describeDockerFailure } from "../../core/lib/actions/docker-error.ts";
-import { logRules } from "../../core/lib/actions/log.ts";
-import { deriveProjectName } from "../../core/lib/docker/compose-project-name.ts";
-import { buildComposeUpArgs, buildComposeDownArgs } from "../../core/lib/docker/args.ts";
+} from "#core/lib/provenance/verify-image.ts";
+import { resolveBuildcageImageRef } from "#core/lib/provenance/image-ref.ts";
+import { describeDockerFailure } from "#core/lib/actions/docker-error.ts";
+import { logRules } from "#core/lib/actions/log.ts";
+import { deriveProjectName } from "#core/lib/docker/compose-project-name.ts";
+import { buildComposeUpArgs, buildComposeDownArgs } from "#core/lib/docker/args.ts";
 
 export { buildACLRules };
 

--- a/setup/src/post.ts
+++ b/setup/src/post.ts
@@ -2,8 +2,8 @@ import { execFileSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as core from "@actions/core";
-import { resolveProjectName } from "../../core/lib/docker/compose-project-name.ts";
-import { buildComposeDownArgs } from "../../core/lib/docker/args.ts";
+import { resolveProjectName } from "#core/lib/docker/compose-project-name.ts";
+import { buildComposeDownArgs } from "#core/lib/docker/args.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
## Summary

Deep relative imports (`../../`, `../../../..`) into `core/lib/` were hard to read at a glance — couldn't tell where they landed without counting `../` segments. Adds a `#core/*` subpath import mapping in `package.json`'s native `imports` field, pointing at `./core/*`, and rewrites every import 2+ directory levels away from its target to use it. Same-directory and one-level-up imports are left as relative, per usual convention.

**Why `package.json`'s `imports` field (`#`-prefixed) rather than a `@/` bundler-only alias**: this repo's Makefile-driven local/CI test flow runs several entry points directly via plain `node` (not through the bundled `dist/`) — `node report/src/main.ts`, `node setup/src/post.ts`, etc. (see `make test_integration_buildkit_*`, `make report_buildkit`). A `@/`-style alias only resolvable by a bundler/tsconfig `paths` would break those. Node's package `imports` field is natively understood by plain Node ESM resolution, `tsc` under `moduleResolution: nodenext` (already in use here), Vite/vitest, and rolldown — so `#core/*` works everywhere with zero extra loader machinery. Verified directly: `node report/src/main.ts`, `node setup/src/main.ts`, `node run/src/main.ts`, `node setup/src/post.ts`, `node run/src/post.ts` all resolve past their `#core/...` imports and fail only on their expected runtime preconditions (no container running, missing input, etc).

Cross-package relative imports that don't target `core/` (e.g. `run/src/main.ts`'s reference into `setup/docker/lib/`) are left untouched — out of scope for this pass.

Pure import-path rewrite — no logic changes. Built output is byte-identical (`git diff` on `setup/dist`, `run/dist`, `report/dist` is empty after rebuilding).

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/lib run/src setup/src report/src` (47 files, 444 tests)
- [x] `make test_unit` (incl. QuickJS scripts build — confirms rolldown resolves `#core/*` inside the Docker build environment too)
- [x] `vp run build` and `pnpm run build:scripts` — verified no `#core` string remains in any bundled output, and dist is byte-identical to before
- [x] Manually ran `node report/src/main.ts`, `node setup/src/main.ts`, `node run/src/main.ts`, `node setup/src/post.ts`, `node run/src/post.ts` directly — all resolve imports correctly (fail only on missing runtime preconditions, not module resolution)