### PR TITLE
docs: correct the comparison claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,19 @@ The closest tools in this space are [StepSecurity Harden-Runner](https://github.
 and [Bullfrog](https://github.com/bullfrogsec/bullfrog), both of which control outbound traffic for
 an entire GitHub Actions job rather than one build step.
 
-**Harden-Runner** is a broader security agent, monitoring network, file integrity, and process
-activity across the whole runner. Buildcage stays narrower on purpose: it only restricts outbound
-traffic during a Docker build and does nothing else. That focus is also why it stays entirely
-within your GitHub Actions job: no external dashboard, no account, no tier to unlock for private
-repos or self-hosted runners.
+Both decide at DNS time and then allow the address the name resolved to, rather than reading the
+SNI or Host header of the connection itself, so shared infrastructure like a CDN can end up
+permitting more than the domain you named. Buildcage matches on the domain in each connection and
+scopes the policy to the build, so two steps in the same job can carry different allowlists.
 
-**Bullfrog** is free and open source too, but the architecture differs. It allowlists by resolving
-a domain to an IP address and then permitting that IP, without inspecting the SNI or Host header of
-the actual connection, so shared infrastructure like a CDN can end up permitting more than the
-intended domain. Its own documentation also states that jobs running in containers aren't
-supported, which rules out protecting a Docker build. Buildcage matches on the domain itself and
-isolates each `RUN` step individually.
+**Harden-Runner** is a broader security agent besides, correlating network, file, and process
+events back to the step that caused them. Buildcage stays narrower on purpose: it only restricts
+outbound traffic during a Docker build and does nothing else. That focus is also why it stays
+entirely within your GitHub Actions job, with no external dashboard and no account. Harden-Runner's
+Community tier covers public repositories on GitHub-hosted Linux runners; private repositories are
+an Enterprise feature.
+
+**Bullfrog** is free and open source too, and covers private repositories as well.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -138,17 +138,19 @@ The closest tools in this space are [StepSecurity Harden-Runner](https://github.
 and [Bullfrog](https://github.com/bullfrogsec/bullfrog), both of which control outbound traffic for
 an entire GitHub Actions job rather than one build step.
 
-Both decide at DNS time and then allow the address the name resolved to, rather than reading the
-SNI or Host header of the connection itself, so shared infrastructure like a CDN can end up
-permitting more than the domain you named. Buildcage matches on the domain in each connection and
-scopes the policy to the build, so two steps in the same job can carry different allowlists.
+Both decide what to block at DNS time and then allow the address the name resolved to, rather than
+reading the SNI or Host header of the connection itself, so shared infrastructure like a CDN can
+end up permitting more than the domain you named. Buildcage matches on the domain in each
+connection and scopes the policy to the build, so two steps in the same job can carry different
+allowlists.
 
 **Harden-Runner** is a broader security agent besides, correlating network, file, and process
-events back to the step that caused them. Buildcage stays narrower on purpose: it only restricts
-outbound traffic during a Docker build and does nothing else. That focus is also why it stays
-entirely within your GitHub Actions job, with no external dashboard and no account. Harden-Runner's
-Community tier covers public repositories on GitHub-hosted Linux runners; private repositories are
-an Enterprise feature.
+events back to the step that caused them. On its paid plans it can also read inside HTTPS by
+hooking the TLS library with eBPF, though that feeds its reporting rather than the block decision.
+Buildcage stays narrower on purpose: it only restricts outbound traffic during a Docker build and
+does nothing else. That focus is also why it stays entirely within your GitHub Actions job, with no
+external dashboard and no account. Harden-Runner's Community tier covers public repositories on
+GitHub-hosted Linux runners; private repositories are an Enterprise feature.
 
 **Bullfrog** is free and open source too, and covers private repositories as well.
 


### PR DESCRIPTION
## Summary

Re-verified both competitors against their own docs and source while writing the landing page, and three claims in this section didn't hold up.

- **Dropped "no tier to unlock for ... self-hosted runners"** — this implied Buildcage supports self-hosted runners. That isn't something we test or actively support, so it shouldn't be a selling point. Private repositories stay, since that one is accurate for us and is genuinely an Enterprise feature for Harden-Runner (verified in their README's tier table)
- **Dropped "jobs running in containers aren't supported, which rules out protecting a Docker build"** — two problems. The inference doesn't follow: a job running in a container (`jobs.<id>.container`) isn't the same as a `docker build` inside an ordinary job. And Harden-Runner documents the same limitation for itself (`docs/limitations.md`: not supported when the job runs in a container, since it needs sudo on the VM), so citing it against only Bullfrog was an unfair comparison
- **Moved the DNS/IP matching point so it applies to both** — it was written as a Bullfrog-specific weakness, but both tools work this way:
  - Harden-Runner's community agent: DNS proxy plus iptables rules on the resolved IP (`step-security/agent`, `dnsproxy.go` + `firewall.go`, which imports `coreos/go-iptables`)
  - Bullfrog's agent: nftables + NFQUEUE with gopacket, and the only L7 parsing is `processDNSTypeAResponse` — no SNI or ClientHello handling (`bullfrogsec/agent`, `pkg/agent`)

  Neither reads SNI or the Host header, so the CDN caveat applies equally. That is the real axis where Buildcage differs, and it reads better stated once for both.

Also worth recording: Harden-Runner does have eBPF-based HTTPS visibility (it hooks SSL write), which is what their "Layer 7" wording refers to. It's Team/Enterprise only, opt-in, monitoring only rather than blocking, and currently limited to `github.com` and `api.github.com` — so it isn't part of how the egress policy is enforced.

The same corrections are already reflected in the landing page copy.

## Test plan
- [x] `vp check` passes