### PR TITLE
fix: scope allow_tls_rules passthrough by port, not SNI alone

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^docker/transparent/Dockerfile$/"],
+      "managerFilePatterns": ["/^docker/transparent/Dockerfile$/", "/^docker/inspect/Dockerfile$/"],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\nARG CNI_VERSION=(?<currentValue>v[\\d.]+)"
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\nARG CNI_VERSION=(?<currentValue>v[\\d.]+)",
+        "# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\nARG COREDNS_VERSION=(?<currentValue>[\\d.]+)"
       ]
     },
     {

--- a/src/core/lib/acl/haproxy-config.test.ts
+++ b/src/core/lib/acl/haproxy-config.test.ts
@@ -369,6 +369,15 @@ describe("passthrough", () => {
     ).toBe(true);
   });
 
+  it("also scopes the early do-resolve trigger by port, not just the backend selection", () => {
+    // Regression: this used to set txn.tlsrule from the SNI ACL alone, so an
+    // SNI matching db.example.com on a *different* port than the rule names
+    // still triggered do-resolve/set-dst here -- overwriting the connection's
+    // destination before the inspected path ever saw it -- even though
+    // txn.pass (gated on sni+port together) correctly never fired for it.
+    expect(config.includes("set-var(txn.tlsrule) int(1) if tls0_sni tls0_port")).toBe(true);
+  });
+
   it("runs every content rule before the accept that ends their evaluation", () => {
     // `tcp-request content accept` stops the rest of the content rules, so a
     // set-var or do-resolve placed after it never runs at all -- silently, and

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -215,7 +215,15 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
       // grouping: `a or b !c` reads as `a or (b and !c)`.
       l.push("");
       for (const host of tlsHosts) {
-        l.push(`    tcp-request content set-var(txn.tlsrule) int(1) if ${host.id}_sni`);
+        // Ports scope a tls rule (see the ip0/tls0 comment above): without
+        // the port ACL here too, an SNI matching a port-scoped rule on a
+        // *different* port would still set txn.tlsrule, triggering an early
+        // do-resolve/set-dst that overwrites the connection's destination
+        // before the inspected path ever sees it, even though txn.pass
+        // (gated on sni+port together) correctly never fires for it.
+        l.push(
+          `    tcp-request content set-var(txn.tlsrule) int(1) if ${host.id}_sni${host.port ? ` ${host.id}_port` : ""}`,
+        );
       }
       l.push(
         "    tcp-request content do-resolve(txn.dst,buildcage,ipv4) req.ssl_sni,lower " +

--- a/src/core/lib/log/inspect.ts
+++ b/src/core/lib/log/inspect.ts
@@ -55,9 +55,11 @@ function actionFor(refused: boolean, isAudit: boolean): TrafficAction {
   return isAudit ? "audit" : "allow";
 }
 
+const URL_AUTHORITY = /^https?:\/\/([^/?#]+)/;
+
 /** The host half of an absolute URL's authority, without its port. */
 function hostOf(url: string): string {
-  const match = /^https?:\/\/([^/?#]+)/.exec(url);
+  const match = URL_AUTHORITY.exec(url);
   if (!match) return url;
   const authority = match[1];
   const colon = authority.lastIndexOf(":");

--- a/src/core/lib/report/build/inspect.ts
+++ b/src/core/lib/report/build/inspect.ts
@@ -40,8 +40,13 @@ export async function buildInspectReportData(
   parameters: GenReportParameters,
 ): Promise<InspectReportData> {
   const isAudit = parameters.mode === "audit";
-  const { events: proxyEvents, startedAt } = await scanInspectLog(proxyLines, isAudit);
-  const dnsEvents = await scanInspectDnsLog(dnsLines, isAudit);
+  // Independent inputs (separate `docker exec` log streams, no data
+  // dependency between them) -- read concurrently rather than paying their
+  // combined latency serially.
+  const [{ events: proxyEvents, startedAt }, dnsEvents] = await Promise.all([
+    scanInspectLog(proxyLines, isAudit),
+    scanInspectDnsLog(dnsLines, isAudit),
+  ]);
 
   const timeline = [...proxyEvents, ...dnsEvents].sort((a, b) => a.time - b.time);
 


### PR DESCRIPTION
## Summary
`allow_tls_rules` passthrough entries can name a specific port, but a connection on any other port for the same hostname was still treated as passthrough-eligible internally, letting an early destination resolution run and overwrite the connection's destination before the normal inspected-path checks ever ran — even though the connection was never actually passed through undecrypted. Alongside it, two small maintenance fixes: Renovate wasn't tracking two dependency versions used by the inspect engine's Dockerfile, and inspect-mode report generation read its two log sources one after another instead of concurrently.

## Changes
- A TLS connection whose SNI matches an `allow_tls_rules` entry, but on a port the rule doesn't name, is no longer treated as passthrough-eligible at all; it now goes straight to the ordinary inspected path and is judged by the usual URL/host rules.
- Renovate now tracks CNI_VERSION in `docker/inspect/Dockerfile` (previously only tracked in `docker/transparent/Dockerfile`) and now also tracks COREDNS_VERSION, which had no automated tracking before.
- Inspect-mode report generation reads the proxy log and the DNS log concurrently instead of one after the other, shortening report generation time.

## Test Plan
- [x] Unit test asserting the generated HAProxy config scopes the passthrough trigger by port, not SNI alone — fails against the pre-fix config generator.