### PR TITLE
fix: report false-fails restrict-mode builds with zero outbound traffic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ report_buildkit: ## Show the buildcage report for the currently running builder
 # ---------------------------------------------------------------------------
 
 .PHONY: test_integration_buildkit
-test_integration_buildkit: test_integration_buildkit_transparent_audit test_integration_buildkit_transparent_restrict test_integration_buildkit_explicit_audit test_integration_buildkit_explicit_restrict ## Run all buildkit integration tests
+test_integration_buildkit: test_integration_buildkit_transparent_audit test_integration_buildkit_transparent_restrict test_integration_buildkit_transparent_restrict_no_traffic test_integration_buildkit_explicit_audit test_integration_buildkit_explicit_restrict ## Run all buildkit integration tests
 
 .PHONY: test_integration_buildkit_transparent_audit
 test_integration_buildkit_transparent_audit: ## Run transparent-engine audit mode tests
@@ -158,6 +158,22 @@ test_integration_buildkit_transparent_restrict: ## Run transparent-engine restri
 	  --load -t buildcage-test
 	@node report/src/main.ts || true
 	@./test/assert-transparent-restrict.sh
+	@node src/post.ts
+	@./test/assert-post.sh
+	@$(MAKE) clean_buildkit
+
+.PHONY: test_integration_buildkit_transparent_restrict_no_traffic
+test_integration_buildkit_transparent_restrict_no_traffic: ## Run transparent-engine restrict mode tests with zero outbound traffic
+	@echo "Running transparent-engine restrict mode tests with zero outbound traffic..."
+	@COMPOSE_FILE=compose.yaml:compose.test-transparent.yaml \
+	  $(MAKE) setup_buildkit_transparent_restrict
+	@docker buildx build --no-cache \
+	  --builder buildcage \
+	  --platform linux/arm64 \
+	  --progress=plain -f test/Dockerfile.transparent-restrict-no-traffic test/ \
+	  --load -t buildcage-test
+	@INPUT_FAIL_ON_BLOCKED=true node report/src/main.ts
+	@./test/assert-transparent-restrict-no-traffic.sh
 	@node src/post.ts
 	@./test/assert-post.sh
 	@$(MAKE) clean_buildkit

--- a/docker/transparent/files/s6-rc.d/haproxy/run
+++ b/docker/transparent/files/s6-rc.d/haproxy/run
@@ -1,3 +1,5 @@
 #!/command/with-contenv sh
 exec 2>&1
+# Guaranteed non-decision line for report's plausibility check (see haproxy.ts).
+echo "buildcage haproxy starting"
 exec s6-notifyoncheck -d -w 250 -n 12 haproxy -f /etc/haproxy/haproxy.cfg -db

--- a/src/core/lib/log/haproxy.test.ts
+++ b/src/core/lib/log/haproxy.test.ts
@@ -110,6 +110,13 @@ describe("scanHaproxyLog", () => {
     expect(result.hasNonBuildcageContent).toBe(true);
   });
 
+  it("hasNonBuildcageContent is true for a zero-traffic run thanks to the guaranteed startup marker", async () => {
+    // See docker/transparent/files/s6-rc.d/haproxy/run
+    const result = await scanHaproxyLog(["buildcage haproxy starting"], false);
+    expect(result.hasNonBuildcageContent).toBe(true);
+    expect(result.blockedCount).toBe(0);
+  });
+
   it("hasNonBuildcageContent ignores blank lines when deciding", async () => {
     const result = await scanHaproxyLog("\n\n  \n".split("\n"), false);
     expect(result.hasNonBuildcageContent).toBe(false);

--- a/test/Dockerfile.transparent-restrict-no-traffic
+++ b/test/Dockerfile.transparent-restrict-no-traffic
@@ -1,0 +1,5 @@
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+
+# No RUN step touches the network — regression test for the haproxy log
+# plausibility check (see docker/transparent/files/s6-rc.d/haproxy/run).
+RUN echo "no network activity in this build"

--- a/test/assert-transparent-restrict-no-traffic.sh
+++ b/test/assert-transparent-restrict-no-traffic.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+echo ""
+echo "=== Zero-Traffic Restrict Mode Assertions ==="
+echo ""
+
+echo "[haproxy log] no traffic, but the guaranteed startup marker is present:"
+if grep -qF "buildcage haproxy starting" <<< "$LOGS"; then
+  echo "  PASS  startup marker found"
+else
+  echo "  FAIL  startup marker not found in haproxy log"
+  FAILURES=$((FAILURES + 1))
+fi
+echo ""
+
+assert_log_not_contains ALLOWED
+assert_log_not_contains BLOCKED
+echo ""
+
+# report-action.js runs its own plausibility check against the haproxy log
+# above; a regression here means it treats the traffic-free log as
+# suspicious and fails the step despite blockedCount being 0 (see
+# docker/transparent/files/s6-rc.d/haproxy/run). fail_on_blocked is forced
+# to true (matching action.yml's default) since that's the setting under
+# which the false positive actually fails the job. GITHUB_STEP_SUMMARY is
+# unset so it prints to stdout instead of a job-summary file.
+REPORT_EXIT_CODE=0
+REPORT_OUTPUT=$(GITHUB_STEP_SUMMARY= INPUT_FAIL_ON_BLOCKED=true node report/src/main.ts 2>&1) || REPORT_EXIT_CODE=$?
+
+echo "[report action] exits successfully despite zero traffic:"
+if [ "$REPORT_EXIT_CODE" -eq 0 ]; then
+  echo "  PASS  report exited 0"
+else
+  echo "  FAIL  report exited $REPORT_EXIT_CODE"
+  echo "$REPORT_OUTPUT"
+  FAILURES=$((FAILURES + 1))
+fi
+echo ""
+
+echo "[report action] no false-positive blocked-connection error:"
+if grep -qF "blocked connection(s) detected" <<< "$REPORT_OUTPUT"; then
+  echo "  FAIL  unexpected blocked-connection message in report output"
+  echo "$REPORT_OUTPUT"
+  FAILURES=$((FAILURES + 1))
+else
+  echo "  PASS  no blocked-connection message"
+fi
+echo ""
+
+assert_results
+echo ""


### PR DESCRIPTION
## Summary
- `report`'s plausibility check treated a haproxy log with no non-decision content as tampered/untrusted, which also matched a legitimate build that made zero outbound connections (e.g. fully cached layers, no network-touching `RUN` steps) — failing the step under `fail_on_blocked: true` even though `blockedCount` was 0.
- `docker/transparent/files/s6-rc.d/haproxy/run` now echoes a fixed startup line before exec'ing haproxy, so the plausibility check always has a guaranteed non-decision line to see, independent of whether any traffic occurred.

## Test plan
- [x] `vp test run src/core/lib/log` / `vp test run src/core/lib/report`
- [x] `vp check`
- [x] `make test_integration_buildkit_transparent_restrict` (existing restrict-mode traffic still detected/reported correctly)
- [x] `make test_integration_buildkit_transparent_restrict_no_traffic` (new — reproduces the zero-traffic false positive; verified it fails without the fix and passes with it)