### PR TITLE
fix(ci): add artifact-metadata:write permission for image attestation storage record

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
+      artifact-metadata: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

`actions/attest` defaults `create-storage-record` to `true`, which needs `artifact-metadata: write`. Without it the step still succeeds, but logs:

```
Failed to create storage record: Error: Failed to persist storage record: no artifacts found
Please check that the "artifact-metadata:write" permission has been included
```
