### PR TITLE
chore: pin uses: examples to the v3.0.0 release SHA

### DIFF
--- a/.github/workflows/example-audit.yml
+++ b/.github/workflows/example-audit.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Start Buildcage builder
-        uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+        uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
         with:
           proxy_mode: audit
 
@@ -41,4 +41,4 @@ jobs:
 
       - name: Show proxy report
         if: always()
-        uses: buildcage/docker/report@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+        uses: buildcage/docker/report@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0

--- a/.github/workflows/example-explicit.yml
+++ b/.github/workflows/example-explicit.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Start Buildcage builder
-        uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+        uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
         with:
           proxy_mode: restrict
           proxy_engine: explicit
@@ -49,6 +49,6 @@ jobs:
 
       - name: Show proxy report
         if: always()
-        uses: buildcage/docker/report@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+        uses: buildcage/docker/report@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
         with:
           fail_on_blocked: false

--- a/.github/workflows/example-restrict.yml
+++ b/.github/workflows/example-restrict.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Start Buildcage builder
-        uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+        uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
         with:
           proxy_mode: restrict
           allowed_https_rules: |
@@ -45,6 +45,6 @@ jobs:
 
       - name: Show proxy report
         if: always()
-        uses: buildcage/docker/report@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+        uses: buildcage/docker/report@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
         with:
           fail_on_blocked: false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ tool works the same way, including `docker/bake-action`: just point its `driver:
 
 ```yaml
 - name: Start Buildcage in audit mode
-  uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
   with:
     proxy_mode: audit # Log every destination, block nothing
 
@@ -59,7 +59,7 @@ tool works the same way, including `docker/bake-action`: just point its `driver:
 
 - name: Show Buildcage report
   if: always()
-  uses: buildcage/docker/report@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker/report@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
 ```
 
 See the [complete example workflow](.github/workflows/example-audit.yml).
@@ -78,7 +78,7 @@ Copy these domain names into `allowed_https_rules` or `allowed_http_rules` for S
 
 ```yaml
 - name: Start Buildcage in restrict mode
-  uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
   with:
     proxy_mode: restrict # Block every destination except the ones you allow
     allowed_https_rules: |
@@ -99,7 +99,7 @@ Copy these domain names into `allowed_https_rules` or `allowed_http_rules` for S
 
 - name: Show Buildcage report
   if: always()
-  uses: buildcage/docker/report@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker/report@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
   # Build fails if any unexpected connections were blocked
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,7 +6,7 @@ Starts the Buildcage builder container.
 
 ```yaml
 - name: Start Buildcage builder
-  uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
   with:
     proxy_mode: restrict
     allowed_https_rules: |
@@ -169,7 +169,7 @@ Displays communication logs after builds and optionally fails if any BLOCKED con
 ```yaml
 - name: Show proxy report
   if: always()
-  uses: buildcage/docker/report@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker/report@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
 ```
 
 ### Job Summary

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -67,7 +67,7 @@ Since the regex is tested against the `domain:port` string, include a port patte
 
 ```yaml
 - name: Start Buildcage
-  uses: buildcage/docker@83f51c5f1d45fbe05391c70e705fcafac056fc7c # v2.3.0
+  uses: buildcage/docker@4878a0c897d728304820dc65005ad22bac353be2 # v3.0.0
   with:
     proxy_mode: restrict
 


### PR DESCRIPTION
## Summary
- The `uses:` examples in `README.md`, `docs/reference.md`, `docs/rules.md`, and the `example-*.yml` demo workflows still pinned the pre-transfer `v2.3.0` commit SHA — update them to `v3.0.0`'s SHA now that it's published

## Test plan
- [x] `vp check` passes