### PR TITLE
test: adopt vitest-style expect() assertions, powered by chai under QuickJS too

### DIFF
--- a/core/lib/acl/source-policy.test.ts
+++ b/core/lib/acl/source-policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { buildSourcePolicy } from "./source-policy.ts";
 
 // Simulates BuildKit's sourcepolicy engine evaluation order exactly
@@ -32,8 +32,8 @@ describe("buildSourcePolicy — rule order (last-match-wins engine semantics)", 
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(policy.rules[0].action, "DENY");
-    assert.equal(policy.rules[1].action, "ALLOW");
+    expect(policy.rules[0].action).toBe("DENY");
+    expect(policy.rules[1].action).toBe("ALLOW");
   });
 
   it("an allowed domain evaluates to ALLOW end-to-end", () => {
@@ -43,8 +43,8 @@ describe("buildSourcePolicy — rule order (last-match-wins engine semantics)", 
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(evaluate(policy, "https://example.com/"), "ALLOW");
-    assert.equal(evaluate(policy, "https://example.com:443/"), "ALLOW");
+    expect(evaluate(policy, "https://example.com/")).toBe("ALLOW");
+    expect(evaluate(policy, "https://example.com:443/")).toBe("ALLOW");
   });
 
   it("a non-allowed domain evaluates to DENY end-to-end", () => {
@@ -54,7 +54,7 @@ describe("buildSourcePolicy — rule order (last-match-wins engine semantics)", 
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(evaluate(policy, "https://blocked.example.com/"), "DENY");
+    expect(evaluate(policy, "https://blocked.example.com/")).toBe("DENY");
   });
 
   it("non-http(s) sources evaluate to ALLOW (no rule ever matches them)", () => {
@@ -64,8 +64,8 @@ describe("buildSourcePolicy — rule order (last-match-wins engine semantics)", 
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(evaluate(policy, "docker-image://docker.io/library/alpine:latest"), "ALLOW");
-    assert.equal(evaluate(policy, "git://github.com/foo/bar.git"), "ALLOW");
+    expect(evaluate(policy, "docker-image://docker.io/library/alpine:latest")).toBe("ALLOW");
+    expect(evaluate(policy, "git://github.com/foo/bar.git")).toBe("ALLOW");
   });
 });
 
@@ -77,8 +77,8 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(policy.version, 1);
-    assert.deepEqual(policy.rules, [
+    expect(policy.version).toBe(1);
+    expect(policy.rules).toStrictEqual([
       { action: "DENY", selector: { identifier: "^https?://.*", matchType: "REGEX" } },
       {
         action: "ALLOW",
@@ -94,7 +94,7 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       httpRulesInput: "deb.debian.org:80",
       ipRulesInput: "",
     });
-    assert.deepEqual(policy.rules[1], {
+    expect(policy.rules[1]).toStrictEqual({
       action: "ALLOW",
       selector: { identifier: "^http://deb\\.debian\\.org(:80)?(/.*)?$", matchType: "REGEX" },
     });
@@ -107,7 +107,7 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(policy.rules[1].selector.identifier, "^https://example\\.com:8443(/.*)?$");
+    expect(policy.rules[1].selector.identifier).toBe("^https://example\\.com:8443(/.*)?$");
   });
 
   it("a wildcard port (:*) is optional too, so it also covers the implicit default port", () => {
@@ -118,9 +118,9 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       ipRulesInput: "",
     });
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://example.com/")); // no port in the URL at all
-    assert.ok(re.test("https://example.com:443/"));
-    assert.ok(re.test("https://example.com:8080/"));
+    expect(re.test("https://example.com/")).toBeTruthy(); // no port in the URL at all
+    expect(re.test("https://example.com:443/")).toBeTruthy();
+    expect(re.test("https://example.com:8080/")).toBeTruthy();
   });
 
   it("expands each ip rule into both an https and an http ALLOW rule", () => {
@@ -130,7 +130,7 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       httpRulesInput: "",
       ipRulesInput: "192.168.1.1:443",
     });
-    assert.deepEqual(policy.rules.slice(1, 3), [
+    expect(policy.rules.slice(1, 3)).toStrictEqual([
       {
         action: "ALLOW",
         selector: { identifier: "^https://192\\.168\\.1\\.1(:443)?(/.*)?$", matchType: "REGEX" },
@@ -150,8 +150,7 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(
-      policy.rules[1].selector.identifier,
+    expect(policy.rules[1].selector.identifier).toBe(
       "^https://[^.]+\\.example\\.com(:443)?(/.*)?$",
     );
   });
@@ -164,14 +163,14 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       ipRulesInput: "",
     });
     const deny = policy.rules[0];
-    assert.equal(deny.action, "DENY");
+    expect(deny.action).toBe("DENY");
     const re = new RegExp(deny.selector.identifier);
-    assert.ok(!re.test("docker-image://docker.io/library/alpine:latest"));
-    assert.ok(!re.test("git://github.com/foo/bar.git"));
-    assert.ok(!re.test("local://context"));
-    assert.ok(!re.test("oci-layout://foo"));
-    assert.ok(re.test("https://blocked.example.com/"));
-    assert.ok(re.test("http://blocked.example.com/"));
+    expect(!re.test("docker-image://docker.io/library/alpine:latest")).toBeTruthy();
+    expect(!re.test("git://github.com/foo/bar.git")).toBeTruthy();
+    expect(!re.test("local://context")).toBeTruthy();
+    expect(!re.test("oci-layout://foo")).toBeTruthy();
+    expect(re.test("https://blocked.example.com/")).toBeTruthy();
+    expect(re.test("http://blocked.example.com/")).toBeTruthy();
   });
 
   it("the ALLOW rule matches the domain with any path, with or without an explicit default port", () => {
@@ -182,11 +181,11 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       ipRulesInput: "",
     });
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://example.com/")); // BuildKit omits :443 when the client didn't specify a port
-    assert.ok(re.test("https://example.com:443/"));
-    assert.ok(re.test("https://example.com:443/some/path?query=1"));
-    assert.ok(!re.test("https://other.com:443/"));
-    assert.ok(!re.test("https://other.com/"));
+    expect(re.test("https://example.com/")).toBeTruthy(); // BuildKit omits :443 when the client didn't specify a port
+    expect(re.test("https://example.com:443/")).toBeTruthy();
+    expect(re.test("https://example.com:443/some/path?query=1")).toBeTruthy();
+    expect(!re.test("https://other.com:443/")).toBeTruthy();
+    expect(!re.test("https://other.com/")).toBeTruthy();
   });
 
   it("empty rule inputs still produce the DENY catch-all only", () => {
@@ -196,7 +195,7 @@ describe("buildSourcePolicy — restrict mode rule shape", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.deepEqual(policy.rules, [
+    expect(policy.rules).toStrictEqual([
       { action: "DENY", selector: { identifier: "^https?://.*", matchType: "REGEX" } },
     ]);
   });
@@ -210,7 +209,7 @@ describe("buildSourcePolicy — regex (~) rules", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.equal(policy.rules[1].selector.identifier, "^https://custom\\.regex:443(/.*)?$");
+    expect(policy.rules[1].selector.identifier).toBe("^https://custom\\.regex:443(/.*)?$");
   });
 
   it("works the same way for an http rule (scheme is a parameter, not hardcoded)", () => {
@@ -220,7 +219,7 @@ describe("buildSourcePolicy — regex (~) rules", () => {
       httpRulesInput: "~^custom\\.regex:80$",
       ipRulesInput: "",
     });
-    assert.equal(policy.rules[1].selector.identifier, "^http://custom\\.regex:80(/.*)?$");
+    expect(policy.rules[1].selector.identifier).toBe("^http://custom\\.regex:80(/.*)?$");
   });
 
   it("an anchor-less regex matches as a substring within the domain, but the missing anchors don't reach into the path", () => {
@@ -231,13 +230,13 @@ describe("buildSourcePolicy — regex (~) rules", () => {
       ipRulesInput: "",
     });
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://example.com/"));
-    assert.ok(re.test("https://notexample.com/")); // no leading anchor: matches anywhere
-    assert.ok(re.test("https://example.company/")); // no trailing anchor: matches anywhere
+    expect(re.test("https://example.com/")).toBeTruthy();
+    expect(re.test("https://notexample.com/")).toBeTruthy(); // no leading anchor: matches anywhere
+    expect(re.test("https://example.company/")).toBeTruthy(); // no trailing anchor: matches anywhere
     // ...but the domain-side [^/]* filling each missing anchor can't reach
     // past a "/" to satisfy a match that only exists in the path, unlike a
     // naive unbounded ".*" would.
-    assert.ok(!re.test("https://evil.com/example.com/"));
+    expect(!re.test("https://evil.com/example.com/")).toBeTruthy();
   });
 
   it("only the anchors actually present are stripped — an unanchored end still gets its own [^/]*", () => {
@@ -248,8 +247,8 @@ describe("buildSourcePolicy — regex (~) rules", () => {
       ipRulesInput: "",
     });
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://example.com/")); // leading-anchored, trailing open
-    assert.ok(!re.test("https://notexample.com/")); // leading anchor still enforced
+    expect(re.test("https://example.com/")).toBeTruthy(); // leading-anchored, trailing open
+    expect(!re.test("https://notexample.com/")).toBeTruthy(); // leading anchor still enforced
   });
 
   it("the user's own \".*\" is confined to the domain (converted to [^/]*), so it can't cross into the path", () => {
@@ -260,8 +259,8 @@ describe("buildSourcePolicy — regex (~) rules", () => {
       ipRulesInput: "",
     });
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://sub.example.com:443/"));
-    assert.ok(!re.test("https://evil.com/sub.example.com:443/"));
+    expect(re.test("https://sub.example.com:443/")).toBeTruthy();
+    expect(!re.test("https://evil.com/sub.example.com:443/")).toBeTruthy();
   });
 
   it("an escaped literal trailing $ is not mistaken for the end anchor (regression)", () => {
@@ -275,8 +274,8 @@ describe("buildSourcePolicy — regex (~) rules", () => {
     // the wrapper's own "(" — see git history for the exact failure): the
     // trailing "$" here is escaped (a literal dollar sign), not an anchor.
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://foo$/"));
-    assert.ok(!re.test("https://bar$/"));
+    expect(re.test("https://foo$/")).toBeTruthy();
+    expect(!re.test("https://bar$/")).toBeTruthy();
   });
 
   it("an escaped literal '.' followed by a real '*' quantifier is left alone (not confined)", () => {
@@ -289,8 +288,8 @@ describe("buildSourcePolicy — regex (~) rules", () => {
     // `\.*` here means "zero or more literal dots", not the wildcard `.*` —
     // confineDotStarToDomain must not touch it.
     const re = new RegExp(policy.rules[1].selector.identifier);
-    assert.ok(re.test("https://example.com:443/"));
-    assert.ok(re.test("https://example.com:443.../"));
+    expect(re.test("https://example.com:443/")).toBeTruthy();
+    expect(re.test("https://example.com:443.../")).toBeTruthy();
   });
 });
 
@@ -302,7 +301,7 @@ describe("buildSourcePolicy — audit mode", () => {
       httpRulesInput: "deb.debian.org:80",
       ipRulesInput: "192.168.1.1:443",
     });
-    assert.deepEqual(policy, { version: 1, rules: [] });
+    expect(policy).toStrictEqual({ version: 1, rules: [] });
   });
 });
 

--- a/core/lib/acl/wildcard-rules.test.ts
+++ b/core/lib/acl/wildcard-rules.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import {
   wildcardToRegex,
   convertRule,
@@ -11,51 +11,51 @@ import {
 // ---------------------------------------------------------------------------
 describe("wildcardToRegex", () => {
   it("exact domain — dots escaped", () => {
-    assert.equal(wildcardToRegex("example.com:443"), "example\\.com:443");
+    expect(wildcardToRegex("example.com:443")).toBe("example\\.com:443");
   });
 
   it("single wildcard *", () => {
-    assert.equal(wildcardToRegex("*.example.com:443"), "[^.]+\\.example\\.com:443");
+    expect(wildcardToRegex("*.example.com:443")).toBe("[^.]+\\.example\\.com:443");
   });
 
   it("double wildcard **", () => {
-    assert.equal(wildcardToRegex("**.example.com:443"), ".+\\.example\\.com:443");
+    expect(wildcardToRegex("**.example.com:443")).toBe(".+\\.example\\.com:443");
   });
 
   it("question mark ?", () => {
-    assert.equal(wildcardToRegex("exampl?.com:443"), "exampl[^.]\\.com:443");
+    expect(wildcardToRegex("exampl?.com:443")).toBe("exampl[^.]\\.com:443");
   });
 
   it("multiple wildcards", () => {
-    assert.equal(wildcardToRegex("*.*.example.com:443"), "[^.]+\\.[^.]+\\.example\\.com:443");
+    expect(wildcardToRegex("*.*.example.com:443")).toBe("[^.]+\\.[^.]+\\.example\\.com:443");
   });
 
   it("rejects mixed * in part", () => {
-    assert.throws(() => wildcardToRegex("w*.example.com:443"), /Invalid wildcard/);
+    expect(() => wildcardToRegex("w*.example.com:443")).toThrow(/Invalid wildcard/);
   });
 
   it("rejects mixed ** in part", () => {
-    assert.throws(() => wildcardToRegex("w**.example.com:443"), /Invalid wildcard/);
+    expect(() => wildcardToRegex("w**.example.com:443")).toThrow(/Invalid wildcard/);
   });
 
   it("escapes regex meta characters in domain", () => {
-    assert.equal(wildcardToRegex("example+site.com:443"), "example\\+site\\.com:443");
+    expect(wildcardToRegex("example+site.com:443")).toBe("example\\+site\\.com:443");
   });
 
   it("wildcard port *", () => {
-    assert.equal(wildcardToRegex("example.com:*"), "example\\.com:\\d+");
+    expect(wildcardToRegex("example.com:*")).toBe("example\\.com:\\d+");
   });
 
   it("rejects missing port", () => {
-    assert.throws(() => wildcardToRegex("example.com"), /Invalid pattern/);
+    expect(() => wildcardToRegex("example.com")).toThrow(/Invalid pattern/);
   });
 
   it("rejects non-numeric port", () => {
-    assert.throws(() => wildcardToRegex("example.com:abc"), /Invalid pattern/);
+    expect(() => wildcardToRegex("example.com:abc")).toThrow(/Invalid pattern/);
   });
 
   it("rejects multiple colons", () => {
-    assert.throws(() => wildcardToRegex("example.com:443:extra"), /Invalid pattern/);
+    expect(() => wildcardToRegex("example.com:443:extra")).toThrow(/Invalid pattern/);
   });
 });
 
@@ -64,23 +64,23 @@ describe("wildcardToRegex", () => {
 // ---------------------------------------------------------------------------
 describe("convertRule", () => {
   it("domain with explicit port", () => {
-    assert.equal(convertRule("example.com:8443"), "^example\\.com:8443$");
+    expect(convertRule("example.com:8443")).toBe("^example\\.com:8443$");
   });
 
   it("wildcard with explicit port", () => {
-    assert.equal(convertRule("*.example.com:8443"), "^[^.]+\\.example\\.com:8443$");
+    expect(convertRule("*.example.com:8443")).toBe("^[^.]+\\.example\\.com:8443$");
   });
 
   it("** wildcard with explicit port", () => {
-    assert.equal(convertRule("**.example.com:443"), "^.+\\.example\\.com:443$");
+    expect(convertRule("**.example.com:443")).toBe("^.+\\.example\\.com:443$");
   });
 
   it("regex rule (~ prefix) — returned as-is without ~", () => {
-    assert.equal(convertRule("~^custom\\.regex:443$"), "^custom\\.regex:443$");
+    expect(convertRule("~^custom\\.regex:443$")).toBe("^custom\\.regex:443$");
   });
 
   it("rejects invalid regex (~ prefix)", () => {
-    assert.throws(() => convertRule("~^(unclosed"), /Invalid regex/);
+    expect(() => convertRule("~^(unclosed")).toThrow(/Invalid regex/);
   });
 });
 
@@ -90,41 +90,41 @@ describe("convertRule", () => {
 describe("convertRule — regex behavior", () => {
   it("* matches single-level subdomain only", () => {
     const re = new RegExp(convertRule("*.example.com:443"));
-    assert.ok(re.test("sub.example.com:443"));
-    assert.ok(!re.test("deep.sub.example.com:443"));
-    assert.ok(!re.test("example.com:443"));
+    expect(re.test("sub.example.com:443")).toBeTruthy();
+    expect(!re.test("deep.sub.example.com:443")).toBeTruthy();
+    expect(!re.test("example.com:443")).toBeTruthy();
   });
 
   it("** matches multi-level subdomains", () => {
     const re = new RegExp(convertRule("**.example.com:443"));
-    assert.ok(re.test("sub.example.com:443"));
-    assert.ok(re.test("deep.sub.example.com:443"));
-    assert.ok(!re.test("example.com:443"));
+    expect(re.test("sub.example.com:443")).toBeTruthy();
+    expect(re.test("deep.sub.example.com:443")).toBeTruthy();
+    expect(!re.test("example.com:443")).toBeTruthy();
   });
 
   it("? matches exactly one non-dot character", () => {
     const re = new RegExp(convertRule("exampl?.com:443"));
-    assert.ok(re.test("example.com:443"));
-    assert.ok(!re.test("exampl.com:443"));
-    assert.ok(!re.test("examplee.com:443"));
+    expect(re.test("example.com:443")).toBeTruthy();
+    expect(!re.test("exampl.com:443")).toBeTruthy();
+    expect(!re.test("examplee.com:443")).toBeTruthy();
   });
 
   it("exact domain does not match subdomains", () => {
     const re = new RegExp(convertRule("example.com:443"));
-    assert.ok(re.test("example.com:443"));
-    assert.ok(!re.test("sub.example.com:443"));
+    expect(re.test("example.com:443")).toBeTruthy();
+    expect(!re.test("sub.example.com:443")).toBeTruthy();
   });
 
   it("port mismatch is rejected", () => {
     const re = new RegExp(convertRule("example.com:443"));
-    assert.ok(!re.test("example.com:8443"));
+    expect(!re.test("example.com:8443")).toBeTruthy();
   });
 
   it("wildcard port matches any port", () => {
     const re = new RegExp(convertRule("example.com:*"));
-    assert.ok(re.test("example.com:443"));
-    assert.ok(re.test("example.com:8080"));
-    assert.ok(!re.test("example.com:abc"));
+    expect(re.test("example.com:443")).toBeTruthy();
+    expect(re.test("example.com:8080")).toBeTruthy();
+    expect(!re.test("example.com:abc")).toBeTruthy();
   });
 });
 
@@ -133,18 +133,18 @@ describe("convertRule — regex behavior", () => {
 // ---------------------------------------------------------------------------
 describe("buildRules", () => {
   it("converts multiple rules", () => {
-    assert.deepEqual(buildRules("example.com:443 *.foo.com:8443"), [
+    expect(buildRules("example.com:443 *.foo.com:8443")).toStrictEqual([
       "^example\\.com:443$",
       "^[^.]+\\.foo\\.com:8443$",
     ]);
   });
 
   it("empty input → empty array", () => {
-    assert.deepEqual(buildRules(""), []);
+    expect(buildRules("")).toStrictEqual([]);
   });
 
   it("regex rules (~ prefix)", () => {
-    assert.deepEqual(buildRules("~^custom\\.regex:(443|8080)$ example.com:443"), [
+    expect(buildRules("~^custom\\.regex:(443|8080)$ example.com:443")).toStrictEqual([
       "^custom\\.regex:(443|8080)$",
       "^example\\.com:443$",
     ]);
@@ -156,22 +156,22 @@ describe("buildRules", () => {
 // ---------------------------------------------------------------------------
 describe("parseAndValidateRules", () => {
   it("returns raw (unconverted) rule tokens", () => {
-    assert.deepEqual(parseAndValidateRules("example.com:443 *.foo.com:8443"), [
+    expect(parseAndValidateRules("example.com:443 *.foo.com:8443")).toStrictEqual([
       "example.com:443",
       "*.foo.com:8443",
     ]);
   });
 
   it("empty input → empty array", () => {
-    assert.deepEqual(parseAndValidateRules(""), []);
+    expect(parseAndValidateRules("")).toStrictEqual([]);
   });
 
   it("validates syntax eagerly, throwing on invalid wildcard rules", () => {
-    assert.throws(() => parseAndValidateRules("w*.example.com:443"), /Invalid wildcard/);
+    expect(() => parseAndValidateRules("w*.example.com:443")).toThrow(/Invalid wildcard/);
   });
 
   it("validates syntax eagerly, throwing on invalid regex rules", () => {
-    assert.throws(() => parseAndValidateRules("~^(unclosed"), /Invalid regex/);
+    expect(() => parseAndValidateRules("~^(unclosed")).toThrow(/Invalid regex/);
   });
 });
 

--- a/core/lib/test/qjs-event-polyfill.ts
+++ b/core/lib/test/qjs-event-polyfill.ts
@@ -1,0 +1,21 @@
+/** Minimal EventTarget/Event stub so chai's plugin bus can load under
+ *  QuickJS. Side-effect-only; import before chai. */
+const globalWithEventApis = globalThis as {
+  Event?: unknown;
+  EventTarget?: unknown;
+};
+
+globalWithEventApis.Event ??= class Event {
+  type: string;
+  constructor(type: string) {
+    this.type = type;
+  }
+};
+
+globalWithEventApis.EventTarget ??= class EventTarget {
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(): boolean {
+    return true;
+  }
+};

--- a/core/lib/test/test-shim.ts
+++ b/core/lib/test/test-shim.ts
@@ -1,15 +1,18 @@
 /**
- * Test shim, portable between Node (delegates to vitest/node:assert) and
- * QuickJS (its own minimal implementation — vitest and fast-check aren't
- * available there). The same *.test.ts source runs unmodified under both.
+ * Test shim, portable between Node (delegates to vitest) and QuickJS (its
+ * own minimal implementation). The same *.test.ts source runs under both.
  *
- * Module specifiers below are routed through non-literal string variables:
- * tsc only tries to resolve a dynamic import()'s module types when the
- * argument is a string *literal*, so this lets the same file type-check
- * under tsconfig.json (Node types, no qjs ambient types) and
- * tsconfig.qjs.json (qjs ambient types, no Node types) without either
- * config needing to know about the other runtime's modules.
+ * `vitest`/`node:assert/strict`/`qjs:std` are dynamic-imported via non-literal
+ * variables so tsc doesn't resolve the other runtime's types. `chai`/
+ * `@vitest/expect` are portable, so they're static imports instead — that's
+ * also required for bundling, since qjs can't resolve a bare specifier left
+ * un-inlined by a dynamic import. The polyfill import must come first: ES
+ * modules evaluate static imports before their own body runs.
  */
+import "./qjs-event-polyfill.ts";
+import * as chai from "chai";
+import { JestChaiExpect } from "@vitest/expect";
+
 const isNode = typeof (globalThis as { process?: unknown }).process !== "undefined";
 
 interface Assert {
@@ -22,25 +25,40 @@ interface Assert {
   rejects(promise: Promise<unknown>, matcher?: (e: unknown) => boolean): Promise<void>;
 }
 
+/** Deliberately narrow subset of vitest's real `expect()` chain — only the
+ *  matchers this codebase's tests actually use. */
+interface ExpectMatchers {
+  toBe(expected: unknown): void;
+  toStrictEqual(expected: unknown): void;
+  toBeTruthy(): void;
+  toThrow(pattern?: RegExp | string): void;
+}
+type Expect = (actual: unknown) => ExpectMatchers;
+
 interface Shim {
   describe(this: void, name: string, fn: () => void): void;
   it(this: void, name: string, fn: () => void): void;
   assert: Assert;
+  expect: Expect;
   reportResults(this: void): void;
 }
 
 async function createNodeShim(): Promise<Shim> {
   const testRunnerSpecifier = "vitest";
   const nodeAssertSpecifier = "node:assert/strict";
-  const { describe, it } = await import(testRunnerSpecifier);
+  const { describe, it, expect } = await import(testRunnerSpecifier);
   const { default: assert } = await import(nodeAssertSpecifier);
   // vitest tracks pass/fail and sets the process exit code itself.
-  return { describe, it, assert, reportResults() {} };
+  return { describe, it, assert, expect, reportResults() {} };
 }
 
 async function createQjsShim(): Promise<Shim> {
   const qjsStdSpecifier = "qjs:std";
   const std = await import(qjsStdSpecifier);
+
+  // The same matcher plugin vitest itself uses on Node, applied directly here.
+  chai.use(JestChaiExpect);
+  const expect = chai.expect as unknown as Expect;
 
   let passed = 0;
   let failed = 0;
@@ -112,17 +130,16 @@ async function createQjsShim(): Promise<Shim> {
   function reportResults(): void {
     std.out.puts(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
     const hadFailures = failed > 0;
-    // Reset so a runner that imports several *.test.js files into one qjs
-    // process (see run-tests.qjs.js) gets an accurate per-file count instead of a
-    // running total — this module is a singleton across those imports.
+    // Reset for an accurate per-file count when a runner loads multiple
+    // *.test.js files into one qjs process (this module is a singleton).
     passed = 0;
     failed = 0;
     if (hadFailures) std.exit(1);
   }
 
-  return { describe, it, assert, reportResults };
+  return { describe, it, assert, expect, reportResults };
 }
 
 const shim = isNode ? await createNodeShim() : await createQjsShim();
 
-export const { describe, it, assert, reportResults } = shim;
+export const { describe, it, assert, expect, reportResults } = shim;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,13 @@ minimumReleaseAge: 20160 # 2 weeks
 minimumReleaseAgeExclude:
   - brace-expansion@5.0.7 || 5.0.8
 
-# Lets tsc resolve vitest's types, even though it's only vite-plus's transitive dependency.
+# Lets tsc/rolldown resolve these, even though they're only vite-plus's
+# transitive dependencies. chai/@vitest/expect/@types/chai are vitest's own
+# expect() engine, reused directly under QuickJS — hoisting (rather than
+# pinning our own copies) keeps them locked to whatever version vitest
+# itself uses on Node.
 publicHoistPattern:
   - vitest
+  - chai
+  - "@vitest/expect"
+  - "@types/chai"


### PR DESCRIPTION
## Summary

Stage 1 of migrating tests from `node:assert/strict` to vitest's `expect()` API. Adds `expect` to `core/lib/test/test-shim.ts`: on Node it's vitest's real `expect`; under QuickJS it's the same matcher plugin vitest itself uses (`@vitest/expect`'s `JestChaiExpect`), layered onto `chai` — so both environments run identical matcher logic rather than a hand-rolled reimplementation. `assert` stays in the shim for the other test files not yet converted.

This stage only converts the two QuickJS-bundled files (`core/lib/acl/source-policy.test.ts`, `wildcard-rules.test.ts`) to prove the approach against the real QuickJS runtime before touching the other 45. A follow-up PR will convert the rest.

Two things needed care, found by actually building and running under real QuickJS-ng (not just assumed):
- chai's plugin bus references `EventTarget`/`Event`, which qjs doesn't implement — added a ~10-line stub (`qjs-event-polyfill.ts`), imported before chai since ES modules evaluate static imports before a file's own body runs.
- `chai`/`@vitest/expect` had to become *static* imports rather than following the file's existing dynamic-`import()` pattern: rolldown only inlines static imports, and qjs's module loader can't resolve a bare package specifier left un-inlined by a dynamic one.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/lib/acl` (58 tests, vitest)
- [x] `make test_unit_qjs` — real Docker/Alpine QuickJS-ng, same engine as production (51 tests)
- [x] `make test_unit` (full suite)
- [x] `vp run build`, `pnpm run build:scripts`, `pnpm run build:qjs` — confirmed the production proxy image's qjs bundle is untouched (doesn't import test-shim.ts)