### PR TITLE
chore: name and describe the actions for the Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,8 @@
-name: Setup Builder
-description: Start Buildcage builder container
+name: "Buildcage for Docker"
+description: "Restrict outbound network access during docker build to an allowlist of domains"
+branding:
+  icon: package
+  color: blue
 
 inputs:
   builder_name:

--- a/report/action.yml
+++ b/report/action.yml
@@ -1,5 +1,5 @@
-name: Report
-description: Show proxy communication logs and fail if blocked connections detected
+name: "Buildcage Report"
+description: "Write the outbound traffic report to the Job Summary and fail the job when blocked connections are detected"
 
 inputs:
   builder_name:


### PR DESCRIPTION
## Summary

Marketplace metadata. `Setup Builder` / `Report` were internal working names.

```yaml
name: "Buildcage for Docker"
description: "Restrict outbound network access during docker build to an allowlist of domains"
branding:
  icon: package
  color: blue
```

`report/action.yml` is renamed to `Buildcage Report`. It's in a subdirectory, so it can't be a listing of its own — no branding there.

Paired with buildcage/isolated-run#22.

## Test plan
- [x] `vp check`
