### PR TITLE
docs: document the allowlist's structural limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ workflow `run:` step rather than a Docker build, use
 - [Proxy engines](#proxy-engines)
 - [Report action](#report-action)
 - [Scope](#scope)
+- [Hardening](#hardening)
 - [Documentation](#documentation)
 
 ## Usage
@@ -252,6 +253,18 @@ Buildcage controls _where_ your build can connect, not _what code_ it runs. A ma
 delivered through an allowed domain still runs. Use it as one layer in a defense-in-depth strategy —
 a last line of defense so that if something slips through your other measures, at least it can't
 call home. See [Security Details](./docs/security.md) for the full threat model.
+
+## Hardening
+
+An allowlist works on domain names, so it cannot stop anything leaving through a service you had to
+allow anyway. That is a structural limit. What it does stop is traffic to a destination that is not
+on the list, and infrastructure an attacker set up is normally not on it, because the build has no
+reason to reach it. That is also the hardest kind of leak to find afterwards.
+
+Buildcage runs against your Dockerfile as it is, and an allowlist generated from an audit run
+already blocks every destination the audit did not record. Whether to go further depends on what the
+build has access to. [Hardening](./docs/security.md#hardening) is what to look at when it holds
+credentials, personal data, or source you do not publish.
 
 ## Documentation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -136,6 +136,49 @@ Given these implementation costs versus the strict preconditions for the attack 
 - **Major CDN countermeasures** — Major CDN providers like CloudFront and Cloudflare have already introduced measures to restrict domain fronting. Consult your CDN provider's documentation for current details.
 - **Regular audits** — Periodically run in [audit mode](../README.md#operation-modes) to detect anomalies in connection patterns.
 
+## Hardening
+
+An allowlist decides which destinations a build can reach. It works on domain names, so it cannot
+tell a legitimate use of an allowed destination from an abusive one. Anything leaving through a
+service you had to allow anyway still leaves. That is a structural limit, not something a better
+rule set fixes.
+
+What it does stop is narrower. Traffic to a destination that is not on the list does not go out, and
+infrastructure an attacker set up is normally not on it, because the build has no reason to reach
+it. That is also the hardest kind of leak to find afterwards, which is why closing it is worth doing
+even though the rest stays open.
+
+An attacker who sends the same data through a service the build already uses stays inside the limit
+above. The rest of this section is about making that set of services smaller. Buildcage runs against
+your Dockerfile as it is, and an allowlist generated from an audit run already blocks every
+destination the audit did not record. Weigh what follows against what the build has access to.
+
+### Keep each rule as narrow as it can be
+
+An audit run only ever emits the exact `host:port` pairs it observed. Wildcards and `:*` ports come
+from broadening a rule by hand, and each one covers destinations the build never asked for. Where a
+broad rule exists, it is worth checking whether the build can be changed instead.
+
+Pay particular attention to general-purpose destinations: a gist host, object storage, or an API
+that can create repositories. They accept uploads as readily as they serve downloads, which is what
+makes them useful for sending data out.
+
+### Reduce what has to be reachable
+
+A package registry is usually the one entry a build cannot do without, and the fetch has to happen
+inside the build. What can change is which registry. A mirror configured as a read-only
+pull-through cache serves upstream packages on demand and accepts no publishes, so nothing can be
+uploaded to the destination on your allowlist. Running one is a bigger commitment than anything
+else in this section.
+
+### Keep the rest of your supply chain practice
+
+Pinning versions, lockfiles, review, least-privilege tokens, and a dependency cooldown each cover
+something an allowlist does not. Pinning base images by digest belongs here too: `FROM`
+instructions are resolved by buildkitd itself, which is not on the isolated network, so image pulls
+are never filtered (see [Architecture](#architecture)). Buildcage is one layer among them, not a
+replacement for any.
+
 ## Explicit Proxy Engine
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

Nothing said what the allowlist can and can't do. It works on domain names, so anything leaving through a service you had to allow anyway still leaves, and no rule set fixes that. What can be claimed is narrower: traffic to a command-and-control server, or any other host an attacker picked, doesn't go through, and that's the case an investigation afterwards has the least to work with.

Adds a `Hardening` section that states the limit first, then four things worth considering if you want to go further within it: review what the audit produced, reduce what has to be reached, read the report when dependencies change, and keep the rest of your supply chain practice. `README.md` carries the same section name with a short version.

The framing is deliberately modest. It runs as-is with no changes to what you already have, the generated allowlist already covers the case above, and none of the four are required.

Docs only. No code or test changes.

Companion to buildcage/isolated-run#27.
