### PR TITLE
test: finish migrating tests off node:assert to vitest expect()

### DIFF
--- a/core/lib/acl/wildcard-rules.property.test.ts
+++ b/core/lib/acl/wildcard-rules.property.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run core/lib/acl/wildcard-rules.property.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 
 import { convertRule, buildRules, parseAndValidateRules } from "./wildcard-rules.ts";
@@ -28,11 +27,11 @@ describe("convertRule – properties", () => {
     fc.assert(
       fc.property(simplePattern, (pattern) => {
         const regex = new RegExp(convertRule(pattern));
-        assert.ok(regex.test(pattern), "regex must match original pattern");
-        assert.ok(
+        expect(regex.test(pattern), "regex must match original pattern").toBeTruthy();
+        expect(
           !regex.test(`sub.${pattern}`),
           "regex must not match with extra subdomain prefix",
-        );
+        ).toBeTruthy();
       }),
     );
   });
@@ -52,7 +51,7 @@ describe("convertRule – properties", () => {
 
     fc.assert(
       fc.property(patternWithMeta, (pattern) => {
-        assert.doesNotThrow(() => new RegExp(convertRule(pattern)));
+        expect(() => new RegExp(convertRule(pattern))).not.toThrow();
       }),
     );
   });
@@ -69,13 +68,7 @@ describe("convertRule – properties", () => {
 
     fc.assert(
       fc.property(mixedWildcardLabel, (label) => {
-        assert.throws(
-          () => convertRule(`${label}.com:443`),
-          (err) => {
-            assert.ok(err instanceof Error);
-            return true;
-          },
-        );
+        expect(() => convertRule(`${label}.com:443`)).toThrow();
       }),
     );
   });
@@ -100,7 +93,7 @@ describe("buildRules – properties", () => {
     fc.assert(
       fc.property(fc.array(validRule, { minLength: 0, maxLength: 5 }), whitespace, (rules, sep) => {
         const result = buildRules(rules.join(sep));
-        assert.equal(result.length, rules.length);
+        expect(result.length).toBe(rules.length);
       }),
     );
   });
@@ -122,19 +115,19 @@ describe("parseAndValidateRules – properties", () => {
     fc.assert(
       fc.property(fc.array(validRule, { minLength: 0, maxLength: 5 }), (rules) => {
         const input = rules.join(" ");
-        assert.deepEqual(parseAndValidateRules(input), rules);
-        assert.equal(parseAndValidateRules(input).length, buildRules(input).length);
+        expect(parseAndValidateRules(input)).toStrictEqual(rules);
+        expect(parseAndValidateRules(input).length).toBe(buildRules(input).length);
       }),
     );
   });
 
   it("returns an empty array for empty/undefined input", () => {
-    assert.deepEqual(parseAndValidateRules(undefined), []);
-    assert.deepEqual(parseAndValidateRules(""), []);
+    expect(parseAndValidateRules(undefined)).toStrictEqual([]);
+    expect(parseAndValidateRules("")).toStrictEqual([]);
   });
 
   it("throws on invalid syntax, matching buildRules' own validation", () => {
-    assert.throws(() => parseAndValidateRules("no-port-specified"));
-    assert.throws(() => buildRules("no-port-specified"));
+    expect(() => parseAndValidateRules("no-port-specified")).toThrow();
+    expect(() => buildRules("no-port-specified")).toThrow();
   });
 });

--- a/core/lib/actions/annotation.test.ts
+++ b/core/lib/actions/annotation.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, vi } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect, vi } from "vitest";
 import { createAnnotation } from "./annotation.ts";
 
 describe("createAnnotation", () => {
@@ -7,22 +6,22 @@ describe("createAnnotation", () => {
     it("notice() logs a ::notice:: line", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(true).notice("hello");
-      assert.equal(log.mock.calls.length, 1);
-      assert.equal(log.mock.calls[0][0], "::notice::hello");
+      expect(log.mock.calls.length).toBe(1);
+      expect(log.mock.calls[0][0]).toBe("::notice::hello");
     });
 
     it("error() logs a ::error:: line", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(true).error("boom");
-      assert.equal(log.mock.calls.length, 1);
-      assert.equal(log.mock.calls[0][0], "::error::boom");
+      expect(log.mock.calls.length).toBe(1);
+      expect(log.mock.calls[0][0]).toBe("::error::boom");
     });
 
     it("warning() logs a ::warning:: line", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(true).warning("careful");
-      assert.equal(log.mock.calls.length, 1);
-      assert.equal(log.mock.calls[0][0], "::warning::careful");
+      expect(log.mock.calls.length).toBe(1);
+      expect(log.mock.calls[0][0]).toBe("::warning::careful");
     });
   });
 
@@ -30,19 +29,19 @@ describe("createAnnotation", () => {
     it("notice() logs nothing", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(false).notice("hello");
-      assert.equal(log.mock.calls.length, 0);
+      expect(log.mock.calls.length).toBe(0);
     });
 
     it("error() logs nothing", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(false).error("boom");
-      assert.equal(log.mock.calls.length, 0);
+      expect(log.mock.calls.length).toBe(0);
     });
 
     it("warning() logs nothing", () => {
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
       createAnnotation(false).warning("careful");
-      assert.equal(log.mock.calls.length, 0);
+      expect(log.mock.calls.length).toBe(0);
     });
   });
 });

--- a/core/lib/actions/docker-error.test.ts
+++ b/core/lib/actions/docker-error.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { describeDockerFailure, isLikelySlimRunner } from "./docker-error.ts";
 
@@ -11,8 +10,8 @@ describe("describeDockerFailure", () => {
       { code: "ENOENT" },
       { operation: "docker compose up", ...noSlimRunner },
     );
-    assert.match(msg, /not found on this runner's PATH/);
-    assert.match(msg, /docker compose up/);
+    expect(msg).toMatch(/not found on this runner's PATH/);
+    expect(msg).toMatch(/docker compose up/);
   });
 
   it("points at the log above (not e.message) when stderr wasn't captured", () => {
@@ -20,8 +19,8 @@ describe("describeDockerFailure", () => {
       { status: 1, message: "Command failed: docker compose up ...huge...args..." },
       noSlimRunner,
     );
-    assert.doesNotMatch(msg, /huge\.\.\.args/);
-    assert.match(msg, /see the Docker output above/);
+    expect(msg).not.toMatch(/huge\.\.\.args/);
+    expect(msg).toMatch(/see the Docker output above/);
   });
 
   it("includes captured stderr text when present", () => {
@@ -29,17 +28,17 @@ describe("describeDockerFailure", () => {
       { status: 1, stderr: "error: no such object: foo" },
       noSlimRunner,
     );
-    assert.match(msg, /error: no such object: foo/);
+    expect(msg).toMatch(/error: no such object: foo/);
   });
 
   it("names ubuntu-slim as unsupported and ubuntu-latest as the working default", () => {
     const msg = describeDockerFailure({ code: "ENOENT" }, noSlimRunner);
-    assert.match(msg, /ubuntu-slim/);
-    assert.match(msg, /ubuntu-latest/);
+    expect(msg).toMatch(/ubuntu-slim/);
+    expect(msg).toMatch(/ubuntu-latest/);
   });
 
   it("defaults the operation label to 'docker' when omitted", () => {
-    assert.match(describeDockerFailure({ code: "ENOENT" }, noSlimRunner), /running docker\./);
+    expect(describeDockerFailure({ code: "ENOENT" }, noSlimRunner)).toMatch(/running docker\./);
   });
 
   it("adds a detection note when the runner looks like a container-based image", () => {
@@ -48,37 +47,25 @@ describe("describeDockerFailure", () => {
       { env: { ImageOS: "Linux" }, exists: () => true },
     );
     const withoutNote = describeDockerFailure({ code: "ENOENT" }, noSlimRunner);
-    assert.match(withNote, /Detected a container-based GitHub-hosted runner image/);
-    assert.doesNotMatch(withoutNote, /Detected a container-based GitHub-hosted runner image/);
+    expect(withNote).toMatch(/Detected a container-based GitHub-hosted runner image/);
+    expect(withoutNote).not.toMatch(/Detected a container-based GitHub-hosted runner image/);
   });
 });
 
 describe("isLikelySlimRunner", () => {
   it("detects when ImageOS is Linux and the containerenv marker exists", () => {
-    assert.equal(
-      isLikelySlimRunner({ ImageOS: "Linux" }, () => true),
-      true,
-    );
+    expect(isLikelySlimRunner({ ImageOS: "Linux" }, () => true)).toBe(true);
   });
 
   it("returns false when ImageOS looks like a normal VM image", () => {
-    assert.equal(
-      isLikelySlimRunner({ ImageOS: "ubuntu24" }, () => true),
-      false,
-    );
+    expect(isLikelySlimRunner({ ImageOS: "ubuntu24" }, () => true)).toBe(false);
   });
 
   it("returns false when the containerenv marker is missing", () => {
-    assert.equal(
-      isLikelySlimRunner({ ImageOS: "Linux" }, () => false),
-      false,
-    );
+    expect(isLikelySlimRunner({ ImageOS: "Linux" }, () => false)).toBe(false);
   });
 
   it("returns false when ImageOS is unset", () => {
-    assert.equal(
-      isLikelySlimRunner({}, () => true),
-      false,
-    );
+    expect(isLikelySlimRunner({}, () => true)).toBe(false);
   });
 });

--- a/core/lib/actions/log.test.ts
+++ b/core/lib/actions/log.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { wrapLogGroup } from "./log.ts";
 
 describe("wrapLogGroup", () => {
   it("wraps non-empty log text in a group-open/content/group-close triple", () => {
-    assert.deepEqual(wrapLogGroup("Title", "line1\nline2\n"), [
+    expect(wrapLogGroup("Title", "line1\nline2\n")).toStrictEqual([
       "::group::Title",
       "line1\nline2\n",
       "::endgroup::",
@@ -11,7 +11,7 @@ describe("wrapLogGroup", () => {
   });
 
   it("returns an empty array for empty log text", () => {
-    assert.deepEqual(wrapLogGroup("Title", ""), []);
+    expect(wrapLogGroup("Title", "")).toStrictEqual([]);
   });
 });
 

--- a/core/lib/docker/args.test.ts
+++ b/core/lib/docker/args.test.ts
@@ -1,16 +1,15 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { buildDockerCpArgs, buildComposeUpArgs, buildComposeDownArgs } from "./args.ts";
 
 describe("buildDockerCpArgs", () => {
   it("builds a `docker cp <container>:<containerPath> <hostPath>` argv", () => {
-    assert.deepEqual(
+    expect(
       buildDockerCpArgs({
         containerName: "buildcage-proxy-abcd1234",
         containerPath: "/opt/buildcage/bin/runc",
         hostPath: "/tmp/x/runc",
       }),
-      ["cp", "buildcage-proxy-abcd1234:/opt/buildcage/bin/runc", "/tmp/x/runc"],
-    );
+    ).toStrictEqual(["cp", "buildcage-proxy-abcd1234:/opt/buildcage/bin/runc", "/tmp/x/runc"]);
   });
 });
 
@@ -26,7 +25,7 @@ describe("buildComposeUpArgs", () => {
       projectName: "buildcage-proxy-abcd1234",
       pullPolicy: "always",
     });
-    assert.deepEqual(args, [
+    expect(args).toStrictEqual([
       "compose",
       "-f",
       "/path/to/compose.yaml",
@@ -49,7 +48,7 @@ describe("buildComposeDownArgs", () => {
       composeFile: "/path/to/compose.yaml",
       projectName: "buildcage-proxy-abcd1234",
     });
-    assert.deepEqual(args, [
+    expect(args).toStrictEqual([
       "compose",
       "-f",
       "/path/to/compose.yaml",

--- a/core/lib/docker/client.test.ts
+++ b/core/lib/docker/client.test.ts
@@ -1,20 +1,20 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { createDocker, parseContainerIds, type SpawnCommand } from "./client.ts";
 import { REPORT_ACTION_SCRIPT_PATH } from "./report-source.ts";
 
 describe("parseContainerIds", () => {
   it("splits one ID per line", () => {
-    assert.deepEqual(parseContainerIds("abc123\ndef456\n"), ["abc123", "def456"]);
+    expect(parseContainerIds("abc123\ndef456\n")).toStrictEqual(["abc123", "def456"]);
   });
 
   it("returns an empty array for empty output", () => {
-    assert.deepEqual(parseContainerIds(""), []);
+    expect(parseContainerIds("")).toStrictEqual([]);
   });
 
   it("drops blank lines and trims whitespace", () => {
-    assert.deepEqual(parseContainerIds("\n  abc123  \n\n"), ["abc123"]);
+    expect(parseContainerIds("\n  abc123  \n\n")).toStrictEqual(["abc123"]);
   });
 });
 
@@ -36,8 +36,8 @@ describe("createDocker", () => {
   it("findContainers ANDs every filter and parses the ID list", () => {
     const { run, calls } = fakeRun(["abc123\ndef456\n"]);
     const ids = createDocker(run).findContainers(["label=a=1", "label=b=2"]);
-    assert.deepEqual(ids, ["abc123", "def456"]);
-    assert.deepEqual(calls, [
+    expect(ids).toStrictEqual(["abc123", "def456"]);
+    expect(calls).toStrictEqual([
       ["ps", "--filter", "label=a=1", "--filter", "label=b=2", "--format", "{{.ID}}"],
     ]);
   });
@@ -49,7 +49,7 @@ describe("createDocker", () => {
       REPORT_ACTION_SCRIPT_PATH,
       "/tmp/report-action.js",
     );
-    assert.deepEqual(calls, [
+    expect(calls).toStrictEqual([
       ["cp", `abc123:${REPORT_ACTION_SCRIPT_PATH}`, "/tmp/report-action.js"],
     ]);
   });
@@ -57,8 +57,8 @@ describe("createDocker", () => {
   it("readEnv runs docker inspect and parses the Env JSON array", () => {
     const { run, calls } = fakeRun(['["PROXY_MODE=restrict","FOO=bar"]']);
     const env = createDocker(run).readEnv("abc123");
-    assert.deepEqual(env, { PROXY_MODE: "restrict", FOO: "bar" });
-    assert.deepEqual(calls, [["inspect", "abc123", "--format", "{{json .Config.Env}}"]]);
+    expect(env).toStrictEqual({ PROXY_MODE: "restrict", FOO: "bar" });
+    expect(calls).toStrictEqual([["inspect", "abc123", "--format", "{{json .Config.Env}}"]]);
   });
 
   it("exec runs docker exec with the given argv and returns its stdout", () => {
@@ -70,8 +70,8 @@ describe("createDocker", () => {
       "--format",
       "{{json .}}",
     ]);
-    assert.equal(out, "histories output");
-    assert.deepEqual(calls, [
+    expect(out).toBe("histories output");
+    expect(calls).toStrictEqual([
       ["exec", "abc123", "buildctl", "debug", "histories", "--format", "{{json .}}"],
     ]);
   });
@@ -132,7 +132,7 @@ describe("createDocker readFileLines", () => {
   it("is lazy — nothing spawns until iteration actually starts", () => {
     const { spawnDocker, calls } = fakeSpawn();
     createDocker(undefined, spawnDocker).readFileLines("abc123", "/var/log/haproxy/current");
-    assert.deepEqual(calls, []);
+    expect(calls).toStrictEqual([]);
   });
 
   it("streams docker exec cat's stdout as lines, in argv order", async () => {
@@ -141,10 +141,10 @@ describe("createDocker readFileLines", () => {
       createDocker(undefined, spawnDocker).readFileLines("abc123", "/var/log/haproxy/current"),
     );
     // drain()'s first pull has already triggered the spawn synchronously.
-    assert.deepEqual(calls, [["exec", "abc123", "cat", "/var/log/haproxy/current"]]);
+    expect(calls).toStrictEqual([["exec", "abc123", "cat", "/var/log/haproxy/current"]]);
     children[0].stdout.write("line one\nline two\n");
     children[0].finish(0);
-    assert.deepEqual(await iterablePromise, ["line one", "line two"]);
+    expect(await iterablePromise).toStrictEqual(["line one", "line two"]);
   });
 
   it("throws {status, stderr} on a non-zero exit", async () => {
@@ -154,8 +154,7 @@ describe("createDocker readFileLines", () => {
     await Promise.resolve();
     children[0].stderr.write("cat: /missing: No such file or directory\n");
     children[0].finish(1);
-    await assert.rejects(
-      drained,
+    await expect(drained).rejects.toSatisfy(
       (e) =>
         (e as { status?: number; stderr?: string }).status === 1 &&
         Boolean((e as { stderr?: string }).stderr?.includes("No such file or directory")),
@@ -167,7 +166,7 @@ describe("createDocker readFileLines", () => {
     const drained = drain(createDocker(undefined, spawnDocker).readFileLines("abc123", "/path"));
     await Promise.resolve();
     children[0].failToSpawn(Object.assign(new Error("spawn docker ENOENT"), { code: "ENOENT" }));
-    await assert.rejects(drained, (e) => (e as NodeJS.ErrnoException).code === "ENOENT");
+    await expect(drained).rejects.toSatisfy((e) => (e as NodeJS.ErrnoException).code === "ENOENT");
   });
 
   it("kills the child if the consumer stops iterating early", async () => {
@@ -181,9 +180,9 @@ describe("createDocker readFileLines", () => {
     // already exists once this returns.
     const firstLine = iterator.next();
     children[0].stdout.write("line one\nline two\n"); // never finish()'d — simulates a still-running process
-    assert.equal((await firstLine).value, "line one");
+    expect((await firstLine).value).toBe("line one");
     await iterator.return?.(undefined); // what `for await...of` does on an early break
-    assert.ok(children[0].killed);
+    expect(children[0].killed).toBeTruthy();
   });
 });
 

--- a/core/lib/docker/compose-project-name.test.ts
+++ b/core/lib/docker/compose-project-name.test.ts
@@ -1,41 +1,38 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { deriveProjectName, resolveProjectName } from "./compose-project-name.ts";
 
 describe("deriveProjectName", () => {
   it("is deterministic — same input always derives the same project name", () => {
-    assert.equal(
-      deriveProjectName("buildcage-proxy-abcd1234"),
+    expect(deriveProjectName("buildcage-proxy-abcd1234")).toBe(
       deriveProjectName("buildcage-proxy-abcd1234"),
     );
   });
 
   it("matches docker compose's project-name character constraints, even for input Compose would reject", () => {
-    assert.match(deriveProjectName("buildcage-proxy-abcd1234"), /^[a-z0-9][a-z0-9_-]*$/);
-    assert.match(deriveProjectName("buildcage"), /^[a-z0-9][a-z0-9_-]*$/);
+    expect(deriveProjectName("buildcage-proxy-abcd1234")).toMatch(/^[a-z0-9][a-z0-9_-]*$/);
+    expect(deriveProjectName("buildcage")).toMatch(/^[a-z0-9][a-z0-9_-]*$/);
     // Uppercase/other characters are a valid Docker container name (what
     // setup's builder_name input only ever had to be before this
     // function's result started being used as a Compose -p value too) but
     // not a valid Compose project name on their own.
-    assert.match(deriveProjectName("MyBuilder"), /^[a-z0-9][a-z0-9_-]*$/);
-    assert.match(deriveProjectName("My.Builder_2"), /^[a-z0-9][a-z0-9_-]*$/);
+    expect(deriveProjectName("MyBuilder")).toMatch(/^[a-z0-9][a-z0-9_-]*$/);
+    expect(deriveProjectName("My.Builder_2")).toMatch(/^[a-z0-9][a-z0-9_-]*$/);
   });
 
   it("derives different project names for different inputs", () => {
-    assert.ok(deriveProjectName("buildcage") !== deriveProjectName("buildcage2"));
+    expect(deriveProjectName("buildcage") !== deriveProjectName("buildcage2")).toBeTruthy();
   });
 });
 
 describe("resolveProjectName", () => {
   it("falls back to deriveProjectName(builderName) when there's no override", () => {
-    assert.equal(
-      resolveProjectName("buildcage-transparent-audit", undefined),
+    expect(resolveProjectName("buildcage-transparent-audit", undefined)).toBe(
       deriveProjectName("buildcage-transparent-audit"),
     );
   });
 
   it("prefers the override when given one", () => {
-    assert.equal(
-      resolveProjectName("buildcage-transparent-audit", "buildcage-project"),
+    expect(resolveProjectName("buildcage-transparent-audit", "buildcage-project")).toBe(
       "buildcage-project",
     );
   });

--- a/core/lib/docker/container-env.test.ts
+++ b/core/lib/docker/container-env.test.ts
@@ -1,30 +1,30 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { parseDockerInspectEnv } from "./container-env.ts";
 
 describe("parseDockerInspectEnv", () => {
   it("parses a JSON array of KEY=VALUE strings into a map", () => {
-    assert.deepEqual(parseDockerInspectEnv('["FOO=bar","PROXY_MODE=restrict"]'), {
+    expect(parseDockerInspectEnv('["FOO=bar","PROXY_MODE=restrict"]')).toStrictEqual({
       FOO: "bar",
       PROXY_MODE: "restrict",
     });
   });
 
   it("returns an empty object for an empty array", () => {
-    assert.deepEqual(parseDockerInspectEnv("[]"), {});
+    expect(parseDockerInspectEnv("[]")).toStrictEqual({});
   });
 
   it("keeps everything after the first '=' as the value, including further '='s", () => {
-    assert.deepEqual(parseDockerInspectEnv('["FOO=a=b=c"]'), { FOO: "a=b=c" });
+    expect(parseDockerInspectEnv('["FOO=a=b=c"]')).toStrictEqual({ FOO: "a=b=c" });
   });
 
   it("preserves embedded newlines (multi-line rule values)", () => {
-    assert.deepEqual(parseDockerInspectEnv('["ALLOWED_HTTPS_RULES=a.com:443\\nb.com:443"]'), {
+    expect(parseDockerInspectEnv('["ALLOWED_HTTPS_RULES=a.com:443\\nb.com:443"]')).toStrictEqual({
       ALLOWED_HTTPS_RULES: "a.com:443\nb.com:443",
     });
   });
 
   it("skips entries with no '='", () => {
-    assert.deepEqual(parseDockerInspectEnv('["MALFORMED","OK=1"]'), { OK: "1" });
+    expect(parseDockerInspectEnv('["MALFORMED","OK=1"]')).toStrictEqual({ OK: "1" });
   });
 });
 

--- a/core/lib/errors.test.ts
+++ b/core/lib/errors.test.ts
@@ -1,23 +1,22 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { ActionError } from "./errors.ts";
 
 describe("ActionError", () => {
   it("sets name, message, and code, and is an instanceof Error", () => {
     const err = new ActionError("msg", "CODE");
-    assert.equal(err.name, "ActionError");
-    assert.equal(err.message, "msg");
-    assert.equal(err.code, "CODE");
-    assert.ok(err instanceof Error);
+    expect(err.name).toBe("ActionError");
+    expect(err.message).toBe("msg");
+    expect(err.code).toBe("CODE");
+    expect(err instanceof Error).toBeTruthy();
   });
 
   it("derives name from the concrete subclass via new.target", () => {
     class FooError extends ActionError {}
     const err = new FooError("msg2", "CODE2");
-    assert.equal(err.name, "FooError");
-    assert.equal(err.message, "msg2");
-    assert.equal(err.code, "CODE2");
-    assert.ok(err instanceof ActionError);
+    expect(err.name).toBe("FooError");
+    expect(err.message).toBe("msg2");
+    expect(err.code).toBe("CODE2");
+    expect(err instanceof ActionError).toBeTruthy();
   });
 });

--- a/core/lib/log/aggregate.test.ts
+++ b/core/lib/log/aggregate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { aggregate } from "./aggregate.ts";
 
 describe("aggregate", () => {
@@ -9,11 +9,11 @@ describe("aggregate", () => {
       { host: "b.com", port: "80", ruleType: "HTTP", reason: "-" },
     ];
     const result = aggregate(entries);
-    assert.equal(result.length, 2);
-    assert.equal(result[0].host, "a.com");
-    assert.equal(result[0].count, 2);
-    assert.equal(result[1].host, "b.com");
-    assert.equal(result[1].count, 1);
+    expect(result.length).toBe(2);
+    expect(result[0].host).toBe("a.com");
+    expect(result[0].count).toBe(2);
+    expect(result[1].host).toBe("b.com");
+    expect(result[1].count).toBe(1);
   });
 
   it("sorts by count descending", () => {
@@ -23,10 +23,10 @@ describe("aggregate", () => {
       { host: "high.com", port: "443", ruleType: "HTTPS", reason: "r1" },
     ];
     const result = aggregate(entries);
-    assert.equal(result[0].host, "high.com");
-    assert.equal(result[0].count, 2);
-    assert.equal(result[1].host, "low.com");
-    assert.equal(result[1].count, 1);
+    expect(result[0].host).toBe("high.com");
+    expect(result[0].count).toBe(2);
+    expect(result[1].host).toBe("low.com");
+    expect(result[1].count).toBe(1);
   });
 
   it("breaks ties by host, then numeric port", () => {
@@ -36,14 +36,15 @@ describe("aggregate", () => {
       { host: "a.com", port: "80", ruleType: "HTTP", reason: "r1" },
     ];
     const result = aggregate(entries);
-    assert.deepEqual(
-      result.map((e) => `${e.host}:${e.port}`),
-      ["a.com:80", "a.com:8080", "b.com:443"],
-    );
+    expect(result.map((e) => `${e.host}:${e.port}`)).toStrictEqual([
+      "a.com:80",
+      "a.com:8080",
+      "b.com:443",
+    ]);
   });
 
   it("empty input returns empty array", () => {
-    assert.deepEqual(aggregate([]), []);
+    expect(aggregate([])).toStrictEqual([]);
   });
 });
 

--- a/core/lib/log/build-histories.test.ts
+++ b/core/lib/log/build-histories.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,7 +16,7 @@ const MULTISTAGE_HISTORIES = readFileSync(join(fixturesDir, "histories.json"), "
 
 describe("selectAllRefs", () => {
   it("returns the ref from a real single-record histories.json capture", () => {
-    assert.deepEqual(selectAllRefs(MULTISTAGE_HISTORIES), ["jsvnbiyvnlslxxui8ap3i2na2"]);
+    expect(selectAllRefs(MULTISTAGE_HISTORIES)).toStrictEqual(["jsvnbiyvnlslxxui8ap3i2na2"]);
   });
 
   it("returns every ref ordered oldest-first by CreatedAt", () => {
@@ -25,7 +24,7 @@ describe("selectAllRefs", () => {
       JSON.stringify({ type: 1, record: { Ref: "newer", CreatedAt: { seconds: 200, nanos: 0 } } }),
       JSON.stringify({ type: 1, record: { Ref: "older", CreatedAt: { seconds: 100, nanos: 0 } } }),
     ].join("\n");
-    assert.deepEqual(selectAllRefs(historiesText), ["older", "newer"]);
+    expect(selectAllRefs(historiesText)).toStrictEqual(["older", "newer"]);
   });
 
   it("breaks ties within the same second using nanos", () => {
@@ -39,7 +38,7 @@ describe("selectAllRefs", () => {
         record: { Ref: "earlier-nanos", CreatedAt: { seconds: 100, nanos: 500 } },
       }),
     ].join("\n");
-    assert.deepEqual(selectAllRefs(historiesText), ["earlier-nanos", "later-nanos"]);
+    expect(selectAllRefs(historiesText)).toStrictEqual(["earlier-nanos", "later-nanos"]);
   });
 
   it("deduplicates a ref reported on multiple lines as its build progresses", () => {
@@ -57,7 +56,7 @@ describe("selectAllRefs", () => {
         },
       }),
     ].join("\n");
-    assert.deepEqual(selectAllRefs(historiesText), ["build-1"]);
+    expect(selectAllRefs(historiesText)).toStrictEqual(["build-1"]);
   });
 
   it("ignores blank lines and records with no Ref/CreatedAt", () => {
@@ -67,10 +66,10 @@ describe("selectAllRefs", () => {
       "",
       MULTISTAGE_HISTORIES.trim(),
     ].join("\n");
-    assert.deepEqual(selectAllRefs(historiesText), ["jsvnbiyvnlslxxui8ap3i2na2"]);
+    expect(selectAllRefs(historiesText)).toStrictEqual(["jsvnbiyvnlslxxui8ap3i2na2"]);
   });
 
   it("returns an empty array when there are no records at all", () => {
-    assert.deepEqual(selectAllRefs(""), []);
+    expect(selectAllRefs("")).toStrictEqual([]);
   });
 });

--- a/core/lib/log/buildkitd.test.ts
+++ b/core/lib/log/buildkitd.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { scanBuildkitdLog } from "./buildkitd.ts";
 
 // Real line captured from a live moby/buildkit v0.31.1 explicit-mode container.
@@ -11,7 +11,7 @@ const REAL_DENY_LINE_WITH_PATH =
 describe("scanBuildkitdLog — blocked", () => {
   it("aggregates a real denial line (no explicit port in URL)", async () => {
     const result = await scanBuildkitdLog(REAL_DENY_LINE.split("\n"));
-    assert.deepEqual(result.blocked, [
+    expect(result.blocked).toStrictEqual([
       {
         ruleType: "HTTPS",
         host: "blocked.example.com",
@@ -24,7 +24,7 @@ describe("scanBuildkitdLog — blocked", () => {
 
   it("aggregates a real denial line with an explicit port and path", async () => {
     const result = await scanBuildkitdLog(REAL_DENY_LINE_WITH_PATH.split("\n"));
-    assert.deepEqual(result.blocked, [
+    expect(result.blocked).toStrictEqual([
       {
         ruleType: "HTTPS",
         host: "dl-cdn.alpinelinux.org",
@@ -39,7 +39,7 @@ describe("scanBuildkitdLog — blocked", () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="Evaluated source policy" error="source \\"http://blocked.example.com:80/\\" denied by policy: source denied by policy" mutated=false ref="http://blocked.example.com:80/" updated="http://blocked.example.com:80/"';
     const result = await scanBuildkitdLog(line.split("\n"));
-    assert.deepEqual(result.blocked, [
+    expect(result.blocked).toStrictEqual([
       {
         ruleType: "HTTP",
         host: "blocked.example.com",
@@ -54,28 +54,28 @@ describe("scanBuildkitdLog — blocked", () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="finished setting up network namespace abc"';
     const result = await scanBuildkitdLog(line.split("\n"));
-    assert.deepEqual(result.blocked, []);
+    expect(result.blocked).toStrictEqual([]);
   });
 
   it("ignores 'Evaluated source policy' lines that are not denials (e.g. a CONVERT)", async () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="Evaluated source policy" mutated=true updated="https://mirror.example.com/" ref="https://example.com/"';
     const result = await scanBuildkitdLog(line.split("\n"));
-    assert.deepEqual(result.blocked, []);
+    expect(result.blocked).toStrictEqual([]);
   });
 
   it("ignores non-http(s) identifiers (defensive — buildcage never denies these)", async () => {
     const line =
       'time="2026-07-05T00:00:00Z" level=debug msg="Evaluated source policy" error="source \\"docker-image://docker.io/library/alpine:latest\\" denied by policy: source denied by policy" ref="docker-image://docker.io/library/alpine:latest"';
     const result = await scanBuildkitdLog(line.split("\n"));
-    assert.deepEqual(result.blocked, []);
+    expect(result.blocked).toStrictEqual([]);
   });
 
   it("aggregates repeated identical denials into one row with a count", async () => {
     const logText = [REAL_DENY_LINE, REAL_DENY_LINE].join("\n");
     const result = await scanBuildkitdLog(logText.split("\n"));
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].count, 2);
+    expect(result.blocked.length).toBe(1);
+    expect(result.blocked[0].count).toBe(2);
   });
 
   it("parses multiple lines and skips non-matching ones", async () => {
@@ -85,7 +85,7 @@ describe("scanBuildkitdLog — blocked", () => {
       REAL_DENY_LINE_WITH_PATH,
     ].join("\n");
     const result = await scanBuildkitdLog(logText.split("\n"));
-    assert.equal(result.blocked.length, 2);
+    expect(result.blocked.length).toBe(2);
   });
 });
 
@@ -93,7 +93,7 @@ describe("scanBuildkitdLog — denied (chronological, unaggregated)", () => {
   it("parses a real denial line's url and timestamp, in chronological order", async () => {
     const logText = [REAL_DENY_LINE, REAL_DENY_LINE_WITH_PATH].join("\n");
     const result = await scanBuildkitdLog(logText.split("\n"));
-    assert.deepEqual(result.denied, [
+    expect(result.denied).toStrictEqual([
       { url: "https://blocked.example.com/", timestamp: "2026-07-05T02:26:34Z" },
       {
         url: "https://dl-cdn.alpinelinux.org:443/alpine/v3.20/main/aarch64/APKINDEX.tar.gz",
@@ -105,37 +105,37 @@ describe("scanBuildkitdLog — denied (chronological, unaggregated)", () => {
   it("does not aggregate — repeated denials for the same URL each get their own entry", async () => {
     const logText = [REAL_DENY_LINE, REAL_DENY_LINE].join("\n");
     const result = await scanBuildkitdLog(logText.split("\n"));
-    assert.equal(result.denied.length, 2);
+    expect(result.denied.length).toBe(2);
   });
 
   it("ignores non-denial lines", async () => {
     const result = await scanBuildkitdLog(
       'time="2026-07-05T00:00:00Z" level=info msg="found worker"'.split("\n"),
     );
-    assert.deepEqual(result.denied, []);
+    expect(result.denied).toStrictEqual([]);
   });
 });
 
 describe("scanBuildkitdLog — hasNonDenialContent", () => {
   it("returns false for empty log text", async () => {
     const result = await scanBuildkitdLog("".split("\n"));
-    assert.equal(result.hasNonDenialContent, false);
+    expect(result.hasNonDenialContent).toBe(false);
   });
 
   it("returns false when the log has only denial lines", async () => {
     const result = await scanBuildkitdLog(REAL_DENY_LINE.split("\n"));
-    assert.equal(result.hasNonDenialContent, false);
+    expect(result.hasNonDenialContent).toBe(false);
   });
 
   it("returns true when the log contains buildkitd's own non-denial debug output", async () => {
     const logText = [REAL_DENY_LINE, 'time="x" level=info msg="found worker"'].join("\n");
     const result = await scanBuildkitdLog(logText.split("\n"));
-    assert.equal(result.hasNonDenialContent, true);
+    expect(result.hasNonDenialContent).toBe(true);
   });
 
   it("ignores blank lines when deciding", async () => {
     const result = await scanBuildkitdLog("\n\n  \n".split("\n"));
-    assert.equal(result.hasNonDenialContent, false);
+    expect(result.hasNonDenialContent).toBe(false);
   });
 });
 

--- a/core/lib/log/haproxy.property.test.ts
+++ b/core/lib/log/haproxy.property.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run core/lib/log/haproxy.property.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 
 import { scanHaproxyLog } from "./haproxy.ts";
@@ -43,23 +42,23 @@ describe("scanHaproxyLog – properties", () => {
           const passedDecision = audit ? "AUDIT" : "ALLOWED";
 
           if (d === "BLOCKED") {
-            assert.equal(result.passed.length, 0);
-            assert.equal(result.blocked.length, 1);
-            assert.equal(result.blocked[0].ruleType, rt);
-            assert.equal(result.blocked[0].host, h);
-            assert.equal(result.blocked[0].port, p);
-            assert.equal(result.blocked[0].reason, r);
+            expect(result.passed.length).toBe(0);
+            expect(result.blocked.length).toBe(1);
+            expect(result.blocked[0].ruleType).toBe(rt);
+            expect(result.blocked[0].host).toBe(h);
+            expect(result.blocked[0].port).toBe(p);
+            expect(result.blocked[0].reason).toBe(r);
           } else if (d === passedDecision) {
-            assert.equal(result.blocked.length, 0);
-            assert.equal(result.passed.length, 1);
-            assert.equal(result.passed[0].ruleType, rt);
-            assert.equal(result.passed[0].host, h);
-            assert.equal(result.passed[0].port, p);
-            assert.equal(result.passed[0].reason, r);
+            expect(result.blocked.length).toBe(0);
+            expect(result.passed.length).toBe(1);
+            expect(result.passed[0].ruleType).toBe(rt);
+            expect(result.passed[0].host).toBe(h);
+            expect(result.passed[0].port).toBe(p);
+            expect(result.passed[0].reason).toBe(r);
           } else {
             // The "other" of ALLOWED/AUDIT for this mode — dropped entirely.
-            assert.equal(result.passed.length, 0);
-            assert.equal(result.blocked.length, 0);
+            expect(result.passed.length).toBe(0);
+            expect(result.blocked.length).toBe(0);
           }
         },
       ),
@@ -75,8 +74,8 @@ describe("scanHaproxyLog – properties", () => {
       fc.asyncProperty(word, word, async (w1, w2) => {
         const line = `[ts] buildcage [ALLOWED] (HTTPS) "example.com:443" ${w1} ${w2}`;
         const result = await scanHaproxyLog([line], false);
-        assert.equal(result.passed.length, 1);
-        assert.equal(result.passed[0].reason, w1);
+        expect(result.passed.length).toBe(1);
+        expect(result.passed[0].reason).toBe(w1);
       }),
     );
   });
@@ -99,7 +98,7 @@ describe("aggregate – properties", () => {
 
     fc.assert(
       fc.property(fc.array(entryWithAlphaPort, { minLength: 1, maxLength: 5 }), (entries) => {
-        assert.doesNotThrow(() => aggregate(entries));
+        expect(() => aggregate(entries)).not.toThrow();
       }),
     );
   });

--- a/core/lib/log/haproxy.test.ts
+++ b/core/lib/log/haproxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { scanHaproxyLog } from "./haproxy.ts";
 
 // ---------------------------------------------------------------------------
@@ -8,46 +8,46 @@ describe("scanHaproxyLog", () => {
   it("aggregates an ALLOWED log line as passed when isAudit is false", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "example.com:443" rule1';
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].ruleType, "HTTPS");
-    assert.equal(result.passed[0].host, "example.com");
-    assert.equal(result.passed[0].port, "443");
-    assert.equal(result.passed[0].reason, "rule1");
-    assert.equal(result.blocked.length, 0);
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].ruleType).toBe("HTTPS");
+    expect(result.passed[0].host).toBe("example.com");
+    expect(result.passed[0].port).toBe("443");
+    expect(result.passed[0].reason).toBe("rule1");
+    expect(result.blocked.length).toBe(0);
   });
 
   it("aggregates a BLOCKED log line regardless of isAudit", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTP) "bad.com:80" not-allowed';
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].reason, "not-allowed");
-    assert.equal(result.blockedCount, 1);
+    expect(result.blocked.length).toBe(1);
+    expect(result.blocked[0].reason).toBe("not-allowed");
+    expect(result.blockedCount).toBe(1);
   });
 
   it("aggregates an AUDIT log line as passed when isAudit is true", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "any.com:443"';
     const result = await scanHaproxyLog(log.split("\n"), true);
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].reason, "-");
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].reason).toBe("-");
   });
 
   it("drops an ALLOWED line when isAudit is true (not the decision this mode aggregates)", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "example.com:443" rule1';
     const result = await scanHaproxyLog(log.split("\n"), true);
-    assert.equal(result.passed.length, 0);
+    expect(result.passed.length).toBe(0);
   });
 
   it("drops an AUDIT line when isAudit is false (not the decision this mode aggregates)", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "any.com:443"';
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.passed.length, 0);
+    expect(result.passed.length).toBe(0);
   });
 
   it("ignores non-matching lines without counting them anywhere", async () => {
     const log = "some random log line\n[2024-01-01] other stuff";
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.passed.length, 0);
-    assert.equal(result.blocked.length, 0);
+    expect(result.passed.length).toBe(0);
+    expect(result.blocked.length).toBe(0);
   });
 
   it("aggregates repeated BLOCKED lines into one row, but keeps blockedCount raw", async () => {
@@ -56,9 +56,9 @@ describe("scanHaproxyLog", () => {
       '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTPS) "bad.com:443" not-allowed',
     ].join("\n");
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].count, 2);
-    assert.equal(result.blockedCount, 2);
+    expect(result.blocked.length).toBe(1);
+    expect(result.blocked[0].count).toBe(2);
+    expect(result.blockedCount).toBe(2);
   });
 
   it("keeps passed/blocked buckets independent across mixed lines", async () => {
@@ -69,10 +69,10 @@ describe("scanHaproxyLog", () => {
       '[2024-01-01T00:00:02] buildcage [ALLOWED] (HTTPS) "a.com:443" r1',
     ].join("\n");
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].count, 2);
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blockedCount, 1);
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].count).toBe(2);
+    expect(result.blocked.length).toBe(1);
+    expect(result.blockedCount).toBe(1);
   });
 
   it("accepts a real AsyncIterable, not just an array", async () => {
@@ -80,8 +80,8 @@ describe("scanHaproxyLog", () => {
       yield '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "async.com:443" r1';
     }
     const result = await scanHaproxyLog(lines(), false);
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].host, "async.com");
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].host).toBe("async.com");
   });
 
   // ---------------------------------------------------------------------
@@ -89,7 +89,7 @@ describe("scanHaproxyLog", () => {
   // ---------------------------------------------------------------------
   it("hasNonBuildcageContent is false for empty log text", async () => {
     const result = await scanHaproxyLog("".split("\n"), false);
-    assert.equal(result.hasNonBuildcageContent, false);
+    expect(result.hasNonBuildcageContent).toBe(false);
   });
 
   it("hasNonBuildcageContent is false when the log has only buildcage-decision lines", async () => {
@@ -98,7 +98,7 @@ describe("scanHaproxyLog", () => {
       '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTP) "b.com:80" not-allowed',
     ].join("\n");
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.hasNonBuildcageContent, false);
+    expect(result.hasNonBuildcageContent).toBe(false);
   });
 
   it("hasNonBuildcageContent is true when the log contains HAProxy's own non-decision output", async () => {
@@ -107,12 +107,12 @@ describe("scanHaproxyLog", () => {
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "a.com:443" r1',
     ].join("\n");
     const result = await scanHaproxyLog(log.split("\n"), false);
-    assert.equal(result.hasNonBuildcageContent, true);
+    expect(result.hasNonBuildcageContent).toBe(true);
   });
 
   it("hasNonBuildcageContent ignores blank lines when deciding", async () => {
     const result = await scanHaproxyLog("\n\n  \n".split("\n"), false);
-    assert.equal(result.hasNonBuildcageContent, false);
+    expect(result.hasNonBuildcageContent).toBe(false);
   });
 });
 

--- a/core/lib/log/parse-identifier.test.ts
+++ b/core/lib/log/parse-identifier.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { parseIdentifier } from "./parse-identifier.ts";
 
 describe("parseIdentifier", () => {
   it("fills in the default port when none is present", () => {
-    assert.deepEqual(parseIdentifier("https://allowed.example.com/"), {
+    expect(parseIdentifier("https://allowed.example.com/")).toStrictEqual({
       scheme: "https",
       host: "allowed.example.com",
       port: "443",
     });
-    assert.deepEqual(parseIdentifier("http://allowed.example.com/"), {
+    expect(parseIdentifier("http://allowed.example.com/")).toStrictEqual({
       scheme: "http",
       host: "allowed.example.com",
       port: "80",
@@ -16,7 +16,7 @@ describe("parseIdentifier", () => {
   });
 
   it("keeps an explicit non-default port", () => {
-    assert.deepEqual(parseIdentifier("https://allowed.example.com:8443/"), {
+    expect(parseIdentifier("https://allowed.example.com:8443/")).toStrictEqual({
       scheme: "https",
       host: "allowed.example.com",
       port: "8443",
@@ -24,7 +24,7 @@ describe("parseIdentifier", () => {
   });
 
   it("returns null for non-http(s) identifiers", () => {
-    assert.equal(parseIdentifier("docker-image://docker.io/library/alpine:latest"), null);
+    expect(parseIdentifier("docker-image://docker.io/library/alpine:latest")).toBe(null);
   });
 });
 

--- a/core/lib/log/proxy-request-text.test.ts
+++ b/core/lib/log/proxy-request-text.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { parseAllowedRequestsFromText } from "./proxy-request-text.ts";
 
 describe("parseAllowedRequestsFromText", () => {
@@ -7,14 +6,14 @@ describe("parseAllowedRequestsFromText", () => {
     const text = ["proxy network requests:", "- GET https://allowed.example.com/ -> 200"].join(
       "\n",
     );
-    assert.deepEqual(parseAllowedRequestsFromText(text), [
+    expect(parseAllowedRequestsFromText(text)).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/", status: 200 },
     ]);
   });
 
   it("parses a request line with no status code at all", () => {
     const text = ["proxy network requests:", "- GET https://allowed.example.com/"].join("\n");
-    assert.deepEqual(parseAllowedRequestsFromText(text), [
+    expect(parseAllowedRequestsFromText(text)).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/" },
     ]);
   });
@@ -26,7 +25,7 @@ describe("parseAllowedRequestsFromText", () => {
       "- GET https://sub.wildcard.example.com/ -> 200",
       'time="x" level=debug msg="Evaluated source policy" error="denied"',
     ].join("\n");
-    assert.deepEqual(parseAllowedRequestsFromText(text), [
+    expect(parseAllowedRequestsFromText(text)).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/", status: 200 },
       { method: "GET", url: "https://sub.wildcard.example.com/", status: 200 },
     ]);
@@ -40,15 +39,17 @@ describe("parseAllowedRequestsFromText", () => {
       "proxy network requests:",
       "- GET http://allowed.example.com:8080/ -> 200",
     ].join("\n");
-    assert.equal(parseAllowedRequestsFromText(text).length, 2);
+    expect(parseAllowedRequestsFromText(text).length).toBe(2);
   });
 
   it("does not misinterpret unrelated '- ' output as a request line outside a block", () => {
     const text = "- rw-r--r-- 1 root root 0 file.txt";
-    assert.deepEqual(parseAllowedRequestsFromText(text), []);
+    expect(parseAllowedRequestsFromText(text)).toStrictEqual([]);
   });
 
   it("returns an empty array when no block is present", () => {
-    assert.deepEqual(parseAllowedRequestsFromText('time="x" level=info msg="found worker"'), []);
+    expect(parseAllowedRequestsFromText('time="x" level=info msg="found worker"')).toStrictEqual(
+      [],
+    );
   });
 });

--- a/core/lib/log/vertex.test.ts
+++ b/core/lib/log/vertex.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,55 +28,62 @@ function encode(text: string) {
 describe("parseVertexAllowedLog", () => {
   it("captures every single-digit step despite BuildKit's leading-space padding (regression: a real 15-step build)", () => {
     const result = parseVertexAllowedLog(PADDED_STEPS_RAWJSON);
-    assert.equal(result.length, 14); // steps 2/15 through 15/15
-    assert.equal(
-      result[0].command,
+    expect(result.length).toBe(14); // steps 2/15 through 15/15
+    expect(result[0].command).toBe(
       '[ 2/15] RUN echo "=== DNS Configuration ===" &&     cat /etc/resolv.conf',
     );
-    assert.deepEqual(result[0].entries, []);
-    assert.equal(
+    expect(result[0].entries).toStrictEqual([]);
+    expect(
       result[1].command.startsWith('[ 3/15] RUN echo "=== [HTTPS - allowed - exact match]'),
-      true,
-    );
-    assert.deepEqual(result[1].entries, [
+    ).toBe(true);
+    expect(result[1].entries).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/", status: 200 },
     ]);
     // step numbers stay in ascending order despite the "[ 2/15]" vs "[10/15]" width difference
-    assert.deepEqual(
-      result.map((v) => v.command.match(/^\[\s*(\d+)\/15\]/)![1]),
-      ["2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15"],
-    );
+    expect(result.map((v) => v.command.match(/^\[\s*(\d+)\/15\]/)![1])).toStrictEqual([
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+    ]);
   });
 
   it("groups a real multi-stage build's RUN vertices by stage, stages ordered by earliest start, marking the no-op step's entries empty", () => {
     const result = parseVertexAllowedLog(MULTISTAGE_RAWJSON);
-    assert.deepEqual(
-      result.map((v) => v.command),
-      [
-        '[stage2 2/2] RUN echo "step B" && wget -q -O /dev/null --timeout=5 https://allowed.example.com/two && echo "B done"',
-        '[stage1 2/3] RUN echo "no network here" && mkdir -p /tmp/work',
-        '[stage1 3/3] RUN echo "step A" && wget -q -O /dev/null --timeout=5 https://allowed.example.com/one && echo "A done"',
-      ],
-    );
+    expect(result.map((v) => v.command)).toStrictEqual([
+      '[stage2 2/2] RUN echo "step B" && wget -q -O /dev/null --timeout=5 https://allowed.example.com/two && echo "B done"',
+      '[stage1 2/3] RUN echo "no network here" && mkdir -p /tmp/work',
+      '[stage1 3/3] RUN echo "step A" && wget -q -O /dev/null --timeout=5 https://allowed.example.com/one && echo "A done"',
+    ]);
     // stage1's two vertices stay adjacent and in step order, even though
     // stage2's single vertex (started ~109us earlier) sorts before the group.
-    assert.deepEqual(result[1].entries, []);
-    assert.deepEqual(result[2].entries, [
+    expect(result[1].entries).toStrictEqual([]);
+    expect(result[2].entries).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/one", status: 200 },
     ]);
-    assert.deepEqual(result[0].entries, [
+    expect(result[0].entries).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/two", status: 200 },
     ]);
     for (const v of result) {
-      assert.equal(typeof v.started, "string");
-      assert.equal(typeof v.completed, "string");
+      expect(typeof v.started).toBe("string");
+      expect(typeof v.completed).toBe("string");
     }
   });
 
   it("excludes non-RUN vertices (FROM, internal loads, COPY, exporting)", () => {
     const result = parseVertexAllowedLog(MULTISTAGE_RAWJSON);
     for (const v of result) {
-      assert.match(v.command, /\bRUN\b/);
+      expect(v.command).toMatch(/\bRUN\b/);
     }
   });
 
@@ -100,11 +106,8 @@ describe("parseVertexAllowedLog", () => {
       logs: [],
     });
     const result = parseVertexAllowedLog(rawJson);
-    assert.deepEqual(
-      result.map((v) => v.command),
-      ["[2/3] RUN first", "[3/3] RUN second"],
-    );
-    assert.deepEqual(result[0].entries, []);
+    expect(result.map((v) => v.command)).toStrictEqual(["[2/3] RUN first", "[3/3] RUN second"]);
+    expect(result[0].entries).toStrictEqual([]);
   });
 
   it("does not let an anonymous stage's auto-numbered prefix ('stage-0') collide across groups", () => {
@@ -127,10 +130,10 @@ describe("parseVertexAllowedLog", () => {
     });
     const result = parseVertexAllowedLog(rawJson);
     // stage-1 started earlier, so its (single-vertex) group sorts first.
-    assert.deepEqual(
-      result.map((v) => v.command),
-      ['[stage-1 2/2] RUN echo "one"', '[stage-0 2/2] RUN echo "zero"'],
-    );
+    expect(result.map((v) => v.command)).toStrictEqual([
+      '[stage-1 2/2] RUN echo "one"',
+      '[stage-0 2/2] RUN echo "zero"',
+    ]);
   });
 
   it("decodes base64 stderr logs and concatenates multiple fragments for the same vertex in timestamp order", () => {
@@ -165,7 +168,7 @@ describe("parseVertexAllowedLog", () => {
       ],
     });
     const result = parseVertexAllowedLog(rawJson);
-    assert.deepEqual(result[0].entries, [
+    expect(result[0].entries).toStrictEqual([
       { method: "GET", url: "https://allowed.example.com/", status: 200 },
     ]);
   });
@@ -184,8 +187,8 @@ describe("parseVertexAllowedLog", () => {
       logs: [],
     });
     const result = parseVertexAllowedLog(rawJson);
-    assert.equal(result.length, 1);
-    assert.equal(result[0].started, "2026-01-01T00:00:00.060Z");
+    expect(result.length).toBe(1);
+    expect(result[0].started).toBe("2026-01-01T00:00:00.060Z");
   });
 
   it("returns an empty array when there are no RUN vertices", () => {
@@ -200,7 +203,7 @@ describe("parseVertexAllowedLog", () => {
       ],
       logs: [],
     });
-    assert.deepEqual(parseVertexAllowedLog(rawJson), []);
+    expect(parseVertexAllowedLog(rawJson)).toStrictEqual([]);
   });
 
   it("merges vertexes and logs when buildctl emits multiple newline-separated JSON documents instead of one blob", () => {
@@ -244,9 +247,9 @@ describe("parseVertexAllowedLog", () => {
     // ("Unexpected non-whitespace character after JSON ... line 2 column 1")
     // — this is the exact failure this parses around.
     const result = parseVertexAllowedLog(`${doc1}\n${doc2}\n`);
-    assert.equal(result.length, 2);
-    assert.equal(result[0].entries[0].url, "https://one.example.com/");
-    assert.equal(result[1].entries[0].url, "https://two.example.com/");
+    expect(result.length).toBe(2);
+    expect(result[0].entries[0].url).toBe("https://one.example.com/");
+    expect(result[1].entries[0].url).toBe("https://two.example.com/");
   });
 
   it("skips a document line that fails to parse as JSON, keeping the rest", () => {
@@ -269,7 +272,7 @@ describe("parseVertexAllowedLog", () => {
       ],
     });
     const result = parseVertexAllowedLog(`${doc1}\nnot json at all\n`);
-    assert.equal(result.length, 1);
-    assert.equal(result[0].entries[0].url, "https://one.example.com/");
+    expect(result.length).toBe(1);
+    expect(result[0].entries[0].url).toBe("https://one.example.com/");
   });
 });

--- a/core/lib/provenance/image-tag.test.ts
+++ b/core/lib/provenance/image-tag.test.ts
@@ -3,44 +3,43 @@
  *
  * Run with: vp test run core/lib/provenance/image-tag.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { imageTagFromRef } from "./image-tag.ts";
 
 describe("imageTagFromRef", () => {
   it("converts a 40-char hex SHA to sha-<sha> by default (no suffix for transparent)", () => {
     const sha = "a".repeat(40);
-    assert.equal(imageTagFromRef(sha), `sha-${"a".repeat(40)}`);
+    expect(imageTagFromRef(sha)).toBe(`sha-${"a".repeat(40)}`);
   });
 
   it("lowercases the SHA", () => {
     const sha = "ABCDEF1234".padEnd(40, "0");
-    assert.equal(imageTagFromRef(sha), `sha-${sha.toLowerCase()}`);
+    expect(imageTagFromRef(sha)).toBe(`sha-${sha.toLowerCase()}`);
   });
 
   it("strips leading 'v' from a version tag", () => {
-    assert.equal(imageTagFromRef("v2.1.0"), "2.1.0");
+    expect(imageTagFromRef("v2.1.0")).toBe("2.1.0");
   });
 
   it("strips 'v' from a major-only tag", () => {
-    assert.equal(imageTagFromRef("v2"), "2");
+    expect(imageTagFromRef("v2")).toBe("2");
   });
 
   it("returns a branch name as-is, with no suffix for the default engine", () => {
-    assert.equal(imageTagFromRef("main"), "main");
+    expect(imageTagFromRef("main")).toBe("main");
   });
 
   it("returns empty string for empty input", () => {
-    assert.equal(imageTagFromRef(""), "");
+    expect(imageTagFromRef("")).toBe("");
   });
 
   it("returns empty string for undefined", () => {
-    assert.equal(imageTagFromRef(undefined), "");
+    expect(imageTagFromRef(undefined)).toBe("");
   });
 
   it("appends the explicit engine suffix instead when requested", () => {
-    assert.equal(imageTagFromRef("v2.1.0", "explicit"), "2.1.0-explicit");
-    assert.equal(imageTagFromRef("a".repeat(40), "explicit"), `sha-${"a".repeat(40)}-explicit`);
+    expect(imageTagFromRef("v2.1.0", "explicit")).toBe("2.1.0-explicit");
+    expect(imageTagFromRef("a".repeat(40), "explicit")).toBe(`sha-${"a".repeat(40)}-explicit`);
   });
 });

--- a/core/lib/provenance/local-image-override.test.ts
+++ b/core/lib/provenance/local-image-override.test.ts
@@ -1,19 +1,18 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { readLocalImageOverride } from "./local-image-override.ts";
 
 describe("readLocalImageOverride", () => {
   it("returns null when BUILDCAGE_LOCAL_IMAGE_REF is unset", () => {
-    assert.equal(readLocalImageOverride({}), null);
+    expect(readLocalImageOverride({})).toBe(null);
   });
 
   it("returns null when BUILDCAGE_LOCAL_IMAGE_REF is an empty string", () => {
-    assert.equal(readLocalImageOverride({ BUILDCAGE_LOCAL_IMAGE_REF: "" }), null);
+    expect(readLocalImageOverride({ BUILDCAGE_LOCAL_IMAGE_REF: "" })).toBe(null);
   });
 
   it("returns the literal image ref and pullPolicy 'never' when set", () => {
     const result = readLocalImageOverride({ BUILDCAGE_LOCAL_IMAGE_REF: "buildcage-builder" });
-    assert.deepEqual(result, { imageRef: "buildcage-builder", pullPolicy: "never" });
+    expect(result).toStrictEqual({ imageRef: "buildcage-builder", pullPolicy: "never" });
   });
 });

--- a/core/lib/provenance/oci-registry.test.ts
+++ b/core/lib/provenance/oci-registry.test.ts
@@ -5,8 +5,7 @@
  *
  * Run with: vp test run core/lib/provenance/oci-registry.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect, assert } from "vitest";
 
 import {
   fetchManifestDigest,
@@ -36,8 +35,8 @@ describe("fetchManifestDigest", () => {
       return makeResp(200, digest);
     };
     const result = await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
-    assert.equal(result, digest);
-    assert.equal(capturedOpts?.method, "HEAD");
+    expect(result).toBe(digest);
+    expect(capturedOpts?.method).toBe("HEAD");
   });
 
   it("throws NOT_FOUND on 404", async () => {
@@ -46,8 +45,8 @@ describe("fetchManifestDigest", () => {
       await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "NOT_FOUND");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("NOT_FOUND");
     }
   });
 
@@ -57,8 +56,8 @@ describe("fetchManifestDigest", () => {
       await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 
@@ -68,12 +67,12 @@ describe("fetchManifestDigest", () => {
       await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
-      assert.ok(
-        err.message.includes("authenticated"),
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
+      expect(
+        (err as VerifyImageError).message.includes("authenticated"),
         "error message should hint at authentication",
-      );
+      ).toBeTruthy();
     }
   });
 
@@ -83,12 +82,12 @@ describe("fetchManifestDigest", () => {
       await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
-      assert.ok(
-        err.message.includes("authenticated"),
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
+      expect(
+        (err as VerifyImageError).message.includes("authenticated"),
         "error message should hint at authentication",
-      );
+      ).toBeTruthy();
     }
   });
 
@@ -98,8 +97,8 @@ describe("fetchManifestDigest", () => {
       await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 
@@ -111,8 +110,8 @@ describe("fetchManifestDigest", () => {
       await fetchManifestDigest("ghcr.io", "owner/repo", "2.1.0", "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 });
@@ -126,12 +125,12 @@ describe("fetchRegistryToken", () => {
     let callCount = 0;
     const mockFetch = async (url: string, opts?: { headers?: Record<string, string> }) => {
       callCount++;
-      assert.equal(opts, undefined, "should send no auth header");
+      expect(opts, "should send no auth header").toBe(undefined);
       return { ok: true, status: 200, json: async () => ({ token: "anon-token" }) };
     };
     const token = await fetchRegistryToken("ghcr.io", "dash14/buildcage", null, mockFetch);
-    assert.equal(token, "anon-token");
-    assert.equal(callCount, 1, "should make exactly one request");
+    expect(token).toBe("anon-token");
+    expect(callCount, "should make exactly one request").toBe(1);
   });
 
   it("throws TOKEN_ERROR on 401 when no Docker credentials (private, not logged in)", async () => {
@@ -140,9 +139,12 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", null, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TOKEN_ERROR");
-      assert.ok(err.message.includes("docker login"), "error message should mention docker login");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TOKEN_ERROR");
+      expect(
+        (err as VerifyImageError).message.includes("docker login"),
+        "error message should mention docker login",
+      ).toBeTruthy();
     }
   });
 
@@ -152,8 +154,8 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", null, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TOKEN_ERROR");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TOKEN_ERROR");
     }
   });
 
@@ -163,8 +165,8 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", null, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 
@@ -176,8 +178,8 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", null, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 
@@ -193,9 +195,9 @@ describe("fetchRegistryToken", () => {
       return { ok: true, status: 200, json: async () => ({ token: "jwt-token" }) };
     };
     const token = await fetchRegistryToken("ghcr.io", "dash14/buildcage", basicAuth, mockFetch);
-    assert.equal(token, "jwt-token");
-    assert.equal(callCount, 1, "should make exactly one request (no anonymous attempt)");
-    assert.equal(capturedAuth, `Basic ${basicAuth}`, "should send the Docker config auth directly");
+    expect(token).toBe("jwt-token");
+    expect(callCount, "should make exactly one request (no anonymous attempt)").toBe(1);
+    expect(capturedAuth, "should send the Docker config auth directly").toBe(`Basic ${basicAuth}`);
   });
 
   it("throws TOKEN_ERROR immediately on 401 when Docker credentials are present (no fallback)", async () => {
@@ -209,10 +211,13 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", basicAuth, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TOKEN_ERROR");
-      assert.ok(err.message.includes("docker login"), "error message should mention docker login");
-      assert.equal(callCount, 1, "should not retry with anonymous");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TOKEN_ERROR");
+      expect(
+        (err as VerifyImageError).message.includes("docker login"),
+        "error message should mention docker login",
+      ).toBeTruthy();
+      expect(callCount, "should not retry with anonymous").toBe(1);
     }
   });
 
@@ -223,8 +228,8 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", basicAuth, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TOKEN_ERROR");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TOKEN_ERROR");
     }
   });
 
@@ -235,8 +240,8 @@ describe("fetchRegistryToken", () => {
       await fetchRegistryToken("ghcr.io", "dash14/buildcage", basicAuth, mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 });
@@ -249,39 +254,39 @@ describe("readGhcrBasicAuth", () => {
   it("returns auth when auths['ghcr.io'].auth is present", () => {
     const config = JSON.stringify({ auths: { "ghcr.io": { auth: "dGVzdDp0b2tlbg==" } } });
     const result = readGhcrBasicAuth({}, mockReadFileSync(config));
-    assert.equal(result, "dGVzdDp0b2tlbg==");
+    expect(result).toBe("dGVzdDp0b2tlbg==");
   });
 
   it("normalizes https:// prefix and trailing slash in key", () => {
     const config = JSON.stringify({ auths: { "https://ghcr.io/": { auth: "dGVzdA==" } } });
     const result = readGhcrBasicAuth({}, mockReadFileSync(config));
-    assert.equal(result, "dGVzdA==");
+    expect(result).toBe("dGVzdA==");
   });
 
   it("returns null when ghcr.io entry is absent", () => {
     const config = JSON.stringify({ auths: { "docker.io": { auth: "dGVzdA==" } } });
-    assert.equal(readGhcrBasicAuth({}, mockReadFileSync(config)), null);
+    expect(readGhcrBasicAuth({}, mockReadFileSync(config))).toBe(null);
   });
 
   it("returns null when auth field is empty string (credsStore environment)", () => {
     const config = JSON.stringify({ auths: { "ghcr.io": {} } });
-    assert.equal(readGhcrBasicAuth({}, mockReadFileSync(config)), null);
+    expect(readGhcrBasicAuth({}, mockReadFileSync(config))).toBe(null);
   });
 
   it("returns null when auths is absent", () => {
     const config = JSON.stringify({ credsStore: "desktop" });
-    assert.equal(readGhcrBasicAuth({}, mockReadFileSync(config)), null);
+    expect(readGhcrBasicAuth({}, mockReadFileSync(config))).toBe(null);
   });
 
   it("returns null on file read error (not logged in at all)", () => {
     const throwingRead = () => {
       throw new Error("ENOENT");
     };
-    assert.equal(readGhcrBasicAuth({}, throwingRead), null);
+    expect(readGhcrBasicAuth({}, throwingRead)).toBe(null);
   });
 
   it("returns null on invalid JSON", () => {
-    assert.equal(readGhcrBasicAuth({}, mockReadFileSync("not json")), null);
+    expect(readGhcrBasicAuth({}, mockReadFileSync("not json"))).toBe(null);
   });
 
   it("uses DOCKER_CONFIG env var to resolve config path", () => {
@@ -291,10 +296,10 @@ describe("readGhcrBasicAuth", () => {
       return JSON.stringify({ auths: {} });
     };
     readGhcrBasicAuth({ DOCKER_CONFIG: "/custom/docker" }, readSpy);
-    assert.ok(
+    expect(
       capturedPath?.startsWith("/custom/docker"),
       `expected path under DOCKER_CONFIG, got: ${capturedPath}`,
-    );
+    ).toBeTruthy();
   });
 });
 
@@ -345,7 +350,7 @@ describe("fetchBundle — Referrers API path", () => {
       { ok: true, status: 200, json: async () => bundleObj },
     ]);
     const result = await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
-    assert.deepEqual(result, bundleObj);
+    expect(result).toStrictEqual(bundleObj);
   });
 
   it("throws NOT_FOUND when Referrers returns no matching artifactType", async () => {
@@ -365,8 +370,8 @@ describe("fetchBundle — Referrers API path", () => {
       await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "NOT_FOUND");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("NOT_FOUND");
     }
   });
 });
@@ -393,7 +398,7 @@ describe("fetchBundle — fallback tag path", () => {
       { ok: true, status: 200, json: async () => bundleObj },
     ]);
     const result = await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
-    assert.deepEqual(result, bundleObj);
+    expect(result).toStrictEqual(bundleObj);
   });
 
   it("falls back to sha256-<hex> tag as OCI image index (standard artifactType match)", async () => {
@@ -427,7 +432,7 @@ describe("fetchBundle — fallback tag path", () => {
       { ok: true, status: 200, json: async () => bundleObj },
     ]);
     const result = await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
-    assert.deepEqual(result, bundleObj);
+    expect(result).toStrictEqual(bundleObj);
   });
 
   it("falls back to sha256-<hex> tag as OCI image index (GHCR: config.mediaType used as artifactType)", async () => {
@@ -475,7 +480,7 @@ describe("fetchBundle — fallback tag path", () => {
       { ok: true, status: 200, json: async () => bundleObj },
     ]);
     const result = await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
-    assert.deepEqual(result, bundleObj);
+    expect(result).toStrictEqual(bundleObj);
   });
 
   it("throws TRANSIENT on 5xx from Referrers API", async () => {
@@ -484,8 +489,8 @@ describe("fetchBundle — fallback tag path", () => {
       await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 
@@ -497,8 +502,8 @@ describe("fetchBundle — fallback tag path", () => {
       await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(err.code, "TRANSIENT");
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("TRANSIENT");
     }
   });
 
@@ -521,12 +526,11 @@ describe("fetchBundle — fallback tag path", () => {
       await fetchBundle("ghcr.io", "dash14/buildcage", digest, "token", mockFetch);
       assert.fail("should have thrown");
     } catch (err) {
-      assert.ok(err instanceof VerifyImageError);
-      assert.equal(
-        err.code,
-        "TRANSIENT",
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect(
+        (err as VerifyImageError).code,
         "auth error must not be reported as NOT_FOUND (unsigned image)",
-      );
+      ).toBe("TRANSIENT");
     }
   });
 });

--- a/core/lib/provenance/signed-digest.test.ts
+++ b/core/lib/provenance/signed-digest.test.ts
@@ -8,8 +8,7 @@
  * Run with: vp test run core/lib/provenance/signed-digest.test.ts
  */
 
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { assertSignedDigest } from "./signed-digest.ts";
 import { VerifyImageError } from "./errors.ts";
 
@@ -61,68 +60,63 @@ function makeBundle(signedDigest: string, { payloadType, subjects }: MakeBundleO
 
 describe("assertSignedDigest — simple-signing (legacy)", () => {
   it("passes when the signed digest matches the expected digest", () => {
-    assert.doesNotThrow(() => assertSignedDigest(makeBundle(DIGEST), DIGEST));
+    expect(() => assertSignedDigest(makeBundle(DIGEST), DIGEST)).not.toThrow();
   });
 
   it("throws VERIFY_FAILED when the signed digest does not match", () => {
-    assert.throws(
-      () => assertSignedDigest(makeBundle("sha256:different"), DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        assert.match(err.message, /does not match/);
-        return true;
-      },
-    );
+    expect.assertions(3);
+    try {
+      assertSignedDigest(makeBundle("sha256:different"), DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+      expect((err as VerifyImageError).message).toMatch(/does not match/);
+    }
   });
 
   it("throws VERIFY_FAILED when the signed digest field is missing", () => {
     const payload = Buffer.from(JSON.stringify({ critical: { image: {} } })).toString("base64");
     const bundle = { dsseEnvelope: { payload } };
-    assert.throws(
-      () => assertSignedDigest(bundle, DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        assert.match(err.message, /missing/);
-        return true;
-      },
-    );
+    expect.assertions(3);
+    try {
+      assertSignedDigest(bundle, DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+      expect((err as VerifyImageError).message).toMatch(/missing/);
+    }
   });
 
   it("throws VERIFY_FAILED when the DSSE payload field is absent", () => {
-    assert.throws(
-      () => assertSignedDigest({ dsseEnvelope: {} }, DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        assert.match(err.message, /missing a signed payload/);
-        return true;
-      },
-    );
+    expect.assertions(3);
+    try {
+      assertSignedDigest({ dsseEnvelope: {} }, DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+      expect((err as VerifyImageError).message).toMatch(/missing a signed payload/);
+    }
   });
 
   it("throws VERIFY_FAILED when dsseEnvelope is absent", () => {
-    assert.throws(
-      () => assertSignedDigest({}, DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        return true;
-      },
-    );
+    expect.assertions(2);
+    try {
+      assertSignedDigest({}, DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+    }
   });
 
   it("throws VERIFY_FAILED when the payload is not valid base64 JSON", () => {
     const bundle = { dsseEnvelope: { payload: "!!!not-base64!!!" } };
-    assert.throws(
-      () => assertSignedDigest(bundle, DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        return true;
-      },
-    );
+    expect.assertions(2);
+    try {
+      assertSignedDigest(bundle, DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+    }
   });
 });
 
@@ -130,9 +124,9 @@ const IN_TOTO = "application/vnd.in-toto+json";
 
 describe("assertSignedDigest — in-toto Statement v1 (cosign --new-bundle-format)", () => {
   it("passes when subject[0].digest.sha256 matches the expected digest", () => {
-    assert.doesNotThrow(() =>
+    expect(() =>
       assertSignedDigest(makeBundle(DIGEST, { payloadType: IN_TOTO }), DIGEST),
-    );
+    ).not.toThrow();
   });
 
   it("passes when one of multiple subjects matches (others do not)", () => {
@@ -143,32 +137,30 @@ describe("assertSignedDigest — in-toto Statement v1 (cosign --new-bundle-forma
         { digest: { sha256: DIGEST.replace(/^sha256:/, "") }, annotations: {} },
       ],
     });
-    assert.doesNotThrow(() => assertSignedDigest(bundle, DIGEST));
+    expect(() => assertSignedDigest(bundle, DIGEST)).not.toThrow();
   });
 
   it("throws VERIFY_FAILED when subject digest does not match", () => {
-    assert.throws(
-      () => assertSignedDigest(makeBundle("sha256:different", { payloadType: IN_TOTO }), DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        assert.match(err.message, /does not match/);
-        return true;
-      },
-    );
+    expect.assertions(3);
+    try {
+      assertSignedDigest(makeBundle("sha256:different", { payloadType: IN_TOTO }), DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+      expect((err as VerifyImageError).message).toMatch(/does not match/);
+    }
   });
 
   it("throws VERIFY_FAILED when subject array is empty", () => {
     const bundle = makeBundle(DIGEST, { payloadType: IN_TOTO, subjects: [] });
-    assert.throws(
-      () => assertSignedDigest(bundle, DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        assert.match(err.message, /missing/);
-        return true;
-      },
-    );
+    expect.assertions(3);
+    try {
+      assertSignedDigest(bundle, DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+      expect((err as VerifyImageError).message).toMatch(/missing/);
+    }
   });
 
   it("throws VERIFY_FAILED when subject has no sha256 field", () => {
@@ -176,13 +168,12 @@ describe("assertSignedDigest — in-toto Statement v1 (cosign --new-bundle-forma
       payloadType: IN_TOTO,
       subjects: [{ digest: { md5: "notsha256" }, annotations: {} }],
     });
-    assert.throws(
-      () => assertSignedDigest(bundle, DIGEST),
-      (err: unknown) => {
-        assert.ok(err instanceof VerifyImageError);
-        assert.equal(err.code, "VERIFY_FAILED");
-        return true;
-      },
-    );
+    expect.assertions(2);
+    try {
+      assertSignedDigest(bundle, DIGEST);
+    } catch (err) {
+      expect(err).toBeInstanceOf(VerifyImageError);
+      expect((err as VerifyImageError).code).toBe("VERIFY_FAILED");
+    }
   });
 });

--- a/core/lib/provenance/verify-image.test.ts
+++ b/core/lib/provenance/verify-image.test.ts
@@ -10,8 +10,7 @@
  *
  * Run with: vp test run core/lib/provenance/verify-image.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { toProvenanceError, requireDigest } from "./verify-image.ts";
 import { ProvenanceError, VerifyImageError } from "./errors.ts";
@@ -23,27 +22,30 @@ describe("toProvenanceError", () => {
     const err = toProvenanceError(
       new VerifyImageError("registry token request failed", "TOKEN_ERROR"),
     );
-    assert.ok(err instanceof ProvenanceError);
-    assert.equal(err.code, "TOKEN_ERROR");
-    assert.equal(err.message, "registry token request failed");
+    expect(err instanceof ProvenanceError).toBeTruthy();
+    expect(err.code).toBe("TOKEN_ERROR");
+    expect(err.message).toBe("registry token request failed");
   });
 
   it("defaults to VERIFY_FAILED when the original error has no code", () => {
     const err = toProvenanceError(new Error("boom"));
-    assert.ok(err instanceof ProvenanceError);
-    assert.equal(err.code, "VERIFY_FAILED");
+    expect(err instanceof ProvenanceError).toBeTruthy();
+    expect(err.code).toBe("VERIFY_FAILED");
   });
 });
 
 describe("requireDigest", () => {
   it("returns the digest when non-null", () => {
-    assert.equal(requireDigest("sha256:abc123", "v2.1.0"), "sha256:abc123");
+    expect(requireDigest("sha256:abc123", "v2.1.0")).toBe("sha256:abc123");
   });
 
   it("throws ProvenanceError with UNVERIFIABLE_REF when the digest is null", () => {
-    assert.throws(
-      () => requireDigest(null, "main"),
-      (err: unknown) => err instanceof ProvenanceError && err.code === "UNVERIFIABLE_REF",
-    );
+    expect.assertions(2);
+    try {
+      requireDigest(null, "main");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProvenanceError);
+      expect((err as ProvenanceError).code).toBe("UNVERIFIABLE_REF");
+    }
   });
 });

--- a/core/lib/provenance/verify-policy.property.test.ts
+++ b/core/lib/provenance/verify-policy.property.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run core/lib/provenance/verify-policy.property.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 
 import { buildVerifyOptions } from "./verify-policy.ts";
@@ -22,10 +21,16 @@ describe("buildVerifyOptions – properties", () => {
         fc.stringMatching(/^[A-Za-z0-9-]{1,20}\/[A-Za-z0-9-]{1,20}$/),
         (actionRef, actionRepo) => {
           const result = buildVerifyOptions({ actionRef, actionRepo });
-          assert.ok(result !== null);
-          assert.ok(result.certificateOIDs !== undefined, "SHA ref must set certificateOIDs");
-          assert.ok(result.certificateIdentityURI!.endsWith("v"), "SAN URI must accept any v-tag");
-          assert.doesNotThrow(() => new RegExp(result.certificateIdentityURI!));
+          expect(result).not.toBeNull();
+          expect(
+            result!.certificateOIDs !== undefined,
+            "SHA ref must set certificateOIDs",
+          ).toBeTruthy();
+          expect(
+            result!.certificateIdentityURI!.endsWith("v"),
+            "SAN URI must accept any v-tag",
+          ).toBeTruthy();
+          expect(() => new RegExp(result!.certificateIdentityURI!)).not.toThrow();
         },
       ),
     );
@@ -40,13 +45,11 @@ describe("buildVerifyOptions – properties", () => {
         fc.stringMatching(/^[A-Za-z0-9-]{1,20}\/[A-Za-z0-9-]{1,20}$/),
         (actionRef, actionRepo) => {
           const result = buildVerifyOptions({ actionRef, actionRepo });
-          assert.ok(result !== null);
-          assert.equal(
-            result.certificateOIDs,
+          expect(result).not.toBeNull();
+          expect(result!.certificateOIDs, "version tag must not set certificateOIDs").toBe(
             undefined,
-            "version tag must not set certificateOIDs",
           );
-          assert.doesNotThrow(() => new RegExp(result.certificateIdentityURI!));
+          expect(() => new RegExp(result!.certificateIdentityURI!)).not.toThrow();
         },
       ),
     );
@@ -60,7 +63,7 @@ describe("buildVerifyOptions – properties", () => {
         fc.string({ minLength: 0, maxLength: 30 }).map((s) => `g${s}`),
         fc.stringMatching(/^[A-Za-z0-9-]{1,20}\/[A-Za-z0-9-]{1,20}$/),
         (actionRef, actionRepo) => {
-          assert.equal(buildVerifyOptions({ actionRef, actionRepo }), null);
+          expect(buildVerifyOptions({ actionRef, actionRepo })).toBe(null);
         },
       ),
     );

--- a/core/lib/provenance/verify-policy.test.ts
+++ b/core/lib/provenance/verify-policy.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run core/lib/provenance/verify-policy.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { buildVerifyOptions } from "./verify-policy.ts";
 import type { VerifyBundleOptions } from "./sigstore.ts";
@@ -29,7 +28,7 @@ function makeSAN(ref: string) {
 describe("buildVerifyOptions — version tag", () => {
   function getOpts(ref: string): VerifyBundleOptions {
     const opts = buildVerifyOptions({ actionRef: ref, actionRepo: REPO });
-    assert.ok(opts, `expected non-null options for ref "${ref}"`);
+    expect(opts, `expected non-null options for ref "${ref}"`).toBeTruthy();
     return opts!;
   }
   function matchesSAN(opts: VerifyBundleOptions, san: string) {
@@ -38,51 +37,60 @@ describe("buildVerifyOptions — version tag", () => {
 
   it("sets certificateIssuer", () => {
     const opts = getOpts("v2.1.0");
-    assert.equal(opts.certificateIssuer, EXPECTED_ISSUER);
+    expect(opts.certificateIssuer).toBe(EXPECTED_ISSUER);
   });
 
   it("matches exact full version @v2.1.0 against cert SAN v2.1.0", () => {
     const opts = getOpts("v2.1.0");
-    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.1.0")));
+    expect(matchesSAN(opts, makeSAN("refs/tags/v2.1.0"))).toBeTruthy();
   });
 
   it("matches floating minor @v2.1 against cert SAN v2.1.3", () => {
     const opts = getOpts("v2.1");
-    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.1.3")));
+    expect(matchesSAN(opts, makeSAN("refs/tags/v2.1.3"))).toBeTruthy();
   });
 
   it("matches floating major @v2 against cert SAN v2.99.0", () => {
     const opts = getOpts("v2");
-    assert.ok(matchesSAN(opts, makeSAN("refs/tags/v2.99.0")));
+    expect(matchesSAN(opts, makeSAN("refs/tags/v2.99.0"))).toBeTruthy();
   });
 
   // ── v2.1 / v2.10 boundary ───────────────────────────────────────────────────
   it("does NOT match @v2.1 against cert SAN v2.10.0 (boundary check)", () => {
     const opts = getOpts("v2.1");
-    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v2.10.0")), "@v2.1 must not match v2.10.0");
+    expect(
+      !matchesSAN(opts, makeSAN("refs/tags/v2.10.0")),
+      "@v2.1 must not match v2.10.0",
+    ).toBeTruthy();
   });
 
   it("does NOT match @v2 against cert SAN v20.0.0 (boundary check)", () => {
     const opts = getOpts("v2");
-    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v20.0.0")), "@v2 must not match v20.0.0");
+    expect(
+      !matchesSAN(opts, makeSAN("refs/tags/v20.0.0")),
+      "@v2 must not match v20.0.0",
+    ).toBeTruthy();
   });
 
   it("does NOT match @v2.1.0 against cert SAN v2.1.1", () => {
     const opts = getOpts("v2.1.0");
-    assert.ok(
+    expect(
       !matchesSAN(opts, makeSAN("refs/tags/v2.1.1")),
       "exact pin must not match different patch",
-    );
+    ).toBeTruthy();
   });
 
   it("does NOT match @v2.1 against cert SAN v2.2.0", () => {
     const opts = getOpts("v2.1");
-    assert.ok(!matchesSAN(opts, makeSAN("refs/tags/v2.2.0")), "@v2.1 must not match v2.2.0");
+    expect(
+      !matchesSAN(opts, makeSAN("refs/tags/v2.2.0")),
+      "@v2.1 must not match v2.2.0",
+    ).toBeTruthy();
   });
 
   it("has no certificateOIDs for version tags", () => {
     const opts = getOpts("v2.1.0");
-    assert.equal(opts.certificateOIDs, undefined);
+    expect(opts.certificateOIDs).toBe(undefined);
   });
 });
 
@@ -91,48 +99,48 @@ describe("buildVerifyOptions — SHA pin", () => {
 
   it("sets certificateIssuer", () => {
     const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
-    assert.equal(opts.certificateIssuer, EXPECTED_ISSUER);
+    expect(opts.certificateIssuer).toBe(EXPECTED_ISSUER);
   });
 
   it("sets certificateOIDs for OID 1.13 with DER UTF8String-encoded SHA", () => {
     const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
-    assert.ok(opts.certificateOIDs, "certificateOIDs must be present for SHA pin");
+    expect(opts.certificateOIDs, "certificateOIDs must be present for SHA pin").toBeTruthy();
     const oidValue = opts.certificateOIDs![OID_SOURCE_REPO_DIGEST];
-    assert.ok(oidValue !== undefined, `OID ${OID_SOURCE_REPO_DIGEST} must be set`);
+    expect(oidValue !== undefined, `OID ${OID_SOURCE_REPO_DIGEST} must be set`).toBeTruthy();
 
     // DER UTF8String: [0x0C, len, ...utf8bytes]
     const expected = Buffer.concat([
       Buffer.from([0x0c, pinSha.length]),
       Buffer.from(pinSha, "utf8"),
     ]);
-    assert.deepEqual(Buffer.from(oidValue, "binary"), expected);
+    expect(Buffer.from(oidValue, "binary")).toStrictEqual(expected);
   });
 
   it("lowercases the SHA in the OID value", () => {
     const opts = buildVerifyOptions({ actionRef: pinSha.toUpperCase(), actionRepo: REPO })!;
     const oidValue = opts.certificateOIDs![OID_SOURCE_REPO_DIGEST];
-    assert.ok(oidValue.includes(pinSha.toLowerCase()), "SHA must be lowercased");
+    expect(oidValue.includes(pinSha.toLowerCase()), "SHA must be lowercased").toBeTruthy();
   });
 
   it("certificateIdentityURI accepts any version tag SAN (SHA checked via OID)", () => {
     const opts = buildVerifyOptions({ actionRef: pinSha, actionRepo: REPO })!;
     const regexp = new RegExp(opts.certificateIdentityURI!);
     // should match some version tags (the SHA in OID is what pins to the commit)
-    assert.ok(regexp.test(makeSAN("refs/tags/v2.1.0")));
-    assert.ok(regexp.test(makeSAN("refs/tags/v3.0.0")));
+    expect(regexp.test(makeSAN("refs/tags/v2.1.0"))).toBeTruthy();
+    expect(regexp.test(makeSAN("refs/tags/v3.0.0"))).toBeTruthy();
   });
 });
 
 describe("buildVerifyOptions — unverifiable refs", () => {
   it("returns null for a branch ref", () => {
-    assert.equal(buildVerifyOptions({ actionRef: "main", actionRepo: REPO }), null);
+    expect(buildVerifyOptions({ actionRef: "main", actionRepo: REPO })).toBe(null);
   });
 
   it("returns null for a local ./setup ref", () => {
-    assert.equal(buildVerifyOptions({ actionRef: "./setup", actionRepo: REPO }), null);
+    expect(buildVerifyOptions({ actionRef: "./setup", actionRepo: REPO })).toBe(null);
   });
 
   it("returns null for an empty ref", () => {
-    assert.equal(buildVerifyOptions({ actionRef: "", actionRepo: REPO }), null);
+    expect(buildVerifyOptions({ actionRef: "", actionRepo: REPO })).toBe(null);
   });
 });

--- a/core/lib/report/build/aggregate.test.ts
+++ b/core/lib/report/build/aggregate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { annotateKnownBlocked, aggregateAllowedHosts } from "./aggregate.ts";
 
 describe("annotateKnownBlocked", () => {
@@ -13,36 +13,36 @@ describe("annotateKnownBlocked", () => {
 
   it("marks all rows as not expected when no rules are given", () => {
     const result = annotateKnownBlocked([row()], []);
-    assert.equal(result[0].expected, false);
+    expect(result[0].expected).toBe(false);
   });
 
   it("marks a row as expected on an exact host:port match", () => {
     const result = annotateKnownBlocked([row()], ["evil.example.com:443"]);
-    assert.equal(result[0].expected, true);
+    expect(result[0].expected).toBe(true);
   });
 
   it("marks a row as expected on a wildcard match", () => {
     const result = annotateKnownBlocked([row()], ["*.example.com:443"]);
-    assert.equal(result[0].expected, true);
+    expect(result[0].expected).toBe(true);
   });
 
   it("marks a row as expected on a ~regex match", () => {
     const result = annotateKnownBlocked([row()], ["~^evil\\.example\\.com:443$"]);
-    assert.equal(result[0].expected, true);
+    expect(result[0].expected).toBe(true);
   });
 
   it("does not match when the port differs", () => {
     const result = annotateKnownBlocked([row({ port: "80" })], ["evil.example.com:443"]);
-    assert.equal(result[0].expected, false);
+    expect(result[0].expected).toBe(false);
   });
 
   it("preserves the original row fields", () => {
     const result = annotateKnownBlocked([row()], []);
-    assert.equal(result[0].host, "evil.example.com");
-    assert.equal(result[0].port, "443");
-    assert.equal(result[0].ruleType, "HTTPS");
-    assert.equal(result[0].reason, "not in allowlist");
-    assert.equal(result[0].count, 3);
+    expect(result[0].host).toBe("evil.example.com");
+    expect(result[0].port).toBe("443");
+    expect(result[0].ruleType).toBe("HTTPS");
+    expect(result[0].reason).toBe("not in allowlist");
+    expect(result[0].count).toBe(3);
   });
 
   it("annotates each row independently across a mixed list", () => {
@@ -50,8 +50,8 @@ describe("annotateKnownBlocked", () => {
       [row({ host: "known.example.com" }), row({ host: "unknown.example.com" })],
       ["known.example.com:443"],
     );
-    assert.equal(result[0].expected, true);
-    assert.equal(result[1].expected, false);
+    expect(result[0].expected).toBe(true);
+    expect(result[1].expected).toBe(false);
   });
 });
 
@@ -63,7 +63,7 @@ describe("aggregateAllowedHosts", () => {
         { entries: [{ method: "GET", url: "https://allowed.example.com/", status: 200 }] },
       ],
     ];
-    assert.deepEqual(aggregateAllowedHosts(builds, "ALLOWED"), [
+    expect(aggregateAllowedHosts(builds, "ALLOWED")).toStrictEqual([
       { host: "allowed.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 2 },
     ]);
   });
@@ -74,35 +74,35 @@ describe("aggregateAllowedHosts", () => {
       [{ entries: [{ method: "GET", url: "https://allowed.example.com/two" }] }],
     ];
     const result = aggregateAllowedHosts(builds, "ALLOWED");
-    assert.equal(result.length, 1);
-    assert.equal(result[0].count, 2);
+    expect(result.length).toBe(1);
+    expect(result[0].count).toBe(2);
   });
 
   it("uses the given decision label", () => {
     const builds = [[{ entries: [{ method: "GET", url: "https://allowed.example.com/" }] }]];
-    assert.equal(aggregateAllowedHosts(builds, "ALLOWED")[0]?.count, 1);
+    expect(aggregateAllowedHosts(builds, "ALLOWED")[0]?.count).toBe(1);
     // decision itself isn't part of the aggregated shape (aggregate() drops it),
     // but distinct decisions must not collide during aggregation
     const mixed = [[{ entries: [{ method: "GET", url: "https://allowed.example.com/" }] }]];
-    assert.deepEqual(aggregateAllowedHosts(mixed, "AUDIT"), [
+    expect(aggregateAllowedHosts(mixed, "AUDIT")).toStrictEqual([
       { host: "allowed.example.com", port: "443", ruleType: "HTTPS", reason: "-", count: 1 },
     ]);
   });
 
   it("skips vertices with no entries", () => {
     const builds = [[{ entries: [] }]];
-    assert.deepEqual(aggregateAllowedHosts(builds, "ALLOWED"), []);
+    expect(aggregateAllowedHosts(builds, "ALLOWED")).toStrictEqual([]);
   });
 
   it("returns an empty array for no builds at all", () => {
-    assert.deepEqual(aggregateAllowedHosts([], "ALLOWED"), []);
+    expect(aggregateAllowedHosts([], "ALLOWED")).toStrictEqual([]);
   });
 
   it("resolves host/port the same way as core/lib/log/parse-identifier.ts's parseIdentifier", () => {
     const builds = [
       [{ entries: [{ method: "GET", url: "http://allowed.example.com:8080/path" }] }],
     ];
-    assert.deepEqual(aggregateAllowedHosts(builds, "ALLOWED"), [
+    expect(aggregateAllowedHosts(builds, "ALLOWED")).toStrictEqual([
       { host: "allowed.example.com", port: "8080", ruleType: "HTTP", reason: "-", count: 1 },
     ]);
   });

--- a/core/lib/report/build/explicit.test.ts
+++ b/core/lib/report/build/explicit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { buildExplicitReportData } from "./explicit.ts";
 import type { GenReportParameters } from "../types.ts";
 import type { VertexAllowedEntry } from "#core/lib/log/vertex.ts";
@@ -34,19 +34,19 @@ const builds: VertexAllowedEntry[][] = [
 describe("buildExplicitReportData", () => {
   it("aggregates passed from builds and blocked from the buildkitd log", async () => {
     const result = await buildExplicitReportData(deniedLine.split("\n"), builds, params());
-    assert.equal(result.engine, "explicit");
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].host, "good.example.com");
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].host, "blocked.example.com");
-    assert.equal(result.blockedCount, 1);
+    expect(result.engine).toBe("explicit");
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].host).toBe("good.example.com");
+    expect(result.blocked.length).toBe(1);
+    expect(result.blocked[0].host).toBe("blocked.example.com");
+    expect(result.blockedCount).toBe(1);
   });
 
   it("blockedCount equals blocked.length (aggregated, not raw event count)", async () => {
     const twoDenials = [deniedLine, deniedLine].join("\n");
     const result = await buildExplicitReportData(twoDenials.split("\n"), [], params());
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blockedCount, 1);
+    expect(result.blocked.length).toBe(1);
+    expect(result.blockedCount).toBe(1);
   });
 
   it("annotates blocked rows against knownBlockedRules", async () => {
@@ -55,34 +55,34 @@ describe("buildExplicitReportData", () => {
       [],
       params({ knownBlockedRules: ["blocked.example.com:443"] }),
     );
-    assert.equal(result.blocked[0].expected, true);
+    expect(result.blocked[0].expected).toBe(true);
   });
 
   it("populates proxyLogs.builds and proxyLogs.denied", async () => {
     const result = await buildExplicitReportData(deniedLine.split("\n"), builds, params());
-    assert.equal(result.proxyLogs.builds, builds);
-    assert.equal(result.proxyLogs.denied.length, 1);
-    assert.equal(result.proxyLogs.denied[0].url, "https://blocked.example.com/");
+    expect(result.proxyLogs.builds).toBe(builds);
+    expect(result.proxyLogs.denied.length).toBe(1);
+    expect(result.proxyLogs.denied[0].url).toBe("https://blocked.example.com/");
   });
 
   it("uses AUDIT decision for passed when mode is audit", async () => {
     const result = await buildExplicitReportData("".split("\n"), builds, params({ mode: "audit" }));
-    assert.equal(result.passed.length, 1);
+    expect(result.passed.length).toBe(1);
   });
 
   it("returns empty passed/blocked and blockedCount 0 for empty inputs", async () => {
     const result = await buildExplicitReportData("".split("\n"), [], params());
-    assert.deepEqual(result.passed, []);
-    assert.deepEqual(result.blocked, []);
-    assert.equal(result.blockedCount, 0);
-    assert.equal(result.logLooksPlausible, false);
+    expect(result.passed).toStrictEqual([]);
+    expect(result.blocked).toStrictEqual([]);
+    expect(result.blockedCount).toBe(0);
+    expect(result.logLooksPlausible).toBe(false);
   });
 
   it("logLooksPlausible is true for a genuinely quiet run (buildkitd's own startup noise, zero denials)", async () => {
     const log = 'time="2026-01-01T00:00:00Z" level=info msg="found worker" builder=0';
     const result = await buildExplicitReportData(log.split("\n"), [], params());
-    assert.equal(result.blockedCount, 0);
-    assert.equal(result.logLooksPlausible, true);
+    expect(result.blockedCount).toBe(0);
+    expect(result.logLooksPlausible).toBe(true);
   });
 });
 

--- a/core/lib/report/build/transparent.test.ts
+++ b/core/lib/report/build/transparent.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { buildTransparentReportData } from "./transparent.ts";
 import type { GenReportParameters } from "../types.ts";
 
@@ -20,19 +20,19 @@ describe("buildTransparentReportData", () => {
       '[2024-01-01T00:00:00] buildcage [BLOCKED] (HTTP) "bad.com:80" not-allowed',
     ].join("\n");
     const result = await buildTransparentReportData(log.split("\n"), params());
-    assert.equal(result.engine, "transparent");
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].host, "good.com");
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].host, "bad.com");
-    assert.equal(result.blockedCount, 1);
+    expect(result.engine).toBe("transparent");
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].host).toBe("good.com");
+    expect(result.blocked.length).toBe(1);
+    expect(result.blocked[0].host).toBe("bad.com");
+    expect(result.blockedCount).toBe(1);
   });
 
   it("aggregates audited traffic in audit mode instead of allowed", async () => {
     const log = '[2024-01-01T00:00:00] buildcage [AUDIT] (HTTPS) "any.com:443"';
     const result = await buildTransparentReportData(log.split("\n"), params({ mode: "audit" }));
-    assert.equal(result.passed.length, 1);
-    assert.equal(result.passed[0].host, "any.com");
+    expect(result.passed.length).toBe(1);
+    expect(result.passed[0].host).toBe("any.com");
   });
 
   it("annotates blocked rows against knownBlockedRules", async () => {
@@ -42,15 +42,15 @@ describe("buildTransparentReportData", () => {
       log.split("\n"),
       params({ knownBlockedRules: ["noisy.example.com:443"] }),
     );
-    assert.equal(result.blocked[0].expected, true);
+    expect(result.blocked[0].expected).toBe(true);
   });
 
   it("returns empty passed/blocked and blockedCount 0 for empty log text", async () => {
     const result = await buildTransparentReportData("".split("\n"), params());
-    assert.deepEqual(result.passed, []);
-    assert.deepEqual(result.blocked, []);
-    assert.equal(result.blockedCount, 0);
-    assert.equal(result.logLooksPlausible, false);
+    expect(result.passed).toStrictEqual([]);
+    expect(result.blocked).toStrictEqual([]);
+    expect(result.blockedCount).toBe(0);
+    expect(result.logLooksPlausible).toBe(false);
   });
 
   it("logLooksPlausible is true for a genuinely quiet run (HAProxy's own startup noise, zero blocked)", async () => {
@@ -59,8 +59,8 @@ describe("buildTransparentReportData", () => {
       '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "good.com:443" -',
     ].join("\n");
     const result = await buildTransparentReportData(log.split("\n"), params());
-    assert.equal(result.blockedCount, 0);
-    assert.equal(result.logLooksPlausible, true);
+    expect(result.blockedCount).toBe(0);
+    expect(result.logLooksPlausible).toBe(true);
   });
 
   it("blockedCount counts raw events, not aggregated rows", async () => {
@@ -69,9 +69,9 @@ describe("buildTransparentReportData", () => {
       '[2024-01-01T00:00:01] buildcage [BLOCKED] (HTTPS) "bad.com:443" not-allowed',
     ].join("\n");
     const result = await buildTransparentReportData(log.split("\n"), params());
-    assert.equal(result.blockedCount, 2);
-    assert.equal(result.blocked.length, 1);
-    assert.equal(result.blocked[0].count, 2);
+    expect(result.blockedCount).toBe(2);
+    expect(result.blocked.length).toBe(1);
+    expect(result.blocked[0].count).toBe(2);
   });
 });
 

--- a/core/lib/report/outcome/blocked-outcome.test.ts
+++ b/core/lib/report/outcome/blocked-outcome.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import {
   determineBlockedOutcome,
   buildBlockedMessage,
@@ -7,7 +7,7 @@ import {
 
 describe("determineBlockedOutcome", () => {
   it("returns none when there are no blocked connections", () => {
-    assert.deepEqual(
+    expect(
       determineBlockedOutcome({
         isAudit: false,
         failOnBlocked: true,
@@ -15,12 +15,11 @@ describe("determineBlockedOutcome", () => {
         blockedRows: [],
         logLooksPlausible: true,
       }),
-      { level: "none", shouldFail: false },
-    );
+    ).toStrictEqual({ level: "none", shouldFail: false });
   });
 
   it("always returns notice in audit mode, even with unmatched rows", () => {
-    assert.deepEqual(
+    expect(
       determineBlockedOutcome({
         isAudit: true,
         failOnBlocked: true,
@@ -28,12 +27,11 @@ describe("determineBlockedOutcome", () => {
         blockedRows: [{ expected: false }],
         logLooksPlausible: true,
       }),
-      { level: "notice", shouldFail: false },
-    );
+    ).toStrictEqual({ level: "notice", shouldFail: false });
   });
 
   it("returns notice (not error) when every blocked row matched known_blocked_rules", () => {
-    assert.deepEqual(
+    expect(
       determineBlockedOutcome({
         isAudit: false,
         failOnBlocked: true,
@@ -41,12 +39,11 @@ describe("determineBlockedOutcome", () => {
         blockedRows: [{ expected: true }, { expected: true }],
         logLooksPlausible: true,
       }),
-      { level: "notice", shouldFail: false },
-    );
+    ).toStrictEqual({ level: "notice", shouldFail: false });
   });
 
   it("returns error when at least one blocked row is unexpected", () => {
-    assert.deepEqual(
+    expect(
       determineBlockedOutcome({
         isAudit: false,
         failOnBlocked: true,
@@ -54,12 +51,11 @@ describe("determineBlockedOutcome", () => {
         blockedRows: [{ expected: true }, { expected: false }],
         logLooksPlausible: true,
       }),
-      { level: "error", shouldFail: true },
-    );
+    ).toStrictEqual({ level: "error", shouldFail: true });
   });
 
   it("returns notice when failOnBlocked is false, even with unexpected rows", () => {
-    assert.deepEqual(
+    expect(
       determineBlockedOutcome({
         isAudit: false,
         failOnBlocked: false,
@@ -67,12 +63,11 @@ describe("determineBlockedOutcome", () => {
         blockedRows: [{ expected: false }],
         logLooksPlausible: true,
       }),
-      { level: "notice", shouldFail: false },
-    );
+    ).toStrictEqual({ level: "notice", shouldFail: false });
   });
 
   it("fails closed when blockedRows is empty but blockedCount is nonzero", () => {
-    assert.deepEqual(
+    expect(
       determineBlockedOutcome({
         isAudit: false,
         failOnBlocked: true,
@@ -80,13 +75,12 @@ describe("determineBlockedOutcome", () => {
         blockedRows: [],
         logLooksPlausible: true,
       }),
-      { level: "error", shouldFail: true },
-    );
+    ).toStrictEqual({ level: "error", shouldFail: true });
   });
 
   describe("logLooksPlausible: false (log has no trace of a real proxy run)", () => {
     it("fails closed when blockedCount is 0 and failOnBlocked is true", () => {
-      assert.deepEqual(
+      expect(
         determineBlockedOutcome({
           isAudit: false,
           failOnBlocked: true,
@@ -94,12 +88,11 @@ describe("determineBlockedOutcome", () => {
           blockedRows: [],
           logLooksPlausible: false,
         }),
-        { level: "error", shouldFail: true },
-      );
+      ).toStrictEqual({ level: "error", shouldFail: true });
     });
 
     it("returns notice (not error) when blockedCount is 0 and failOnBlocked is false", () => {
-      assert.deepEqual(
+      expect(
         determineBlockedOutcome({
           isAudit: false,
           failOnBlocked: false,
@@ -107,12 +100,11 @@ describe("determineBlockedOutcome", () => {
           blockedRows: [],
           logLooksPlausible: false,
         }),
-        { level: "notice", shouldFail: false },
-      );
+      ).toStrictEqual({ level: "notice", shouldFail: false });
     });
 
     it("never fails in audit mode, even with an implausible log", () => {
-      assert.deepEqual(
+      expect(
         determineBlockedOutcome({
           isAudit: true,
           failOnBlocked: true,
@@ -120,12 +112,11 @@ describe("determineBlockedOutcome", () => {
           blockedRows: [],
           logLooksPlausible: false,
         }),
-        { level: "notice", shouldFail: false },
-      );
+      ).toStrictEqual({ level: "notice", shouldFail: false });
     });
 
     it("has no additional effect when blockedCount is already nonzero", () => {
-      assert.deepEqual(
+      expect(
         determineBlockedOutcome({
           isAudit: false,
           failOnBlocked: true,
@@ -133,8 +124,7 @@ describe("determineBlockedOutcome", () => {
           blockedRows: [{ expected: true }, { expected: true }],
           logLooksPlausible: false,
         }),
-        { level: "notice", shouldFail: false },
-      );
+      ).toStrictEqual({ level: "notice", shouldFail: false });
     });
   });
 });
@@ -147,7 +137,7 @@ describe("buildBlockedMessage", () => {
       engineLabel: "sandbox",
       isAudit: false,
     });
-    assert.equal(message, "2 blocked connection(s) detected by buildcage sandbox");
+    expect(message).toBe("2 blocked connection(s) detected by buildcage sandbox");
   });
 
   it("notes that all rows matched when every row is expected", () => {
@@ -157,7 +147,7 @@ describe("buildBlockedMessage", () => {
       engineLabel: "proxy",
       isAudit: false,
     });
-    assert.match(message, /all matched known_blocked_rules \(expected\)/);
+    expect(message).toMatch(/all matched known_blocked_rules \(expected\)/);
   });
 
   it("reports the unmatched count when some rows are unexpected", () => {
@@ -167,7 +157,7 @@ describe("buildBlockedMessage", () => {
       engineLabel: "sandbox",
       isAudit: false,
     });
-    assert.match(message, /1 of 2 distinct blocked host\(s\) unmatched by known_blocked_rules/);
+    expect(message).toMatch(/1 of 2 distinct blocked host\(s\) unmatched by known_blocked_rules/);
   });
 
   // Audit's outcome never depends on matching (see determineBlockedOutcome),
@@ -182,7 +172,7 @@ describe("buildBlockedMessage", () => {
         engineLabel: "sandbox",
         isAudit: true,
       });
-      assert.equal(message, fixedText);
+      expect(message).toBe(fixedText);
     });
 
     it("stays fixed when some rows are unmatched", () => {
@@ -192,7 +182,7 @@ describe("buildBlockedMessage", () => {
         engineLabel: "sandbox",
         isAudit: true,
       });
-      assert.equal(message, fixedText);
+      expect(message).toBe(fixedText);
     });
 
     it("stays fixed when no rows matched", () => {
@@ -202,7 +192,7 @@ describe("buildBlockedMessage", () => {
         engineLabel: "sandbox",
         isAudit: true,
       });
-      assert.equal(message, fixedText);
+      expect(message).toBe(fixedText);
     });
   });
 });
@@ -217,7 +207,7 @@ describe("describeBlockedOutcome", () => {
       logLooksPlausible: true,
       engineLabel: "proxy",
     });
-    assert.deepEqual(result, {
+    expect(result).toStrictEqual({
       level: "error",
       shouldFail: true,
       message: "1 blocked connection(s) detected by buildcage proxy",
@@ -233,7 +223,7 @@ describe("describeBlockedOutcome", () => {
       logLooksPlausible: true,
       engineLabel: "sandbox",
     });
-    assert.equal(result.level, "none");
+    expect(result.level).toBe("none");
   });
 });
 

--- a/core/lib/report/outcome/emit.test.ts
+++ b/core/lib/report/outcome/emit.test.ts
@@ -1,5 +1,4 @@
-import { describe, it, beforeEach, afterEach, vi } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { emitBlockedOutcome } from "./emit.ts";
 import { annotateKnownBlocked } from "../build/aggregate.ts";
@@ -43,7 +42,7 @@ function report(overrides: Partial<ReportDataCommon> = {}): ReportDataCommon {
 describe("emitBlockedOutcome", () => {
   it("leaves exitCode untouched when there are no blocked connections", () => {
     emitBlockedOutcome(report(), { failOnBlocked: true, summaryFile: undefined });
-    assert.equal(process.exitCode, undefined);
+    expect(process.exitCode).toBe(undefined);
   });
 
   it("sets exitCode=1 when an unexpected blocked connection is found and failOnBlocked is true", () => {
@@ -63,7 +62,7 @@ describe("emitBlockedOutcome", () => {
       ),
     });
     emitBlockedOutcome(r, { failOnBlocked: true, summaryFile: undefined });
-    assert.equal(process.exitCode, 1);
+    expect(process.exitCode).toBe(1);
   });
 
   it("emits ::notice:: (not ::error::) when console output is enabled and outcome level is notice", () => {
@@ -91,8 +90,8 @@ describe("emitBlockedOutcome", () => {
     const errors = log.mock.calls
       .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::error::"));
-    assert.equal(notices.length, 1);
-    assert.equal(errors.length, 0);
+    expect(notices.length).toBe(1);
+    expect(errors.length).toBe(0);
   });
 
   it("emits ::error:: when console output is enabled and outcome level is error", () => {
@@ -116,7 +115,7 @@ describe("emitBlockedOutcome", () => {
     const errors = log.mock.calls
       .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::error::"));
-    assert.equal(errors.length, 1);
+    expect(errors.length).toBe(1);
   });
 
   it("suppresses annotation output when summaryFile is undefined (not running as the real action)", () => {
@@ -140,6 +139,6 @@ describe("emitBlockedOutcome", () => {
     const annotations = log.mock.calls
       .map((c) => c[0] as string)
       .filter((s) => s.startsWith("::notice::") || s.startsWith("::error::"));
-    assert.equal(annotations.length, 0);
+    expect(annotations.length).toBe(0);
   });
 });

--- a/core/lib/report/parameters.test.ts
+++ b/core/lib/report/parameters.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, assert, reportResults } from "../test/test-shim.ts";
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
 import { buildReportParameters } from "./parameters.ts";
 
 describe("buildReportParameters", () => {
   it("tokenizes each rules field and passes mode through", () => {
-    assert.deepEqual(
+    expect(
       buildReportParameters({
         PROXY_MODE: "restrict",
         ALLOWED_HTTPS_RULES: "a.com:443 b.com:443",
@@ -11,26 +11,25 @@ describe("buildReportParameters", () => {
         ALLOWED_IP_RULES: "",
         KNOWN_BLOCKED_RULES: "noisy.example.com:443",
       }),
-      {
-        mode: "restrict",
-        allowedHttpsRules: ["a.com:443", "b.com:443"],
-        allowedHttpRules: ["c.com:80"],
-        allowedIpRules: [],
-        knownBlockedRules: ["noisy.example.com:443"],
-      },
-    );
+    ).toStrictEqual({
+      mode: "restrict",
+      allowedHttpsRules: ["a.com:443", "b.com:443"],
+      allowedHttpRules: ["c.com:80"],
+      allowedIpRules: [],
+      knownBlockedRules: ["noisy.example.com:443"],
+    });
   });
 
   it('defaults mode to "restrict" when unset', () => {
-    assert.equal(buildReportParameters({}).mode, "restrict");
+    expect(buildReportParameters({}).mode).toBe("restrict");
   });
 
   it("returns empty arrays for unset rules fields", () => {
     const params = buildReportParameters({ PROXY_MODE: "audit" });
-    assert.deepEqual(params.allowedHttpsRules, []);
-    assert.deepEqual(params.allowedHttpRules, []);
-    assert.deepEqual(params.allowedIpRules, []);
-    assert.deepEqual(params.knownBlockedRules, []);
+    expect(params.allowedHttpsRules).toStrictEqual([]);
+    expect(params.allowedHttpRules).toStrictEqual([]);
+    expect(params.allowedIpRules).toStrictEqual([]);
+    expect(params.knownBlockedRules).toStrictEqual([]);
   });
 });
 

--- a/core/lib/report/render/build-example.test.ts
+++ b/core/lib/report/render/build-example.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { buildRestrictExample } from "./build-example.ts";
 
 const REPO = "dash14/buildcage";
@@ -17,12 +17,12 @@ function wrap(yaml: string) {
 
 describe("buildRestrictExample", () => {
   it("empty array → empty string", () => {
-    assert.equal(buildRestrictExample([], REPO), "");
+    expect(buildRestrictExample([], REPO)).toBe("");
   });
 
   it("null/undefined → empty string", () => {
-    assert.equal(buildRestrictExample(null, REPO), "");
-    assert.equal(buildRestrictExample(undefined, REPO), "");
+    expect(buildRestrictExample(null, REPO)).toBe("");
+    expect(buildRestrictExample(undefined, REPO)).toBe("");
   });
 
   it("HTTPS only entries", () => {
@@ -30,8 +30,7 @@ describe("buildRestrictExample", () => {
       { host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 5 },
       { host: "github.com", port: "443", ruleType: "HTTPS", count: 2 },
     ];
-    assert.equal(
-      buildRestrictExample(rows, REPO, REF),
+    expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -51,8 +50,7 @@ describe("buildRestrictExample", () => {
       { host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 3 },
       { host: "deb.debian.org", port: "80", ruleType: "HTTP", count: 1 },
     ];
-    assert.equal(
-      buildRestrictExample(rows, REPO, REF),
+    expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -70,8 +68,7 @@ describe("buildRestrictExample", () => {
 
   it("IP entries", () => {
     const rows = [{ host: "192.168.1.1", port: "443", ruleType: "IP", count: 1 }];
-    assert.equal(
-      buildRestrictExample(rows, REPO, REF),
+    expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -91,8 +88,7 @@ describe("buildRestrictExample", () => {
       { host: "example.com", port: "80", ruleType: "HTTP", count: 1 },
       { host: "10.0.0.1", port: "8080", ruleType: "IP", count: 1 },
     ];
-    assert.equal(
-      buildRestrictExample(rows, REPO, REF),
+    expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -112,8 +108,7 @@ describe("buildRestrictExample", () => {
 
   it("uses custom actionRepo", () => {
     const rows = [{ host: "example.com", port: "443", ruleType: "HTTPS", count: 1 }];
-    assert.equal(
-      buildRestrictExample(rows, "myorg/myrepo", REF),
+    expect(buildRestrictExample(rows, "myorg/myrepo", REF)).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -129,8 +124,7 @@ describe("buildRestrictExample", () => {
 
   it("renders a tag actionRef as-is", () => {
     const rows = [{ host: "example.com", port: "443", ruleType: "HTTPS", count: 1 }];
-    assert.equal(
-      buildRestrictExample(rows, REPO, "v2.1.0"),
+    expect(buildRestrictExample(rows, REPO, "v2.1.0")).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -147,8 +141,7 @@ describe("buildRestrictExample", () => {
   it("renders a commit SHA actionRef as a <sha> placeholder", () => {
     const rows = [{ host: "example.com", port: "443", ruleType: "HTTPS", count: 1 }];
     const sha = "abc1234567890def1234567890abcdef12345678";
-    assert.equal(
-      buildRestrictExample(rows, REPO, sha),
+    expect(buildRestrictExample(rows, REPO, sha)).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -164,8 +157,9 @@ describe("buildRestrictExample", () => {
 
   it("uses the run action and includes the run command when actionName is 'run'", () => {
     const rows = [{ host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 5 }];
-    assert.equal(
+    expect(
       buildRestrictExample(rows, REPO, REF, { actionName: "run", runCommand: "npm install" }),
+    ).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -183,8 +177,9 @@ describe("buildRestrictExample", () => {
 
   it("preserves multi-line run commands, indented under run: |", () => {
     const rows = [{ host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 1 }];
-    assert.equal(
+    expect(
       buildRestrictExample(rows, REPO, REF, { actionName: "run", runCommand: "npm ci\nnpm test" }),
+    ).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -203,11 +198,12 @@ describe("buildRestrictExample", () => {
 
   it("strips the trailing newline GitHub Actions adds to `run: |` block scalars", () => {
     const rows = [{ host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 1 }];
-    assert.equal(
+    expect(
       buildRestrictExample(rows, REPO, REF, {
         actionName: "run",
         runCommand: "npm ci\nnpm test\n",
       }),
+    ).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",
@@ -226,8 +222,7 @@ describe("buildRestrictExample", () => {
 
   it("actionName 'run' without a runCommand omits the run: block", () => {
     const rows = [{ host: "registry.npmjs.org", port: "443", ruleType: "HTTPS", count: 1 }];
-    assert.equal(
-      buildRestrictExample(rows, REPO, REF, { actionName: "run" }),
+    expect(buildRestrictExample(rows, REPO, REF, { actionName: "run" })).toBe(
       wrap(
         [
           "- name: Start Buildcage in restrict mode",

--- a/core/lib/report/render/communication-details.test.ts
+++ b/core/lib/report/render/communication-details.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { renderCommunicationDetails } from "./communication-details.ts";
 
 function wrap(body: string) {
@@ -41,24 +41,24 @@ const ALLOWED_B =
 
 describe("renderCommunicationDetails", () => {
   it("empty arrays → empty string", () => {
-    assert.equal(renderCommunicationDetails([], []), "");
+    expect(renderCommunicationDetails([], [])).toBe("");
   });
 
   it("null/undefined → empty string", () => {
-    assert.equal(renderCommunicationDetails(null, null), "");
-    assert.equal(renderCommunicationDetails(undefined, undefined), "");
+    expect(renderCommunicationDetails(null, null)).toBe("");
+    expect(renderCommunicationDetails(undefined, undefined)).toBe("");
   });
 
   it("a build containing only an all-empty vertex list is treated as no builds", () => {
-    assert.equal(renderCommunicationDetails([[]], []), "");
+    expect(renderCommunicationDetails([[]], [])).toBe("");
   });
 
   it("a vertex with no entries renders '(no communication)'", () => {
-    assert.equal(renderCommunicationDetails([[VERTEX_A]], []), wrap(ALLOWED_A));
+    expect(renderCommunicationDetails([[VERTEX_A]], [])).toBe(wrap(ALLOWED_A));
   });
 
   it("a vertex with an allowed entry renders the request line in a code block", () => {
-    assert.equal(renderCommunicationDetails([[VERTEX_B]], []), wrap(ALLOWED_B));
+    expect(renderCommunicationDetails([[VERTEX_B]], [])).toBe(wrap(ALLOWED_B));
   });
 
   it("an entry with no status omits the arrow", () => {
@@ -66,17 +66,15 @@ describe("renderCommunicationDetails", () => {
       ...VERTEX_B,
       entries: [{ method: "GET", url: "https://allowed.example.com/" }],
     };
-    assert.match(
-      renderCommunicationDetails([[vertex]], []),
+    expect(renderCommunicationDetails([[vertex]], [])).toMatch(
       /- GET https:\/\/allowed\.example\.com\/\n/,
     );
   });
 
   it("renders multiple vertices within one build under one 'Allowed Urls' item, no build item", () => {
     const md = renderCommunicationDetails([[VERTEX_A, VERTEX_B]], []);
-    assert.equal(md.includes("Build"), false);
-    assert.equal(
-      md,
+    expect(md.includes("Build")).toBe(false);
+    expect(md).toBe(
       wrap(
         "* **✅ Allowed Urls**\n\n" +
           "   * RUN echo no-network-here && mkdir -p /tmp/work\n\n" +
@@ -95,21 +93,20 @@ describe("renderCommunicationDetails", () => {
 
   it("adds a 'Build N' item per build, one level deeper, only when there is more than one build", () => {
     const md = renderCommunicationDetails([[VERTEX_A], [VERTEX_B]], []);
-    assert.equal(md.includes("   * Build 1\n\n      * RUN echo no-network-here"), true);
-    assert.equal(md.includes("   * Build 2\n\n      * RUN echo step-A"), true);
+    expect(md.includes("   * Build 1\n\n      * RUN echo no-network-here")).toBe(true);
+    expect(md.includes("   * Build 2\n\n      * RUN echo step-A")).toBe(true);
   });
 
   it("skips empty builds when deciding whether to show build items (only 1 non-empty build)", () => {
     const md = renderCommunicationDetails([[], [VERTEX_A], []], []);
-    assert.equal(md.includes("Build"), false);
+    expect(md.includes("Build")).toBe(false);
   });
 
   it("renders the Blocked Urls section with whole-second timestamps, no vertex attribution", () => {
     const deniedTimeline = [
       { url: "https://blocked.example.com/", timestamp: "2026-07-05T22:08:41Z" },
     ];
-    assert.equal(
-      renderCommunicationDetails([], deniedTimeline),
+    expect(renderCommunicationDetails([], deniedTimeline)).toBe(
       wrap("* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/\n\n"),
     );
   });
@@ -119,8 +116,7 @@ describe("renderCommunicationDetails", () => {
       { url: "https://blocked.example.com/a", timestamp: "2026-07-05T22:08:41Z" },
       { url: "https://blocked.example.com/b", timestamp: "2026-07-05T22:08:42Z" },
     ];
-    assert.equal(
-      renderCommunicationDetails([], deniedTimeline),
+    expect(renderCommunicationDetails([], deniedTimeline)).toBe(
       wrap(
         "* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/a\n   - (22:08:42Z) https://blocked.example.com/b\n\n",
       ),
@@ -131,8 +127,7 @@ describe("renderCommunicationDetails", () => {
     const deniedTimeline = [
       { url: "https://blocked.example.com/", timestamp: "2026-07-05T22:08:41Z" },
     ];
-    assert.equal(
-      renderCommunicationDetails([[VERTEX_B]], deniedTimeline),
+    expect(renderCommunicationDetails([[VERTEX_B]], deniedTimeline)).toBe(
       wrap(
         ALLOWED_B + "* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/\n\n",
       ),
@@ -143,14 +138,13 @@ describe("renderCommunicationDetails", () => {
     const deniedTimeline = [
       { url: "https://blocked.example.com/", timestamp: "2026-07-05T22:08:41Z" },
     ];
-    assert.equal(
-      renderCommunicationDetails([], deniedTimeline),
+    expect(renderCommunicationDetails([], deniedTimeline)).toBe(
       wrap("* **🚫 Blocked Urls**\n\n   - (22:08:41Z) https://blocked.example.com/\n\n"),
     );
   });
 
   it("renders only Allowed Urls when deniedTimeline is empty but builds is not", () => {
-    assert.equal(renderCommunicationDetails([[VERTEX_B]], []), wrap(ALLOWED_B));
+    expect(renderCommunicationDetails([[VERTEX_B]], [])).toBe(wrap(ALLOWED_B));
   });
 
   describe("markdown escaping", () => {
@@ -161,19 +155,19 @@ describe("renderCommunicationDetails", () => {
         entries: [],
       };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /\* \\\[2\/2\\\] RUN echo "=== \\\[HTTPS - allowed\\\] ==="\n/);
+      expect(md).toMatch(/\* \\\[2\/2\\\] RUN echo "=== \\\[HTTPS - allowed\\\] ==="\n/);
     });
 
     it("escapes '*' and '_' in a command so they can't be misread as emphasis", () => {
       const vertex = { ...VERTEX_A, command: "RUN echo *hi* && echo _bye_", entries: [] };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /\* RUN echo \\\*hi\\\* && echo \\_bye\\_\n/);
+      expect(md).toMatch(/\* RUN echo \\\*hi\\\* && echo \\_bye\\_\n/);
     });
 
     it("escapes backticks and backslashes in a command", () => {
       const vertex = { ...VERTEX_A, command: "RUN echo `whoami` && echo C:\\\\path", entries: [] };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /echo \\`whoami\\` && echo C:\\\\\\\\path/);
+      expect(md).toMatch(/echo \\`whoami\\` && echo C:\\\\\\\\path/);
     });
 
     it("escapes special characters in an allowed request's URL inside the code block", () => {
@@ -182,7 +176,7 @@ describe("renderCommunicationDetails", () => {
         entries: [{ method: "GET", url: "https://allowed.example.com/[id]", status: 200 }],
       };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /- GET https:\/\/allowed\.example\.com\/\\\[id\\\] -> 200/);
+      expect(md).toMatch(/- GET https:\/\/allowed\.example\.com\/\\\[id\\\] -> 200/);
     });
 
     it("escapes special characters in a denied URL", () => {
@@ -190,13 +184,13 @@ describe("renderCommunicationDetails", () => {
         { url: "https://blocked.example.com/[id]", timestamp: "2026-07-05T22:08:41Z" },
       ];
       const md = renderCommunicationDetails([], deniedTimeline);
-      assert.match(md, /- \(22:08:41Z\) https:\/\/blocked\.example\.com\/\\\[id\\\]/);
+      expect(md).toMatch(/- \(22:08:41Z\) https:\/\/blocked\.example\.com\/\\\[id\\\]/);
     });
 
     it("does not escape '.' or '-', which are common and harmless in URLs/commands", () => {
       const vertex = { ...VERTEX_A, command: "RUN echo hello-world.txt", entries: [] };
       const md = renderCommunicationDetails([[vertex]], []);
-      assert.match(md, /\* RUN echo hello-world\.txt\n/);
+      expect(md).toMatch(/\* RUN echo hello-world\.txt\n/);
     });
   });
 });

--- a/core/lib/report/render/host-table.test.ts
+++ b/core/lib/report/render/host-table.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { renderHostTable } from "./host-table.ts";
 
 describe("renderHostTable", () => {
@@ -13,27 +13,26 @@ describe("renderHostTable", () => {
 
   it("renders a default 3-column table (Host, Rule, Count)", () => {
     const table = renderHostTable([row()]);
-    assert.equal(
-      table,
+    expect(table).toBe(
       "| Host | Rule | Count |\n| --- | --- | ---: |\n| example.com:443 | HTTPS | 2 |",
     );
   });
 
   it("adds a Reason column when showReason is true", () => {
     const table = renderHostTable([row()], { showReason: true });
-    assert.match(table, /^\| Host \| Rule \| Reason \| Count \|/);
-    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \|/);
+    expect(table).toMatch(/^\| Host \| Rule \| Reason \| Count \|/);
+    expect(table).toMatch(/\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \|/);
   });
 
   it("adds an Expected column with a checkmark when showExpected is true and the row matched", () => {
     const table = renderHostTable([row({ expected: true })], { showExpected: true });
-    assert.match(table, /^\| Host \| Rule \| Count \| Expected \|/);
-    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| ✅ \|/);
+    expect(table).toMatch(/^\| Host \| Rule \| Count \| Expected \|/);
+    expect(table).toMatch(/\| example\.com:443 \| HTTPS \| 2 \| ✅ \|/);
   });
 
   it("leaves the Expected cell blank when the row did not match", () => {
     const table = renderHostTable([row({ expected: false })], { showExpected: true });
-    assert.match(table, /\| example\.com:443 \| HTTPS \| 2 \| {2}\|/);
+    expect(table).toMatch(/\| example\.com:443 \| HTTPS \| 2 \| {2}\|/);
   });
 
   it("renders all 5 columns when both showReason and showExpected are true", () => {
@@ -41,13 +40,13 @@ describe("renderHostTable", () => {
       showReason: true,
       showExpected: true,
     });
-    assert.match(table, /^\| Host \| Rule \| Reason \| Count \| Expected \|/);
-    assert.match(table, /\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \| ✅ \|/);
+    expect(table).toMatch(/^\| Host \| Rule \| Reason \| Count \| Expected \|/);
+    expect(table).toMatch(/\| example\.com:443 \| HTTPS \| not in allowlist \| 2 \| ✅ \|/);
   });
 
   it("renders only the header rows for an empty list", () => {
     const table = renderHostTable([]);
-    assert.equal(table, "| Host | Rule | Count |\n| --- | --- | ---: |");
+    expect(table).toBe("| Host | Rule | Count |\n| --- | --- | ---: |");
   });
 });
 

--- a/core/lib/report/render/markdown-table.test.ts
+++ b/core/lib/report/render/markdown-table.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { markdownTable } from "./markdown-table.ts";
 
 describe("markdownTable", () => {
@@ -11,7 +10,7 @@ describe("markdownTable", () => {
       ],
       [{ a: "1", b: "2" }],
     );
-    assert.equal(table, "| A | B |\n| --- | --- |\n| 1 | 2 |");
+    expect(table).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
   });
 
   it("supports right and center alignment per column", () => {
@@ -23,11 +22,11 @@ describe("markdownTable", () => {
       ],
       [{ a: 1, b: 2, c: 3 }],
     );
-    assert.equal(table, "| A | B | C |\n| ---: | :---: | --- |\n| 1 | 2 | 3 |");
+    expect(table).toBe("| A | B | C |\n| ---: | :---: | --- |\n| 1 | 2 | 3 |");
   });
 
   it("renders only the header rows for an empty row list", () => {
     const table = markdownTable([{ key: "a", title: "A" }], []);
-    assert.equal(table, "| A |\n| --- |");
+    expect(table).toBe("| A |\n| --- |");
   });
 });

--- a/core/lib/report/render/render-report-markdown.test.ts
+++ b/core/lib/report/render/render-report-markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, reportResults } from "#core/lib/test/test-shim.ts";
+import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
 import { renderReportMarkdown } from "./render-report-markdown.ts";
 import type { GenReportParameters, TransparentReportData, ExplicitReportData } from "../types.ts";
 
@@ -25,7 +25,7 @@ const blockedRow = {
 
 // test-shim's Assert interface has no doesNotMatch.
 function assertNotMatch(value: string, pattern: RegExp): void {
-  assert.equal(pattern.test(value), false);
+  expect(pattern.test(value)).toBe(false);
 }
 
 describe("renderReportMarkdown — transparent", () => {
@@ -42,9 +42,9 @@ describe("renderReportMarkdown — transparent", () => {
     const md = renderReportMarkdown({ ...base, passed: [allowedRow] }, "dash14/buildcage", "v2", {
       title: "Outbound Traffic Report during Docker Build",
     });
-    assert.match(md, /## Outbound Traffic Report during Docker Build \(restrict mode\)/);
-    assert.match(md, /### ✅ Allowed Hosts/);
-    assert.match(md, /good\.com/);
+    expect(md).toMatch(/## Outbound Traffic Report during Docker Build \(restrict mode\)/);
+    expect(md).toMatch(/### ✅ Allowed Hosts/);
+    expect(md).toMatch(/good\.com/);
   });
 
   it("renders the audit-mode heading and Audited Hosts table, plus a restrict-mode example", () => {
@@ -53,8 +53,8 @@ describe("renderReportMarkdown — transparent", () => {
       "dash14/buildcage",
       "v2",
     );
-    assert.match(md, /### 📋 Audited Hosts/);
-    assert.match(md, /Switch to restrict mode/);
+    expect(md).toMatch(/### 📋 Audited Hosts/);
+    expect(md).toMatch(/Switch to restrict mode/);
   });
 
   it("renders Blocked Hosts and shows the SNI footnote, not Communication details", () => {
@@ -63,14 +63,14 @@ describe("renderReportMarkdown — transparent", () => {
       "dash14/buildcage",
       "v2",
     );
-    assert.match(md, /### 🚫 Blocked Hosts/);
-    assert.match(md, /based on the Host header/);
+    expect(md).toMatch(/### 🚫 Blocked Hosts/);
+    expect(md).toMatch(/based on the Host header/);
     assertNotMatch(md, /Communication details/);
   });
 
   it("uses the real actionRepo in the footer, not a placeholder", () => {
     const md = renderReportMarkdown(base, "dash14/buildcage", "v2");
-    assert.match(md, /Reported by \[Buildcage\]\(https:\/\/github\.com\/dash14\/buildcage\)/);
+    expect(md).toMatch(/Reported by \[Buildcage\]\(https:\/\/github\.com\/dash14\/buildcage\)/);
     assertNotMatch(md, /GITHUB_ACTION_REPOSITORY/);
   });
 
@@ -81,7 +81,7 @@ describe("renderReportMarkdown — transparent", () => {
 
   it("shows a '(no communication)' note when nothing passed and nothing blocked", () => {
     const md = renderReportMarkdown(base, "dash14/buildcage", "v2");
-    assert.match(md, /_\(no communication\)_/);
+    expect(md).toMatch(/_\(no communication\)_/);
   });
 
   it("omits the '(no communication)' note once anything passed or was blocked", () => {
@@ -104,7 +104,7 @@ describe("renderReportMarkdown — transparent", () => {
     const md = renderReportMarkdown(base, "dash14/buildcage", "v2", {
       title: "Outbound Traffic Report — npm install",
     });
-    assert.match(md, /^## Outbound Traffic Report — npm install \(restrict mode\)/);
+    expect(md).toMatch(/^## Outbound Traffic Report — npm install \(restrict mode\)/);
   });
 
   it("shows a run-flavored restrict-mode example including the run: command", () => {
@@ -114,8 +114,8 @@ describe("renderReportMarkdown — transparent", () => {
       "v2",
       { actionName: "run", runCommand: "npm install" },
     );
-    assert.match(md, /uses: dash14\/buildcage\/run@v2/);
-    assert.match(md, /run: \|\n\s+npm install/);
+    expect(md).toMatch(/uses: dash14\/buildcage\/run@v2/);
+    expect(md).toMatch(/run: \|\n\s+npm install/);
   });
 
   it("adds an Expected column marking known_blocked_rules matches when set", () => {
@@ -124,7 +124,7 @@ describe("renderReportMarkdown — transparent", () => {
       "dash14/buildcage",
       "v2",
     );
-    assert.match(md, /\| Host \| Rule \| Reason \| Count \| Expected \|/);
+    expect(md).toMatch(/\| Host \| Rule \| Reason \| Count \| Expected \|/);
   });
 
   it("omits the Expected column when known_blocked_rules is not set", () => {
@@ -158,9 +158,9 @@ describe("renderReportMarkdown — explicit", () => {
 
   it("renders Communication details instead of the SNI footnote", () => {
     const md = renderReportMarkdown(base, "dash14/buildcage", "v2");
-    assert.match(md, /Communication details/);
-    assert.match(md, /Allowed Urls/);
-    assert.match(md, /Blocked Urls/);
+    expect(md).toMatch(/Communication details/);
+    expect(md).toMatch(/Allowed Urls/);
+    expect(md).toMatch(/Blocked Urls/);
     assertNotMatch(md, /based on the Host header/);
   });
 });

--- a/core/lib/test/test-shim.ts
+++ b/core/lib/test/test-shim.ts
@@ -2,28 +2,18 @@
  * Test shim, portable between Node (delegates to vitest) and QuickJS (its
  * own minimal implementation). The same *.test.ts source runs under both.
  *
- * `vitest`/`node:assert/strict`/`qjs:std` are dynamic-imported via non-literal
- * variables so tsc doesn't resolve the other runtime's types. `chai`/
- * `@vitest/expect` are portable, so they're static imports instead — that's
- * also required for bundling, since qjs can't resolve a bare specifier left
- * un-inlined by a dynamic import. The polyfill import must come first: ES
- * modules evaluate static imports before their own body runs.
+ * `vitest`/`qjs:std` are dynamic-imported via non-literal variables so tsc
+ * doesn't resolve the other runtime's types. `chai`/`@vitest/expect` are
+ * portable, so they're static imports instead — that's also required for
+ * bundling, since qjs can't resolve a bare specifier left un-inlined by a
+ * dynamic import. The polyfill import must come first: ES modules evaluate
+ * static imports before their own body runs.
  */
 import "./qjs-event-polyfill.ts";
 import * as chai from "chai";
 import { JestChaiExpect } from "@vitest/expect";
 
 const isNode = typeof (globalThis as { process?: unknown }).process !== "undefined";
-
-interface Assert {
-  equal(actual: unknown, expected: unknown): void;
-  deepEqual(actual: unknown, expected: unknown): void;
-  ok(value: unknown): void;
-  throws(fn: () => void, pattern?: RegExp): void;
-  match(value: string, pattern: RegExp): void;
-  /** Node-only in practice; the QuickJS shim implements it just to satisfy this type. */
-  rejects(promise: Promise<unknown>, matcher?: (e: unknown) => boolean): Promise<void>;
-}
 
 /** Deliberately narrow subset of vitest's real `expect()` chain — only the
  *  matchers this codebase's tests actually use. */
@@ -32,24 +22,35 @@ interface ExpectMatchers {
   toStrictEqual(expected: unknown): void;
   toBeTruthy(): void;
   toThrow(pattern?: RegExp | string): void;
+  toMatch(pattern: RegExp | string): void;
+  toSatisfy(predicate: (value: unknown) => boolean): void;
+  not: ExpectMatchers;
+  rejects: AsyncExpectMatchers;
+}
+
+/** `expect(promise).rejects.toX(...)` — same matchers, each resolving once the promise settles. */
+interface AsyncExpectMatchers {
+  toBe(expected: unknown): Promise<void>;
+  toStrictEqual(expected: unknown): Promise<void>;
+  toBeTruthy(): Promise<void>;
+  toThrow(pattern?: RegExp | string): Promise<void>;
+  toMatch(pattern: RegExp | string): Promise<void>;
+  toSatisfy(predicate: (value: unknown) => boolean): Promise<void>;
 }
 type Expect = (actual: unknown) => ExpectMatchers;
 
 interface Shim {
   describe(this: void, name: string, fn: () => void): void;
   it(this: void, name: string, fn: () => void): void;
-  assert: Assert;
   expect: Expect;
   reportResults(this: void): void;
 }
 
 async function createNodeShim(): Promise<Shim> {
   const testRunnerSpecifier = "vitest";
-  const nodeAssertSpecifier = "node:assert/strict";
   const { describe, it, expect } = await import(testRunnerSpecifier);
-  const { default: assert } = await import(nodeAssertSpecifier);
   // vitest tracks pass/fail and sets the process exit code itself.
-  return { describe, it, assert, expect, reportResults() {} };
+  return { describe, it, expect, reportResults() {} };
 }
 
 async function createQjsShim(): Promise<Shim> {
@@ -80,53 +81,6 @@ async function createQjsShim(): Promise<Shim> {
     }
   }
 
-  const assert: Assert = {
-    equal(actual, expected) {
-      if (actual !== expected) {
-        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
-      }
-    },
-    deepEqual(actual, expected) {
-      const a = JSON.stringify(actual);
-      const b = JSON.stringify(expected);
-      if (a !== b) {
-        throw new Error(`Expected ${b}, got ${a}`);
-      }
-    },
-    ok(value) {
-      if (!value) {
-        throw new Error(`Expected truthy value, got ${JSON.stringify(value)}`);
-      }
-    },
-    throws(fn, pattern) {
-      try {
-        fn();
-        throw new Error("Expected function to throw");
-      } catch (e) {
-        if ((e as Error).message === "Expected function to throw") throw e;
-        if (pattern && !pattern.test((e as Error).message)) {
-          throw new Error(`Expected error matching ${pattern}, got "${(e as Error).message}"`);
-        }
-      }
-    },
-    match(value, pattern) {
-      if (!pattern.test(value)) {
-        throw new Error(`Expected "${value}" to match ${pattern}`);
-      }
-    },
-    async rejects(promise, matcher) {
-      try {
-        await promise;
-      } catch (e) {
-        if (matcher && !matcher(e)) {
-          throw new Error("Rejection did not match the expected condition");
-        }
-        return;
-      }
-      throw new Error("Expected promise to reject");
-    },
-  };
-
   function reportResults(): void {
     std.out.puts(`\n${passed + failed} tests: ${passed} passed, ${failed} failed\n`);
     const hadFailures = failed > 0;
@@ -137,9 +91,9 @@ async function createQjsShim(): Promise<Shim> {
     if (hadFailures) std.exit(1);
   }
 
-  return { describe, it, assert, expect, reportResults };
+  return { describe, it, expect, reportResults };
 }
 
 const shim = isNode ? await createNodeShim() : await createQjsShim();
 
-export const { describe, it, assert, expect, reportResults } = shim;
+export const { describe, it, expect, reportResults } = shim;

--- a/rolldown.scripts.config.js
+++ b/rolldown.scripts.config.js
@@ -59,7 +59,12 @@ export default defineConfig(
   target === "qjs-test"
     ? qjsTestInputs.map((input) => ({
         input,
-        external: ["qjs:std", "qjs:os"],
+        // "vitest" is only ever reached by test-shim.ts's Node branch (dead at
+        // qjs runtime), but its dynamic import()'s specifier is a compile-time
+        // constant, so rolldown resolves and inlines it unless excluded here —
+        // dragging in vitest's own devDependencies (e.g. expect-type), which
+        // aren't installed for/resolvable under qjs's "neutral" platform.
+        external: ["qjs:std", "qjs:os", "vitest"],
         platform: "neutral",
         output: { file: `dist/test-qjs/${input.replace(/\.ts$/, ".js")}`, ...baseOutput },
       }))

--- a/run/src/lib/container.test.ts
+++ b/run/src/lib/container.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { generateContainerName, getContainerPid, isContainerNotFoundError } from "./container.ts";
 import { deriveProjectName } from "#core/lib/docker/compose-project-name.ts";
@@ -7,12 +6,12 @@ import { SandboxError } from "./errors.ts";
 
 describe("generateContainerName", () => {
   it("always starts with the buildcage-proxy- prefix", () => {
-    assert.match(generateContainerName(), /^buildcage-proxy-[0-9a-f]{8}$/);
+    expect(generateContainerName()).toMatch(/^buildcage-proxy-[0-9a-f]{8}$/);
   });
 
   it("produces distinct names across calls", () => {
     const names = new Set(Array.from({ length: 20 }, () => generateContainerName()));
-    assert.equal(names.size, 20);
+    expect(names.size).toBe(20);
   });
 });
 
@@ -21,56 +20,56 @@ describe("getContainerPid", () => {
     const fakeExec = () => {
       throw { stderr: "error: no such object: buildcage-proxy-xyz" };
     };
-    assert.equal(getContainerPid("buildcage-proxy-xyz", { exec: fakeExec }), null);
+    expect(getContainerPid("buildcage-proxy-xyz", { exec: fakeExec })).toBe(null);
   });
 
   it("parses the PID from a successful docker inspect", () => {
     const fakeExec = () => "12345\n";
-    assert.equal(getContainerPid("buildcage-proxy-abc", { exec: fakeExec }), 12345);
+    expect(getContainerPid("buildcage-proxy-abc", { exec: fakeExec })).toBe(12345);
   });
 
   it("returns null when docker inspect prints a non-numeric/empty PID", () => {
     const fakeExec = () => "\n";
-    assert.equal(getContainerPid("buildcage-proxy-abc", { exec: fakeExec }), null);
+    expect(getContainerPid("buildcage-proxy-abc", { exec: fakeExec })).toBe(null);
   });
 
   it("throws SandboxError with DOCKER_UNAVAILABLE when docker is unreachable", () => {
     const fakeExec = () => {
       throw { stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock" };
     };
-    assert.throws(
-      () => getContainerPid("buildcage-proxy-abc", { exec: fakeExec }),
-      (err) => err instanceof SandboxError && err.code === "DOCKER_UNAVAILABLE",
-    );
+    expect.assertions(2);
+    try {
+      getContainerPid("buildcage-proxy-abc", { exec: fakeExec });
+    } catch (err) {
+      expect(err).toBeInstanceOf(SandboxError);
+      expect((err as SandboxError).code).toBe("DOCKER_UNAVAILABLE");
+    }
   });
 });
 
 describe("isContainerNotFoundError", () => {
   it("recognizes docker's 'no such object' wording", () => {
-    assert.equal(
-      isContainerNotFoundError({ stderr: "error: no such object: buildcage-proxy-xyz" }),
+    expect(isContainerNotFoundError({ stderr: "error: no such object: buildcage-proxy-xyz" })).toBe(
       true,
     );
   });
 
   it("recognizes docker's 'no such container' wording", () => {
-    assert.equal(
+    expect(
       isContainerNotFoundError({ stderr: "Error: No such container: buildcage-proxy-xyz" }),
-      true,
-    );
+    ).toBe(true);
   });
 
   it("does not misclassify a daemon-unreachable failure", () => {
-    assert.equal(
+    expect(
       isContainerNotFoundError({
         stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
       }),
-      false,
-    );
+    ).toBe(false);
   });
 
   it("does not misclassify an ENOENT (docker not on PATH)", () => {
-    assert.equal(isContainerNotFoundError({ code: "ENOENT" }), false);
+    expect(isContainerNotFoundError({ code: "ENOENT" })).toBe(false);
   });
 });
 
@@ -80,7 +79,7 @@ describe("deriveProjectName", () => {
   it("matches docker compose's project-name character constraints for any generated container name", () => {
     for (let i = 0; i < 20; i++) {
       const projectName = deriveProjectName(generateContainerName());
-      assert.match(projectName, /^[a-z0-9][a-z0-9_-]*$/);
+      expect(projectName).toMatch(/^[a-z0-9][a-z0-9_-]*$/);
     }
   });
 });

--- a/run/src/lib/report.test.ts
+++ b/run/src/lib/report.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { computeReportOutcome, type Report, type ComputeReportOutcomeOptions } from "./report.ts";
 import { annotateKnownBlocked } from "#core/lib/report/build/aggregate.ts";
@@ -47,7 +46,7 @@ function report(overrides: Partial<Report> = {}): Report {
 describe("computeReportOutcome", () => {
   it("does not fail when there are no blocked connections", () => {
     const r = report({ blockedCount: 0 });
-    assert.equal(computeReportOutcome(r, options({ failOnBlocked: true })).shouldFail, false);
+    expect(computeReportOutcome(r, options({ failOnBlocked: true })).shouldFail).toBe(false);
   });
 
   it("fails when blocked connections are detected and failOnBlocked is true", () => {
@@ -66,7 +65,7 @@ describe("computeReportOutcome", () => {
         [],
       ),
     });
-    assert.equal(computeReportOutcome(r, options({ failOnBlocked: true })).shouldFail, true);
+    expect(computeReportOutcome(r, options({ failOnBlocked: true })).shouldFail).toBe(true);
   });
 
   // Audit's outcome never depends on known_blocked_rules matching, so the
@@ -82,8 +81,8 @@ describe("computeReportOutcome", () => {
       ),
     });
     const outcome = computeReportOutcome(r, options({ failOnBlocked: true }));
-    assert.equal(outcome.level, "notice");
-    assert.equal(outcome.message, "2 blocked connection(s) detected by buildcage sandbox");
+    expect(outcome.level).toBe("notice");
+    expect(outcome.message).toBe("2 blocked connection(s) detected by buildcage sandbox");
   });
 
   it("passes stepLabel/runCommand through to the rendered markdown", () => {
@@ -97,8 +96,8 @@ describe("computeReportOutcome", () => {
       r,
       options({ stepLabel: "npm install", runCommand: "npm install" }),
     );
-    assert.match(markdown, /^## Outbound Traffic Report — npm install \(audit mode\)/);
-    assert.match(markdown, /uses: dash14\/buildcage\/run@v2/);
-    assert.match(markdown, /run: \|\n\s+npm install/);
+    expect(markdown).toMatch(/^## Outbound Traffic Report — npm install \(audit mode\)/);
+    expect(markdown).toMatch(/uses: dash14\/buildcage\/run@v2/);
+    expect(markdown).toMatch(/run: \|\n\s+npm install/);
   });
 });

--- a/run/src/lib/sandbox/mountinfo.test.ts
+++ b/run/src/lib/sandbox/mountinfo.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { parseMountinfo } from "./mountinfo.ts";
 
 // Realistic /proc/self/mountinfo lines (see parseMountinfo's doc comment
@@ -15,7 +14,7 @@ const SAMPLE_MOUNTINFO = [
 
 describe("parseMountinfo", () => {
   it("extracts the mount point and filesystem type of every line", () => {
-    assert.deepEqual(parseMountinfo(SAMPLE_MOUNTINFO), [
+    expect(parseMountinfo(SAMPLE_MOUNTINFO)).toStrictEqual([
       { mountPoint: "/", fsType: "ext4" },
       { mountPoint: "/proc", fsType: "proc" },
       { mountPoint: "/run", fsType: "tmpfs" },
@@ -25,6 +24,6 @@ describe("parseMountinfo", () => {
   });
 
   it("ignores trailing/blank lines", () => {
-    assert.deepEqual(parseMountinfo(`${SAMPLE_MOUNTINFO}\n\n`).length, 5);
+    expect(parseMountinfo(`${SAMPLE_MOUNTINFO}\n\n`).length).toStrictEqual(5);
   });
 });

--- a/run/src/lib/sandbox/oci-config.test.ts
+++ b/run/src/lib/sandbox/oci-config.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { readFileSync, statSync } from "node:fs";
 
 import {
@@ -18,7 +17,7 @@ describe("writeRunScript", () => {
     withScratchDir((dir) => {
       const path = writeRunScript("echo hello", dir);
       const content = readFileSync(path, "utf8");
-      assert.equal(content, "#!/bin/sh\nset -e\necho hello\n");
+      expect(content).toBe("#!/bin/sh\nset -e\necho hello\n");
     });
   });
 
@@ -26,7 +25,7 @@ describe("writeRunScript", () => {
     withScratchDir((dir) => {
       const script = "#!/usr/bin/env bash\necho custom-shebang\n";
       const path = writeRunScript(script, dir);
-      assert.equal(readFileSync(path, "utf8"), script);
+      expect(readFileSync(path, "utf8")).toBe(script);
     });
   });
 
@@ -34,7 +33,7 @@ describe("writeRunScript", () => {
     withScratchDir((dir) => {
       const path = writeRunScript("echo hi", dir);
       const mode = statSync(path).mode & 0o777;
-      assert.equal(mode, 0o700);
+      expect(mode).toBe(0o700);
     });
   });
 });
@@ -43,7 +42,7 @@ describe("writeResolvConf", () => {
   it("writes a single nameserver line", () => {
     withScratchDir((dir) => {
       const path = writeResolvConf("172.20.0.1", dir);
-      assert.equal(readFileSync(path, "utf8"), "nameserver 172.20.0.1\n");
+      expect(readFileSync(path, "utf8")).toBe("nameserver 172.20.0.1\n");
     });
   });
 });
@@ -65,28 +64,28 @@ describe("computeReadonlyHostMounts", () => {
 
   it("excludes '/' itself (already covered by root.readonly)", () => {
     const result = computeReadonlyHostMounts(hostMounts, new Set(), freshMountDestinations);
-    assert.ok(!result.includes("/"));
+    expect(!result.includes("/")).toBeTruthy();
   });
 
   it("excludes paths runc's own base spec already mounts fresh", () => {
     const result = computeReadonlyHostMounts(hostMounts, new Set(), freshMountDestinations);
-    assert.ok(!result.includes("/proc"));
+    expect(!result.includes("/proc")).toBeTruthy();
   });
 
   it("excludes explicitly protected (writable) paths", () => {
     const result = computeReadonlyHostMounts(hostMounts, new Set(["/run"]), freshMountDestinations);
-    assert.ok(!result.includes("/run"));
-    assert.ok(
+    expect(!result.includes("/run")).toBeTruthy();
+    expect(
       result.includes("/run/user/1000"),
       "a nested mount under a protected path is still its own separate mount point",
-    );
+    ).toBeTruthy();
   });
 
   it("includes real, non-pseudo, non-protected host mounts (e.g. a separate disk at /mnt)", () => {
     const result = computeReadonlyHostMounts(hostMounts, new Set(), freshMountDestinations);
-    assert.ok(result.includes("/mnt"));
-    assert.ok(result.includes("/run"));
-    assert.ok(result.includes("/run/user/1000"));
+    expect(result.includes("/mnt")).toBeTruthy();
+    expect(result.includes("/run")).toBeTruthy();
+    expect(result.includes("/run/user/1000")).toBeTruthy();
   });
 
   it("includes a pseudo-filesystem-like mount whose path isn't one of runc's own fresh destinations", () => {
@@ -99,7 +98,7 @@ describe("computeReadonlyHostMounts", () => {
       { mountPoint: "/sys/kernel/security", fsType: "securityfs" },
     ];
     const result = computeReadonlyHostMounts(withSecurityfs, new Set(), freshMountDestinations);
-    assert.ok(result.includes("/sys/kernel/security"));
+    expect(result.includes("/sys/kernel/security")).toBeTruthy();
   });
 });
 
@@ -108,7 +107,9 @@ describe("freshMountDestinationsFrom", () => {
     const baseSpec = {
       mounts: [{ destination: "/proc" }, { destination: "/sys" }, { destination: "/dev/pts" }],
     };
-    assert.deepEqual(freshMountDestinationsFrom(baseSpec), new Set(["/proc", "/sys", "/dev/pts"]));
+    expect(freshMountDestinationsFrom(baseSpec)).toStrictEqual(
+      new Set(["/proc", "/sys", "/dev/pts"]),
+    );
   });
 });
 
@@ -172,28 +173,28 @@ describe("buildOciConfig", () => {
 
   it("clears all five capability sets and sets noNewPrivileges", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
-    assert.deepEqual(config.process.capabilities, {
+    expect(config.process.capabilities).toStrictEqual({
       bounding: [],
       effective: [],
       permitted: [],
       inheritable: [],
       ambient: [],
     });
-    assert.equal(config.process.noNewPrivileges, true);
+    expect(config.process.noNewPrivileges).toBe(true);
   });
 
   it("sets uid/gid and cwd from the given options", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
-    assert.deepEqual(config.process.user, { uid: 1000, gid: 1000 });
-    assert.equal(config.process.cwd, baseArgs.writable.workdir);
+    expect(config.process.user).toStrictEqual({ uid: 1000, gid: 1000 });
+    expect(config.process.cwd).toBe(baseArgs.writable.workdir);
   });
 
   it("wraps the script in `setpriv --pdeathsig=KILL` (die-with-parent, see run-isolated.sh)", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
     // args[0] is setpriv resolved to an absolute path where it exists (e.g.
     // /usr/bin/setpriv on Linux), falling back to bare "setpriv" otherwise.
-    assert.match(config.process.args[0], /(^|\/)setpriv$/);
-    assert.deepEqual(config.process.args.slice(1), [
+    expect(config.process.args[0]).toMatch(/(^|\/)setpriv$/);
+    expect(config.process.args.slice(1)).toStrictEqual([
       "--pdeathsig=KILL",
       "--",
       baseArgs.runtime.scriptPath,
@@ -202,14 +203,14 @@ describe("buildOciConfig", () => {
 
   it("replaces process.env with the given env, dropping undefined values", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
-    assert.deepEqual(config.process.env, ["FOO=bar"]);
+    expect(config.process.env).toStrictEqual(["FOO=bar"]);
   });
 
   it("adds `path` to the network namespace entry, leaving other namespace types untouched", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
     const netNs = config.linux.namespaces.find((ns) => ns.type === "network");
-    assert.equal(netNs!.path, baseArgs.runtime.netnsPath);
-    assert.equal(config.linux.namespaces.length, 6);
+    expect(netNs!.path).toBe(baseArgs.runtime.netnsPath);
+    expect(config.linux.namespaces.length).toBe(6);
   });
 
   it("extends maskedPaths with kallsyms/kmsg/sysrq-trigger and moves sysrq-trigger out of readonlyPaths", () => {
@@ -222,15 +223,18 @@ describe("buildOciConfig", () => {
       "/proc/keys",
       "/proc/timer_list",
     ]) {
-      assert.ok(config.linux.maskedPaths.includes(p), `expected maskedPaths to include ${p}`);
+      expect(
+        config.linux.maskedPaths.includes(p),
+        `expected maskedPaths to include ${p}`,
+      ).toBeTruthy();
     }
-    assert.ok(!config.linux.readonlyPaths.includes("/proc/sysrq-trigger"));
-    assert.ok(config.linux.readonlyPaths.includes("/proc/bus"));
+    expect(!config.linux.readonlyPaths.includes("/proc/sysrq-trigger")).toBeTruthy();
+    expect(config.linux.readonlyPaths.includes("/proc/bus")).toBeTruthy();
   });
 
   it("embeds the seccomp profile as-is", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
-    assert.deepEqual(config.linux.seccomp, baseArgs.runtime.seccompProfile);
+    expect(config.linux.seccomp).toStrictEqual(baseArgs.runtime.seccompProfile);
   });
 
   it("makes root read-only and binds workdir/home/tmp/writablePaths as writable exceptions", () => {
@@ -238,11 +242,10 @@ describe("buildOciConfig", () => {
       ...baseArgs,
       writable: { ...baseArgs.writable, writablePaths: ["/opt/cache"] },
     });
-    assert.equal(config.root.readonly, true);
-    assert.equal(config.root.path, baseArgs.runtime.rootfsBindDir);
+    expect(config.root.readonly).toBe(true);
+    expect(config.root.path).toBe(baseArgs.runtime.rootfsBindDir);
     const rw = config.mounts.filter((m) => m.options?.includes("rw")).map((m) => m.destination);
-    assert.deepEqual(
-      rw.sort(),
+    expect(rw.sort()).toStrictEqual(
       ["/opt/cache", "/tmp", baseArgs.writable.home, baseArgs.writable.workdir].sort(),
     );
   });
@@ -252,72 +255,66 @@ describe("buildOciConfig", () => {
       ...baseArgs,
       writable: { ...baseArgs.writable, writablePaths: ["/opt/cache"] },
     });
-    assert.ok(!config.mounts.some((m) => m.destination === baseArgs.runtime.rootfsBindDir));
+    expect(
+      !config.mounts.some((m) => m.destination === baseArgs.runtime.rootfsBindDir),
+    ).toBeTruthy();
   });
 
   it("fails closed when writable: lists the scratch base itself", () => {
-    assert.throws(
-      () =>
-        buildOciConfig(fakeBaseSpec(), {
-          ...baseArgs,
-          writable: { ...baseArgs.writable, writablePaths: ["/var/tmp/buildcage"] },
-        }),
-      /overlaps the sandbox's own scratch directory/,
-    );
+    expect(() =>
+      buildOciConfig(fakeBaseSpec(), {
+        ...baseArgs,
+        writable: { ...baseArgs.writable, writablePaths: ["/var/tmp/buildcage"] },
+      }),
+    ).toThrow(/overlaps the sandbox's own scratch directory/);
   });
 
   it("fails closed when writable: lists an ancestor of the scratch base", () => {
-    assert.throws(
-      () =>
-        buildOciConfig(fakeBaseSpec(), {
-          ...baseArgs,
-          writable: { ...baseArgs.writable, writablePaths: ["/var/tmp"] },
-        }),
-      /overlaps/,
-    );
+    expect(() =>
+      buildOciConfig(fakeBaseSpec(), {
+        ...baseArgs,
+        writable: { ...baseArgs.writable, writablePaths: ["/var/tmp"] },
+      }),
+    ).toThrow(/overlaps/);
   });
 
   it("fails closed when writable: lists a descendant of the scratch base", () => {
-    assert.throws(
-      () =>
-        buildOciConfig(fakeBaseSpec(), {
-          ...baseArgs,
-          writable: {
-            ...baseArgs.writable,
-            writablePaths: ["/var/tmp/buildcage/some-other-run"],
-          },
-        }),
-      /overlaps/,
-    );
+    expect(() =>
+      buildOciConfig(fakeBaseSpec(), {
+        ...baseArgs,
+        writable: {
+          ...baseArgs.writable,
+          writablePaths: ["/var/tmp/buildcage/some-other-run"],
+        },
+      }),
+    ).toThrow(/overlaps/);
   });
 
   it("fails closed when $HOME or RUNNER_TEMP itself overlaps the scratch base", () => {
-    assert.throws(
-      () =>
-        buildOciConfig(fakeBaseSpec(), {
-          ...baseArgs,
-          writable: { ...baseArgs.writable, home: "/var/tmp/buildcage", writablePaths: [] },
-        }),
-      /overlaps/,
-    );
+    expect(() =>
+      buildOciConfig(fakeBaseSpec(), {
+        ...baseArgs,
+        writable: { ...baseArgs.writable, home: "/var/tmp/buildcage", writablePaths: [] },
+      }),
+    ).toThrow(/overlaps/);
   });
 
   it("does not fail closed for an unrelated sibling under /var/tmp", () => {
-    assert.doesNotThrow(() =>
+    expect(() =>
       buildOciConfig(fakeBaseSpec(), {
         ...baseArgs,
         writable: { ...baseArgs.writable, writablePaths: ["/var/tmp/some-other-tool"] },
       }),
-    );
+    ).not.toThrow();
   });
 
   it("`writable: /` is exempt from the scratch-base guard (documented full opt-out)", () => {
-    assert.doesNotThrow(() =>
+    expect(() =>
       buildOciConfig(fakeBaseSpec(), {
         ...baseArgs,
         writable: { ...baseArgs.writable, writablePaths: ["/"] },
       }),
-    );
+    ).not.toThrow();
   });
 
   it("keeps RUNNER_TEMP writable (rw bind) and out of readonlyPaths", () => {
@@ -332,11 +329,11 @@ describe("buildOciConfig", () => {
       runtime: { ...baseArgs.runtime, hostMounts },
     });
     const rw = config.mounts.filter((m) => m.options?.includes("rw")).map((m) => m.destination);
-    assert.ok(rw.includes(runnerTemp), "RUNNER_TEMP must be bind-mounted writable");
-    assert.ok(
+    expect(rw.includes(runnerTemp), "RUNNER_TEMP must be bind-mounted writable").toBeTruthy();
+    expect(
       !config.linux.readonlyPaths.includes(runnerTemp),
       "RUNNER_TEMP must not be forced read-only",
-    );
+    ).toBeTruthy();
   });
 
   it("does not double-mount RUNNER_TEMP when it duplicates another writable path", () => {
@@ -347,13 +344,13 @@ describe("buildOciConfig", () => {
     const tmpMounts = config.mounts.filter(
       (m) => m.destination === "/tmp" && m.options?.includes("rw"),
     );
-    assert.equal(tmpMounts.length, 1);
+    expect(tmpMounts.length).toBe(1);
   });
 
   it("adds a read-only resolv.conf bind mount", () => {
     const config = buildOciConfig(fakeBaseSpec(), baseArgs);
     const resolv = config.mounts.find((m) => m.destination === "/etc/resolv.conf");
-    assert.deepEqual(resolv, {
+    expect(resolv).toStrictEqual({
       destination: "/etc/resolv.conf",
       type: "none",
       source: baseArgs.runtime.resolvConfPath,
@@ -366,9 +363,9 @@ describe("buildOciConfig", () => {
       ...baseArgs,
       writable: { ...baseArgs.writable, writablePaths: ["/"] },
     });
-    assert.equal(config.root.readonly, false);
+    expect(config.root.readonly).toBe(false);
     const rw = config.mounts.filter((m) => m.options?.includes("rw"));
-    assert.equal(rw.length, 0);
+    expect(rw.length).toBe(0);
   });
 
   it("forces real host mount points not already writable into readonlyPaths (root.readonly alone doesn't cover them)", () => {
@@ -383,22 +380,22 @@ describe("buildOciConfig", () => {
       writable: { ...baseArgs.writable, writablePaths: [] },
       runtime: { ...baseArgs.runtime, hostMounts },
     });
-    assert.ok(
+    expect(
       config.linux.readonlyPaths.includes("/mnt"),
       "a real, separate host mount not covered by root.readonly must be listed explicitly",
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       !config.linux.readonlyPaths.includes("/"),
       "'/' itself is already covered by root.readonly",
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       !config.linux.readonlyPaths.includes("/proc"),
       "pseudo-filesystems get their own fresh mount, not a readonly remount of the host copy",
-    );
-    assert.ok(
+    ).toBeTruthy();
+    expect(
       !config.linux.readonlyPaths.includes(baseArgs.writable.workdir),
       "workdir must stay writable, not be added to readonlyPaths",
-    );
+    ).toBeTruthy();
   });
 
   it("`writable: /` skips the host-mount readonly pass entirely", () => {
@@ -408,7 +405,7 @@ describe("buildOciConfig", () => {
       writable: { ...baseArgs.writable, writablePaths: ["/"] },
       runtime: { ...baseArgs.runtime, hostMounts },
     });
-    assert.ok(!config.linux.readonlyPaths.includes("/mnt"));
+    expect(!config.linux.readonlyPaths.includes("/mnt")).toBeTruthy();
   });
 
   it("forces a kernel pseudo-fs into readonlyPaths when runc's own base spec doesn't mount it fresh", () => {
@@ -424,7 +421,7 @@ describe("buildOciConfig", () => {
       writable: { ...baseArgs.writable, writablePaths: [] },
       runtime: { ...baseArgs.runtime, hostMounts },
     });
-    assert.ok(config.linux.readonlyPaths.includes("/sys/kernel/security"));
+    expect(config.linux.readonlyPaths.includes("/sys/kernel/security")).toBeTruthy();
   });
 });
 
@@ -433,7 +430,7 @@ describe("writeOciConfig", () => {
     withScratchDir((dir) => {
       const config = { ociVersion: "1.0.2", process: { args: ["/bin/true"] } };
       const path = writeOciConfig(config, dir);
-      assert.deepEqual(JSON.parse(readFileSync(path, "utf8")), config);
+      expect(JSON.parse(readFileSync(path, "utf8"))).toStrictEqual(config);
     });
   });
 
@@ -441,7 +438,7 @@ describe("writeOciConfig", () => {
     withScratchDir((dir) => {
       const path = writeOciConfig({ process: { env: ["SECRET=s3cr3t"] } }, dir);
       const mode = statSync(path).mode & 0o777;
-      assert.equal(mode, 0o600);
+      expect(mode).toBe(0o600);
     });
   });
 });

--- a/run/src/lib/sandbox/scratch-dir.test.ts
+++ b/run/src/lib/sandbox/scratch-dir.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -9,11 +8,11 @@ import { writeRunScript } from "./oci-config.ts";
 describe("scratchDirFor", () => {
   it("derives a path under /var/tmp/buildcage from the container name (not under a writable exception)", () => {
     const dir = scratchDirFor("buildcage-proxy-abcd1234");
-    assert.equal(dir, "/var/tmp/buildcage/sandbox-abcd1234");
+    expect(dir).toBe("/var/tmp/buildcage/sandbox-abcd1234");
   });
 
   it("is deterministic for the same container name (so post.ts can reconstruct it)", () => {
-    assert.equal(scratchDirFor("buildcage-proxy-xyz"), scratchDirFor("buildcage-proxy-xyz"));
+    expect(scratchDirFor("buildcage-proxy-xyz")).toBe(scratchDirFor("buildcage-proxy-xyz"));
   });
 });
 
@@ -27,20 +26,22 @@ describe("parseMountsUnder", () => {
 
   it("finds only mount points nested under the given directory", () => {
     const result = parseMountsUnder(mountinfo, "/tmp/buildcage-sandbox-abc");
-    assert.deepEqual(
-      result.sort(),
+    expect(result.sort()).toStrictEqual(
       ["/tmp/buildcage-sandbox-abc", "/tmp/buildcage-sandbox-abc/rootfs"].sort(),
     );
   });
 
   it("orders deepest paths first, so children are unmounted before their parents", () => {
     const result = parseMountsUnder(mountinfo, "/tmp/buildcage-sandbox-abc");
-    assert.deepEqual(result, ["/tmp/buildcage-sandbox-abc/rootfs", "/tmp/buildcage-sandbox-abc"]);
+    expect(result).toStrictEqual([
+      "/tmp/buildcage-sandbox-abc/rootfs",
+      "/tmp/buildcage-sandbox-abc",
+    ]);
   });
 
   it("does not match a sibling directory with a similar prefix", () => {
     const result = parseMountsUnder(mountinfo, "/tmp/buildcage-sandbox-ab");
-    assert.deepEqual(result, []);
+    expect(result).toStrictEqual([]);
   });
 });
 
@@ -51,17 +52,17 @@ describe("withScratchDir", () => {
       capturedDir = dir;
       writeRunScript("echo hi", dir);
     });
-    assert.throws(() => readFileSync(join(capturedDir, "run-script.sh")));
+    expect(() => readFileSync(join(capturedDir, "run-script.sh"))).toThrow();
   });
 
   it("removes the directory even if the callback throws", () => {
     let capturedDir: string;
-    assert.throws(() => {
+    expect(() => {
       withScratchDir((dir) => {
         capturedDir = dir;
         throw new Error("boom");
       });
-    });
-    assert.throws(() => readFileSync(join(capturedDir, "run-script.sh")));
+    }).toThrow();
+    expect(() => readFileSync(join(capturedDir, "run-script.sh"))).toThrow();
   });
 });

--- a/run/src/lib/sudo-preflight.test.ts
+++ b/run/src/lib/sudo-preflight.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { describeSudoFailure } from "./sudo-preflight.ts";
 
@@ -8,14 +7,13 @@ describe("describeSudoFailure", () => {
 
   it("mirrors the docs' passwordless-sudo phrasing", () => {
     const msg = describeSudoFailure({ status: 1 }, noSlimRunner);
-    assert.match(msg, /requires a Linux runner with passwordless sudo/);
+    expect(msg).toMatch(/requires a Linux runner with passwordless sudo/);
   });
 
   it("includes captured stderr detail when present", () => {
-    assert.match(
+    expect(
       describeSudoFailure({ status: 1, stderr: "sudo: a password is required" }, noSlimRunner),
-      /a password is required/,
-    );
+    ).toMatch(/a password is required/);
   });
 
   it("adds a detection note when the runner looks like a container-based image", () => {
@@ -24,7 +22,7 @@ describe("describeSudoFailure", () => {
       { env: { ImageOS: "Linux" }, exists: () => true },
     );
     const withoutNote = describeSudoFailure({ status: 1 }, noSlimRunner);
-    assert.match(withNote, /Detected a container-based GitHub-hosted runner image/);
-    assert.doesNotMatch(withoutNote, /Detected a container-based GitHub-hosted runner image/);
+    expect(withNote).toMatch(/Detected a container-based GitHub-hosted runner image/);
+    expect(withoutNote).not.toMatch(/Detected a container-based GitHub-hosted runner image/);
   });
 });

--- a/run/src/main.property.test.ts
+++ b/run/src/main.property.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run run/src/main.property.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 
 import { buildACLRules } from "./main.ts";
@@ -24,9 +23,9 @@ describe("buildACLRules – properties", () => {
           httpRulesInput: p,
           ipRulesInput: i,
         });
-        assert.deepEqual(result.httpsRules, []);
-        assert.deepEqual(result.httpRules, []);
-        assert.deepEqual(result.ipRules, []);
+        expect(result.httpsRules).toStrictEqual([]);
+        expect(result.httpRules).toStrictEqual([]);
+        expect(result.ipRules).toStrictEqual([]);
       }),
     );
   });
@@ -46,7 +45,7 @@ describe("buildACLRules – properties", () => {
           httpRulesInput: "",
           ipRulesInput: "",
         });
-        assert.equal(result.httpsRules.length, rules.length);
+        expect(result.httpsRules.length).toBe(rules.length);
       }),
     );
   });
@@ -55,19 +54,19 @@ describe("buildACLRules – properties", () => {
   it("any token without a colon and without ~ prefix always throws SandboxError", () => {
     fc.assert(
       fc.property(fc.stringMatching(/^[^\s:~]{1,30}$/), (token) => {
-        assert.throws(
-          () =>
+        expect(() => {
+          try {
             buildACLRules({
               httpsRulesInput: token,
               httpRulesInput: "",
               ipRulesInput: "",
-            }),
-          (err) => {
-            assert.ok(err instanceof Error);
-            assert.equal((err as Error & { code?: string }).code, "INVALID_RULES");
-            return true;
-          },
-        );
+            });
+          } catch (err) {
+            expect(err).toBeInstanceOf(Error);
+            expect((err as Error & { code?: string }).code).toBe("INVALID_RULES");
+            throw err;
+          }
+        }).toThrow();
       }),
     );
   });

--- a/run/src/main.test.ts
+++ b/run/src/main.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run run/src/main.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { buildACLRules, parseWritablePaths, readKnownBlockedRules } from "./main.ts";
 import { InvalidRulesError } from "#core/lib/acl/rules.ts";
@@ -16,7 +15,7 @@ describe("buildACLRules", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.deepEqual(httpsRules, ["example.com:443", "*.cdn.example.com:443"]);
+    expect(httpsRules).toStrictEqual(["example.com:443", "*.cdn.example.com:443"]);
   });
 
   it("handles newline-separated rules", () => {
@@ -25,7 +24,7 @@ describe("buildACLRules", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.deepEqual(httpsRules, ["a.com:443", "b.com:443"]);
+    expect(httpsRules).toStrictEqual(["a.com:443", "b.com:443"]);
   });
 
   it("returns empty arrays for empty/undefined inputs", () => {
@@ -34,75 +33,71 @@ describe("buildACLRules", () => {
       httpRulesInput: undefined,
       ipRulesInput: "   ",
     });
-    assert.deepEqual(result.httpsRules, []);
-    assert.deepEqual(result.httpRules, []);
-    assert.deepEqual(result.ipRules, []);
+    expect(result.httpsRules).toStrictEqual([]);
+    expect(result.httpRules).toStrictEqual([]);
+    expect(result.ipRules).toStrictEqual([]);
   });
 
   it("throws InvalidRulesError with code INVALID_RULES for invalid rule syntax", () => {
-    assert.throws(
-      () =>
-        buildACLRules({
-          httpsRulesInput: "no-port-specified",
-          httpRulesInput: "",
-          ipRulesInput: "",
-        }),
-      (err) => {
-        assert.ok(err instanceof InvalidRulesError);
-        assert.equal(err.code, "INVALID_RULES");
-        return true;
-      },
-    );
+    expect.assertions(2);
+    try {
+      buildACLRules({
+        httpsRulesInput: "no-port-specified",
+        httpRulesInput: "",
+        ipRulesInput: "",
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidRulesError);
+      expect((err as InvalidRulesError).code).toBe("INVALID_RULES");
+    }
   });
 });
 
 describe("readKnownBlockedRules", () => {
   it("parses whitespace-separated rules", () => {
-    assert.deepEqual(readKnownBlockedRules("known-bad.example.com:443 *.noisy.example.com:80"), [
-      "known-bad.example.com:443",
-      "*.noisy.example.com:80",
-    ]);
+    expect(readKnownBlockedRules("known-bad.example.com:443 *.noisy.example.com:80")).toStrictEqual(
+      ["known-bad.example.com:443", "*.noisy.example.com:80"],
+    );
   });
 
   it("returns an empty array for empty/undefined input", () => {
-    assert.deepEqual(readKnownBlockedRules(undefined), []);
-    assert.deepEqual(readKnownBlockedRules(""), []);
+    expect(readKnownBlockedRules(undefined)).toStrictEqual([]);
+    expect(readKnownBlockedRules("")).toStrictEqual([]);
   });
 
   it("throws InvalidRulesError with code INVALID_RULES for invalid rule syntax", () => {
-    assert.throws(
-      () => readKnownBlockedRules("no-port-specified"),
-      (err) => {
-        assert.ok(err instanceof InvalidRulesError);
-        assert.equal(err.code, "INVALID_RULES");
-        return true;
-      },
-    );
+    expect.assertions(2);
+    try {
+      readKnownBlockedRules("no-port-specified");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidRulesError);
+      expect((err as InvalidRulesError).code).toBe("INVALID_RULES");
+    }
   });
 });
 
 describe("parseWritablePaths", () => {
   it("splits on newlines, trimming each entry", () => {
-    assert.deepEqual(parseWritablePaths("/opt/extra\n /var/cache \n"), [
+    expect(parseWritablePaths("/opt/extra\n /var/cache \n")).toStrictEqual([
       "/opt/extra",
       "/var/cache",
     ]);
   });
 
   it("does not split on internal spaces (paths may contain them)", () => {
-    assert.deepEqual(parseWritablePaths("/path with spaces\n/other"), [
+    expect(parseWritablePaths("/path with spaces\n/other")).toStrictEqual([
       "/path with spaces",
       "/other",
     ]);
   });
 
   it("returns an empty array for empty/undefined input", () => {
-    assert.deepEqual(parseWritablePaths(""), []);
-    assert.deepEqual(parseWritablePaths(undefined), []);
-    assert.deepEqual(parseWritablePaths("   \n  \n"), []);
+    expect(parseWritablePaths("")).toStrictEqual([]);
+    expect(parseWritablePaths(undefined)).toStrictEqual([]);
+    expect(parseWritablePaths("   \n  \n")).toStrictEqual([]);
   });
 
   it("preserves a lone '/' entry (the disable-readonly sentinel)", () => {
-    assert.deepEqual(parseWritablePaths("/"), ["/"]);
+    expect(parseWritablePaths("/")).toStrictEqual(["/"]);
   });
 });

--- a/setup/src/main.property.test.ts
+++ b/setup/src/main.property.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run setup/src/main.property.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 
 import { imageTagFromRef } from "#core/lib/provenance/image-tag.ts";
@@ -26,10 +25,7 @@ describe("imageTagFromRef – properties", () => {
         fc.stringMatching(/^[0-9a-fA-F]{40}$/),
         fc.constantFrom("transparent", "explicit"),
         (sha, engine) => {
-          assert.equal(
-            imageTagFromRef(sha, engine),
-            `sha-${sha.toLowerCase()}${suffixFor(engine)}`,
-          );
+          expect(imageTagFromRef(sha, engine)).toBe(`sha-${sha.toLowerCase()}${suffixFor(engine)}`);
         },
       ),
     );
@@ -41,7 +37,7 @@ describe("imageTagFromRef – properties", () => {
         fc.string({ minLength: 1 }).map((s) => `v${s}`),
         fc.constantFrom("transparent", "explicit"),
         (ref, engine) => {
-          assert.equal(imageTagFromRef(ref, engine), `${ref.slice(1)}${suffixFor(engine)}`);
+          expect(imageTagFromRef(ref, engine)).toBe(`${ref.slice(1)}${suffixFor(engine)}`);
         },
       ),
     );
@@ -54,7 +50,7 @@ describe("imageTagFromRef – properties", () => {
         fc.string({ minLength: 0, maxLength: 50 }).map((s) => `g${s}`),
         fc.constantFrom("transparent", "explicit"),
         (ref, engine) => {
-          assert.equal(imageTagFromRef(ref, engine), `${ref}${suffixFor(engine)}`);
+          expect(imageTagFromRef(ref, engine)).toBe(`${ref}${suffixFor(engine)}`);
         },
       ),
     );
@@ -65,7 +61,7 @@ describe("imageTagFromRef – properties", () => {
       fc.property(
         fc.string({ minLength: 0, maxLength: 50 }).map((s) => `g${s}`),
         (ref) => {
-          assert.equal(imageTagFromRef(ref), ref);
+          expect(imageTagFromRef(ref)).toBe(ref);
         },
       ),
     );
@@ -86,7 +82,7 @@ describe("resolveProxyEngine – properties", () => {
         } catch {
           return; // throwing is an acceptable outcome for invalid input
         }
-        assert.ok(result === "transparent" || result === "explicit");
+        expect(result === "transparent" || result === "explicit").toBeTruthy();
       }),
     );
   });
@@ -94,7 +90,7 @@ describe("resolveProxyEngine – properties", () => {
   it("is idempotent for its own valid outputs", () => {
     fc.assert(
       fc.property(fc.constantFrom("transparent", "explicit"), (engine) => {
-        assert.equal(resolveProxyEngine(resolveProxyEngine(engine)), engine);
+        expect(resolveProxyEngine(resolveProxyEngine(engine))).toBe(engine);
       }),
     );
   });
@@ -119,9 +115,9 @@ describe("buildACLRules – properties", () => {
           httpRulesInput: p,
           ipRulesInput: i,
         });
-        assert.deepEqual(result.httpsRules, []);
-        assert.deepEqual(result.httpRules, []);
-        assert.deepEqual(result.ipRules, []);
+        expect(result.httpsRules).toStrictEqual([]);
+        expect(result.httpRules).toStrictEqual([]);
+        expect(result.ipRules).toStrictEqual([]);
       }),
     );
   });
@@ -141,7 +137,7 @@ describe("buildACLRules – properties", () => {
           httpRulesInput: "",
           ipRulesInput: "",
         });
-        assert.equal(result.httpsRules.length, rules.length);
+        expect(result.httpsRules.length).toBe(rules.length);
       }),
     );
   });
@@ -150,18 +146,13 @@ describe("buildACLRules – properties", () => {
   it("any token without a colon and without ~ prefix always throws", () => {
     fc.assert(
       fc.property(fc.stringMatching(/^[^\s:~]{1,30}$/), (token) => {
-        assert.throws(
-          () =>
-            buildACLRules({
-              httpsRulesInput: token,
-              httpRulesInput: "",
-              ipRulesInput: "",
-            }),
-          (err) => {
-            assert.ok(err instanceof Error);
-            return true;
-          },
-        );
+        expect(() =>
+          buildACLRules({
+            httpsRulesInput: token,
+            httpRulesInput: "",
+            ipRulesInput: "",
+          }),
+        ).toThrow();
       }),
     );
   });
@@ -185,7 +176,7 @@ describe("resolveBuildcageImageRef – properties", () => {
           actionRepository,
         });
         const [repoPart] = result.split("@");
-        assert.equal(repoPart, `ghcr.io/${actionRepository.toLowerCase()}`);
+        expect(repoPart).toBe(`ghcr.io/${actionRepository.toLowerCase()}`);
       }),
     );
   });

--- a/setup/src/main.test.ts
+++ b/setup/src/main.test.ts
@@ -3,8 +3,7 @@
  *
  * Run with: vp test run setup/src/main.test.ts
  */
-import { describe, it } from "vitest";
-import assert from "node:assert/strict";
+import { describe, it, expect } from "vitest";
 
 import { resolveBuildcageImageRef } from "#core/lib/provenance/image-ref.ts";
 import { buildACLRules, resolveProxyEngine } from "./main.ts";
@@ -20,7 +19,7 @@ describe("resolveBuildcageImageRef", () => {
       imageDigest: digest,
       actionRepository: "Owner/Repo",
     });
-    assert.equal(result, `ghcr.io/owner/repo@${digest}`);
+    expect(result).toBe(`ghcr.io/owner/repo@${digest}`);
   });
 
   it("lowercases the repository", () => {
@@ -29,7 +28,7 @@ describe("resolveBuildcageImageRef", () => {
       imageDigest: digest,
       actionRepository: "MyOrg/MyRepo",
     });
-    assert.ok(result.startsWith("ghcr.io/myorg/myrepo@"));
+    expect(result.startsWith("ghcr.io/myorg/myrepo@")).toBeTruthy();
   });
 
   it("always derives repository from actionRepository (no external override)", () => {
@@ -38,7 +37,7 @@ describe("resolveBuildcageImageRef", () => {
       imageDigest: digest,
       actionRepository: "dash14/buildcage",
     });
-    assert.ok(result.startsWith("ghcr.io/dash14/buildcage@"));
+    expect(result.startsWith("ghcr.io/dash14/buildcage@")).toBeTruthy();
   });
 });
 
@@ -48,39 +47,27 @@ describe("resolveBuildcageImageRef", () => {
 
 describe("resolveProxyEngine", () => {
   it("defaults to transparent for undefined", () => {
-    assert.equal(resolveProxyEngine(undefined), "transparent");
+    expect(resolveProxyEngine(undefined)).toBe("transparent");
   });
 
   it("defaults to transparent for empty string", () => {
-    assert.equal(resolveProxyEngine(""), "transparent");
+    expect(resolveProxyEngine("")).toBe("transparent");
   });
 
   it("accepts transparent explicitly", () => {
-    assert.equal(resolveProxyEngine("transparent"), "transparent");
+    expect(resolveProxyEngine("transparent")).toBe("transparent");
   });
 
   it("accepts explicit", () => {
-    assert.equal(resolveProxyEngine("explicit"), "explicit");
+    expect(resolveProxyEngine("explicit")).toBe("explicit");
   });
 
   it("throws SetupError for an invalid value", () => {
-    assert.throws(
-      () => resolveProxyEngine("restrict"),
-      (err) => {
-        assert.ok(err instanceof Error);
-        return true;
-      },
-    );
+    expect(() => resolveProxyEngine("restrict")).toThrow();
   });
 
   it("throws SetupError for a value with different casing (case-sensitive)", () => {
-    assert.throws(
-      () => resolveProxyEngine("Explicit"),
-      (err) => {
-        assert.ok(err instanceof Error);
-        return true;
-      },
-    );
+    expect(() => resolveProxyEngine("Explicit")).toThrow();
   });
 });
 
@@ -95,7 +82,7 @@ describe("buildACLRules", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.deepEqual(httpsRules, ["example.com:443", "*.cdn.example.com:443"]);
+    expect(httpsRules).toStrictEqual(["example.com:443", "*.cdn.example.com:443"]);
   });
 
   it("handles newline-separated rules", () => {
@@ -104,7 +91,7 @@ describe("buildACLRules", () => {
       httpRulesInput: "",
       ipRulesInput: "",
     });
-    assert.deepEqual(httpsRules, ["a.com:443", "b.com:443"]);
+    expect(httpsRules).toStrictEqual(["a.com:443", "b.com:443"]);
   });
 
   it("returns empty arrays for empty/undefined inputs", () => {
@@ -113,23 +100,18 @@ describe("buildACLRules", () => {
       httpRulesInput: undefined,
       ipRulesInput: "   ",
     });
-    assert.deepEqual(result.httpsRules, []);
-    assert.deepEqual(result.httpRules, []);
-    assert.deepEqual(result.ipRules, []);
+    expect(result.httpsRules).toStrictEqual([]);
+    expect(result.httpRules).toStrictEqual([]);
+    expect(result.ipRules).toStrictEqual([]);
   });
 
   it("throws for invalid rule syntax", () => {
-    assert.throws(
-      () =>
-        buildACLRules({
-          httpsRulesInput: "no-port-specified",
-          httpRulesInput: "",
-          ipRulesInput: "",
-        }),
-      (err) => {
-        assert.ok(err instanceof Error, "expected Error");
-        return true;
-      },
-    );
+    expect(() =>
+      buildACLRules({
+        httpsRulesInput: "no-port-specified",
+        httpRulesInput: "",
+        ipRulesInput: "",
+      }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Completes the vitest `expect()` migration started in #242 (stage 1): converts every remaining `core/lib`, `run/src`, and `setup/src` test file off `node:assert` to `expect()`.
- Removes the now-unused `Assert` interface and its two runtime implementations from `test-shim.ts`, since no test file uses `assert` from the shim anymore.
- `node:assert`'s `assert.throws(fn, predicateFn)` has no vitest equivalent (`toThrow()` doesn't accept a predicate) — those call sites were rewritten by hand as `try { ... } catch (err) { expect(err).toBeInstanceOf(X); ... }`, using `expect.assertions(n)` in single-shot `it()`s and a `expect(() => {...}).toThrow()` wrapper inside property-based tests (where `expect.assertions()` doesn't fit a repeated-iteration callback).
- Fixes a QuickJS test-bundle build issue surfaced along the way: `test-shim.ts`'s Node-only `await import("vitest")` uses a compile-time-constant specifier, which rolldown was resolving and inlining into the qjs bundle despite being dead code at qjs runtime — dragging in vitest's own `expect-type` devDependency, unresolvable under qjs's "neutral" platform. Fixed by adding `"vitest"` to that build target's `external` list.

## Test plan

- [x] `vp run typecheck`
- [x] `vp check`
- [x] `vp test run core/ setup/src run/src` — 47 files / 444 tests passing
- [x] `make test_unit` (including QuickJS) — 21 + 30 QuickJS tests passing
- [x] `vp run build` — no `dist/` diff (test-only change)