### PR TITLE
fix: report rendering: job log <details> tags and the restrict-mode title

### DIFF
--- a/docker/explicit/scripts/report-action.node.ts
+++ b/docker/explicit/scripts/report-action.node.ts
@@ -12,7 +12,7 @@ import { createDocker, type Docker } from "#core/lib/docker/client.ts";
 import { buildReportParameters } from "#core/lib/report/parameters.ts";
 import { buildExplicitReportData } from "#core/lib/report/build/explicit.ts";
 import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
-import { renderCommunicationDetails } from "#core/lib/report/render/communication-details.ts";
+import { renderCommunicationDetailsBody } from "#core/lib/report/render/communication-details.ts";
 import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
 import { errorMessage } from "#core/lib/errors.ts";
 import { wrapLogGroup } from "#core/lib/actions/log.ts";
@@ -70,7 +70,7 @@ async function main(): Promise<void> {
 
   for (const line of wrapLogGroup(
     "HTTP Proxy communication logs",
-    renderCommunicationDetails(report.proxyLogs.builds, report.proxyLogs.denied),
+    renderCommunicationDetailsBody(report.proxyLogs.builds, report.proxyLogs.denied),
   )) {
     console.log(line);
   }

--- a/docker/inspect/scripts/report-action.node.ts
+++ b/docker/inspect/scripts/report-action.node.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
   );
 
   for (const line of wrapLogGroup(
-    "HTTP Proxy communication logs",
+    "Communication details",
     renderInspectDetailsBody(report.timeline, report.startedAt),
   )) {
     console.log(line);

--- a/docker/inspect/scripts/report-action.node.ts
+++ b/docker/inspect/scripts/report-action.node.ts
@@ -11,7 +11,7 @@ import { createDocker } from "#core/lib/docker/client.ts";
 import { buildReportParameters } from "#core/lib/report/parameters.ts";
 import { buildInspectReportData } from "#core/lib/report/build/inspect.ts";
 import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
-import { renderInspectDetails } from "#core/lib/report/render/inspect-details.ts";
+import { renderInspectDetailsBody } from "#core/lib/report/render/inspect-details.ts";
 import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
 import { writeTrafficFile, buildTrafficRecords } from "#core/lib/report/outcome/traffic-output.ts";
 import { errorMessage } from "#core/lib/errors.ts";
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
 
   for (const line of wrapLogGroup(
     "HTTP Proxy communication logs",
-    renderInspectDetails(report.timeline, report.startedAt),
+    renderInspectDetailsBody(report.timeline, report.startedAt),
   )) {
     console.log(line);
   }

--- a/src/core/lib/report/render/communication-details.test.ts
+++ b/src/core/lib/report/render/communication-details.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
-import { renderCommunicationDetails } from "./communication-details.ts";
+import {
+  renderCommunicationDetails,
+  renderCommunicationDetailsBody,
+} from "./communication-details.ts";
 
 function wrap(body: string) {
   return "\n<details>\n<summary>💬 Communication details</summary>\n\n" + body + "</details>\n";
@@ -192,6 +195,17 @@ describe("renderCommunicationDetails", () => {
       const md = renderCommunicationDetails([[vertex]], []);
       expect(md).toMatch(/\* RUN echo hello-world\.txt\n/);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapLogGroup skips emitting a ::group:: at all when handed "" -- the
+// property that actually matters here, not the tag shape of a non-empty one.
+// ---------------------------------------------------------------------------
+describe("renderCommunicationDetailsBody", () => {
+  it("renders nothing at all when there is nothing to show", () => {
+    expect(renderCommunicationDetailsBody([], [])).toBe("");
+    expect(renderCommunicationDetailsBody(null, null)).toBe("");
   });
 });
 

--- a/src/core/lib/report/render/communication-details.ts
+++ b/src/core/lib/report/render/communication-details.ts
@@ -19,12 +19,27 @@ export function renderCommunicationDetails(
   builds: VertexAllowedEntry[][] | null | undefined,
   deniedTimeline: DeniedEntry[] | null | undefined,
 ): string {
+  const body = renderCommunicationDetailsBody(builds, deniedTimeline);
+  if (!body) return "";
+  return `\n<details>\n<summary>💬 Communication details</summary>\n\n${body}</details>\n`;
+}
+
+/**
+ * The same content with no `<details>`/`<summary>` wrapper, or "" if
+ * there's nothing to show -- for a plain-text destination like the job log,
+ * where those HTML tags render as literal text rather than a collapsible
+ * section (unlike the Job Summary, which is what the wrapper is for).
+ */
+export function renderCommunicationDetailsBody(
+  builds: VertexAllowedEntry[][] | null | undefined,
+  deniedTimeline: DeniedEntry[] | null | undefined,
+): string {
   const nonEmptyBuilds = (builds || []).filter((b) => b && b.length > 0);
   const hasVertexLog = nonEmptyBuilds.length > 0;
   const hasDenied = deniedTimeline && deniedTimeline.length > 0;
   if (!hasVertexLog && !hasDenied) return "";
 
-  let md = "\n<details>\n<summary>💬 Communication details</summary>\n\n";
+  let md = "";
 
   if (hasVertexLog) {
     md += "* **✅ Allowed Urls**\n\n";
@@ -44,7 +59,6 @@ export function renderCommunicationDetails(
     md += "\n";
   }
 
-  md += "</details>\n";
   return md;
 }
 

--- a/src/core/lib/report/render/inspect-details.test.ts
+++ b/src/core/lib/report/render/inspect-details.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts";
-import { renderInspectDetails } from "./inspect-details.ts";
+import { renderInspectDetails, renderInspectDetailsBody } from "./inspect-details.ts";
 import type { TrafficEvent } from "#core/lib/log/traffic-event.ts";
 
 const t = 1787471975;
@@ -166,6 +166,16 @@ describe("renderInspectDetails elapsed time", () => {
     );
     expect(md.includes("00:00.000:")).toBe(false);
     expect(md.includes("Z:")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapLogGroup skips emitting a ::group:: at all when handed "" -- the
+// property that actually matters here, not the tag shape of a non-empty one.
+// ---------------------------------------------------------------------------
+describe("renderInspectDetailsBody", () => {
+  it("renders nothing at all when there was no traffic", () => {
+    expect(renderInspectDetailsBody([], t)).toBe("");
   });
 });
 

--- a/src/core/lib/report/render/inspect-details.ts
+++ b/src/core/lib/report/render/inspect-details.ts
@@ -21,14 +21,16 @@ export function renderInspectDetails(
 ): string {
   const body = renderInspectDetailsBody(timeline, startedAt);
   if (!body) return "";
-  return `\n<details>\n<summary>💬 Communication details</summary>\n\n${body}</details>\n`;
+  // A fenced block, so URLs need no markdown escaping and stay copy-pastable.
+  return `\n<details>\n<summary>💬 Communication details</summary>\n\n\`\`\`\n${body}\`\`\`\n\n</details>\n`;
 }
 
 /**
- * The same content with no `<details>`/`<summary>` wrapper, or "" if
- * there's nothing to show -- for a plain-text destination like the job log,
- * where those HTML tags render as literal text rather than a collapsible
- * section (unlike the Job Summary, which is what the wrapper is for).
+ * The same content with no `<details>`/`<summary>` wrapper and no fenced
+ * code block, or "" if there's nothing to show -- for a plain-text
+ * destination like the job log, where both would render as literal text
+ * rather than the collapsible, syntax-highlighted section they give the
+ * Job Summary.
  */
 export function renderInspectDetailsBody(
   timeline: TrafficEvent[],
@@ -39,11 +41,7 @@ export function renderInspectDetailsBody(
   );
   if (shown.length === 0) return "";
 
-  // A fenced block, so URLs need no markdown escaping and stay copy-pastable.
-  let md = "```\n";
-  for (const event of shown) md += `${renderEvent(event, startedAt)}\n`;
-  md += "```\n\n";
-  return md;
+  return shown.map((event) => renderEvent(event, startedAt)).join("\n") + "\n";
 }
 
 function renderEvent(event: TrafficEvent, startedAt: number | undefined): string {

--- a/src/core/lib/report/render/inspect-details.ts
+++ b/src/core/lib/report/render/inspect-details.ts
@@ -19,17 +19,30 @@ export function renderInspectDetails(
   timeline: TrafficEvent[],
   startedAt: number | undefined,
 ): string {
+  const body = renderInspectDetailsBody(timeline, startedAt);
+  if (!body) return "";
+  return `\n<details>\n<summary>💬 Communication details</summary>\n\n${body}</details>\n`;
+}
+
+/**
+ * The same content with no `<details>`/`<summary>` wrapper, or "" if
+ * there's nothing to show -- for a plain-text destination like the job log,
+ * where those HTML tags render as literal text rather than a collapsible
+ * section (unlike the Job Summary, which is what the wrapper is for).
+ */
+export function renderInspectDetailsBody(
+  timeline: TrafficEvent[],
+  startedAt: number | undefined,
+): string {
   const shown = timeline.filter(
     (e) => (e.protocol !== "dns" || e.action === "block") && !isRedundantBlockedDns(e, timeline),
   );
   if (shown.length === 0) return "";
 
-  let md = "\n<details>\n<summary>💬 Communication details</summary>\n\n";
   // A fenced block, so URLs need no markdown escaping and stay copy-pastable.
-  md += "```\n";
+  let md = "```\n";
   for (const event of shown) md += `${renderEvent(event, startedAt)}\n`;
   md += "```\n\n";
-  md += "</details>\n";
   return md;
 }
 

--- a/src/core/lib/report/render/render-report-markdown.test.ts
+++ b/src/core/lib/report/render/render-report-markdown.test.ts
@@ -38,9 +38,10 @@ describe("renderReportMarkdown — transparent", () => {
     logLooksPlausible: true,
   };
 
-  it("renders the restrict-mode heading and Allowed Hosts table", () => {
+  it("renders a bare restrict-mode title, since that is the day-to-day mode", () => {
     const md = renderReportMarkdown({ ...base, passed: [allowedRow] }, "buildcage/docker", "v2");
-    expect(md).toMatch(/## Outbound Traffic Report \(restrict mode\)/);
+    expect(md).toMatch(/^## Outbound Traffic Report\n/);
+    assertNotMatch(md, /restrict mode\)/);
     expect(md).toMatch(/### ✅ Allowed Hosts/);
     expect(md).toMatch(/good\.com/);
   });
@@ -51,6 +52,7 @@ describe("renderReportMarkdown — transparent", () => {
       "buildcage/docker",
       "v2",
     );
+    expect(md).toMatch(/^## Outbound Traffic Report \(audit mode\)\n/);
     expect(md).toMatch(/### 📋 Audited Hosts/);
     expect(md).toMatch(/Switch to restrict mode/);
   });
@@ -102,7 +104,7 @@ describe("renderReportMarkdown — transparent", () => {
     const md = renderReportMarkdown(base, "buildcage/docker", "v2", {
       title: "Outbound Traffic Report — npm install",
     });
-    expect(md).toMatch(/^## Outbound Traffic Report — npm install \(restrict mode\)/);
+    expect(md).toMatch(/^## Outbound Traffic Report — npm install\n/);
   });
 
   it("adds an Expected column marking known_blocked_rules matches when set", () => {

--- a/src/core/lib/report/render/render-report-markdown.ts
+++ b/src/core/lib/report/render/render-report-markdown.ts
@@ -25,7 +25,10 @@ export function renderReportMarkdown(
   const showExpected = report.parameters.knownBlockedRules.length > 0;
   const heading = isAudit ? "📋 Audited Hosts" : "✅ Allowed Hosts";
 
-  let markdown = `## ${title} (${report.parameters.mode} mode)\n\n`;
+  // restrict is what a real run normally uses day to day, so its heading
+  // stays bare; audit is the occasional, deliberately-different mode and
+  // says so, the same way the heading below calls out "Audited" vs "Allowed".
+  let markdown = `## ${title}${isAudit ? " (audit mode)" : ""}\n\n`;
 
   if (report.passed.length > 0) {
     markdown += `### ${heading}\n\n` + renderHostTable(report.passed) + "\n";


### PR DESCRIPTION
## Summary
Three independent fixes to the report renderer, unrelated except for sharing the same files: the job log's own communication-details section was showing raw, unrendered markdown syntax (`<details>` tags, and inspect's fenced code block) meant for the Job Summary; inspect's job-log group title didn't fit it as well as it fits explicit; and the report title repeated "(restrict mode)" on every run even though restrict is the everyday mode.

## Changes
- The job log's communication-details group now prints only the inner content; the `<details>`/`<summary>` wrapper and, for `inspect`, the fenced code block stay Job-Summary-only, since the job log renders plain text, not markdown.
- `inspect`'s job-log group is retitled "Communication details", matching the Job Summary's own heading. `explicit` keeps "HTTP Proxy communication logs", which fits it: unlike `inspect`, it is an explicit HTTP proxy and its log holds no DNS entries.
- The report title drops the "(restrict mode)" suffix; audit keeps its "(audit mode)" suffix, being the occasional, deliberately different mode. Applies to every engine, since they all share this renderer.

## Test Plan
- [x] The job log's rendered output for `explicit` and `inspect` no longer contains literal `<details>`/`<summary>` text, and `inspect`'s no longer contains a literal ` ``` ` fence either, while the Job Summary output for both is unchanged.
- [x] `inspect`'s job-log group is titled "Communication details"; `explicit`'s is unchanged, still "HTTP Proxy communication logs".
- [x] A restrict-mode report renders a bare "Outbound Traffic Report" title; an audit-mode report still renders "Outbound Traffic Report (audit mode)" — checked across every engine that shares this renderer.