### PR TITLE
chore: remind the publisher to tick the Marketplace checkbox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,5 @@ jobs:
           echo "### $TAG draft release is ready" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Review and publish: $RELEASE_URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tick **Publish this Action to the GitHub Marketplace** on that page before publishing — the release API has no field for it, so it has to be set by hand every time." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The release workflow can't tick **Publish this Action to the GitHub Marketplace** for us — the REST "Create a release" endpoint has no field for it (`tag_name`, `target_commitish`, `name`, `body`, `draft`, `prerelease`, `discussion_category_name`, `generate_release_notes`, `make_latest`), and it's a per-release checkbox on the release page. So the job summary says so instead.

```
Tick **Publish this Action to the GitHub Marketplace** on that page before publishing — the release API has no field for it, so it has to be set by hand every time.
```
