### PR TITLE
fix: keep injecting NODE_EXTRA_CA_CERTS/DENO_CERT when a build has no system CA store

### DIFF
--- a/docker/inspect/buildkit-runc/inject.go
+++ b/docker/inspect/buildkit-runc/inject.go
@@ -122,14 +122,23 @@ func inject(bundle string, ca []byte) (func(), error) {
 		return nil, err
 	}
 
-	systemStore, systemStorePath, err := findSystemStore(s.rootfs)
-	if err != nil {
-		return nil, err
+	// A store's absence is not fatal: only the variables that need one
+	// (pointAtSystemStore below, and the store itself as an append target)
+	// are affected. NODE_EXTRA_CA_CERTS and DENO_CERT get their own file
+	// regardless, so a scratch/distroless image, or a base before
+	// ca-certificates is installed, still gets those working.
+	systemStore, systemStorePath, storeErr := findSystemStore(s.rootfs)
+	haveSystemStore := storeErr == nil
+	if !haveSystemStore {
+		logf("no system CA store in %s (%v); only variables independent of it will be set", s.rootfs, storeErr)
 	}
 
 	// Every bundle the CA has to go into, keyed by resolved path so a file
 	// named by two variables is only written once.
-	targets := map[string]bool{systemStore: true}
+	targets := map[string]bool{}
+	if haveSystemStore {
+		targets[systemStore] = true
+	}
 	newEnv := map[string]string{}
 	createdOwnCA := ""
 
@@ -150,6 +159,9 @@ func inject(bundle string, ca []byte) (func(), error) {
 		switch variable.whenUnset {
 		case leaveUnset:
 		case pointAtSystemStore:
+			if !haveSystemStore {
+				continue
+			}
 			newEnv[variable.name] = systemStorePath
 		case pointAtOwnCA:
 			resolved, err := resolveInRoot(s.rootfs, ownCAPath)

--- a/docker/inspect/buildkit-runc/inject_test.go
+++ b/docker/inspect/buildkit-runc/inject_test.go
@@ -43,6 +43,33 @@ func toAny(env []string) []any {
 	return out
 }
 
+// newBundleNoStore lays out a bundle with no CA store at all under
+// rootfs/etc/ssl/certs — the node:*-slim shape: no OS trust store, only
+// Node's own bundled roots, which findSystemStore cannot find.
+func newBundleNoStore(t *testing.T, env []string) (bundle, rootfs string) {
+	t.Helper()
+	bundle = t.TempDir()
+	rootfs = filepath.Join(bundle, "rootfs")
+	// /etc exists, as it does in any real base image (passwd, hostname, ...);
+	// only etc/ssl/certs and its siblings are absent, which is what actually
+	// makes findSystemStore fail.
+	if err := os.MkdirAll(filepath.Join(rootfs, "etc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := map[string]any{
+		"root":    map[string]any{"path": "rootfs"},
+		"process": map[string]any{"env": toAny(env)},
+	}
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "config.json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return bundle, rootfs
+}
+
 func loadEnv(t *testing.T, bundle string) map[string]string {
 	t.Helper()
 	s, err := loadSpec(bundle)
@@ -151,5 +178,47 @@ func TestInjectRestoreUndoesTheFilesOnly(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(rootfs, strings.TrimPrefix(ownCAPath, "/"))); !os.IsNotExist(err) {
 		t.Fatalf("own CA file still present: %v", err)
+	}
+}
+
+
+// A base image with no CA store of its own (node:*-slim before
+// ca-certificates is installed, or a scratch/distroless image) must not lose
+// the additive variables just because the system store is missing: they get
+// their own file regardless of it. This is the corepack/node:22-slim failure
+// mode under the inspect engine.
+func TestInjectWithoutSystemStoreStillSetsAdditiveVariables(t *testing.T) {
+	bundle, rootfs := newBundleNoStore(t, []string{"PATH=/usr/bin"})
+
+	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env := loadEnv(t, bundle)
+
+	for _, additive := range []string{"NODE_EXTRA_CA_CERTS", "DENO_CERT"} {
+		if env[additive] != ownCAPath {
+			t.Errorf("%s = %q, want %q", additive, env[additive], ownCAPath)
+		}
+	}
+	own, err := os.ReadFile(filepath.Join(rootfs, strings.TrimPrefix(ownCAPath, "/")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(own) != "BUILDCAGE-CA" {
+		t.Fatalf("own CA file = %q", own)
+	}
+
+	// Nowhere to point these: no system store exists for them to replace.
+	for _, replacing := range []string{"REQUESTS_CA_BUNDLE", "PIP_CERT", "SSL_CERT_FILE"} {
+		if _, set := env[replacing]; set {
+			t.Errorf("%s should be left unset; there is no system store to point it at", replacing)
+		}
+	}
+
+	restore()
+	if _, err := os.Stat(filepath.Join(rootfs, strings.TrimPrefix(ownCAPath, "/"))); !os.IsNotExist(err) {
+		t.Fatalf("own CA file still present after restore: %v", err)
 	}
 }

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -486,12 +486,25 @@ integrity-bound materials.
   roots for everything else.
 - **Injection is computed once, from the rootfs as it stood when the step started.** The wrapper
   does not revisit that decision as the step's script runs, so creating the system store and relying
-  on it in the same `RUN` step does not work: `RUN apt-get install -y ca-certificates && pip install
-requests` still fails, because `PIP_CERT` was already fixed as unset before `apt-get` had created
-  anything for it to point at. Splitting it into two steps fixes it — the store `apt-get` creates in
-  the first is part of the rootfs the second one starts from, so that step's own injection finds it.
+  on it in the same `RUN` step does not work. Installing `ca-certificates` and then running `pip` in
+  one step still fails, because `PIP_CERT` was already fixed as unset before `apt-get` had created
+  anything for it to point at:
+
+  ```dockerfile
+  RUN apt-get install -y ca-certificates && pip install requests   # still fails
+  ```
+
+  Splitting it into two steps fixes it — the store `apt-get` creates in the first is part of the
+  rootfs the second one starts from, so that step's own injection finds it:
+
+  ```dockerfile
+  RUN apt-get install -y ca-certificates
+  RUN pip install requests   # this step's injection sees the store the previous one created
+  ```
+
   `NODE_EXTRA_CA_CERTS`/`DENO_CERT` are unaffected: their file is written unconditionally at the same
   instant regardless of what the store looks like.
+
 - **`allow_tls_rules` and `allowed_ip_rules` are uninspected by design.** They are recorded, with a
   byte count, but nothing inside them is.
 - **Query strings are kept in the log**, so a credential passed as a query parameter is recorded

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -484,6 +484,14 @@ integrity-bound materials.
   in a layer with no system store at all — the common case is a `node:*-slim` image, which never
   carries one, and where the gap would otherwise go unnoticed because Node reads its own bundled
   roots for everything else.
+- **Injection is computed once, from the rootfs as it stood when the step started.** The wrapper
+  does not revisit that decision as the step's script runs, so creating the system store and relying
+  on it in the same `RUN` step does not work: `RUN apt-get install -y ca-certificates && pip install
+requests` still fails, because `PIP_CERT` was already fixed as unset before `apt-get` had created
+  anything for it to point at. Splitting it into two steps fixes it — the store `apt-get` creates in
+  the first is part of the rootfs the second one starts from, so that step's own injection finds it.
+  `NODE_EXTRA_CA_CERTS`/`DENO_CERT` are unaffected: their file is written unconditionally at the same
+  instant regardless of what the store looks like.
 - **`allow_tls_rules` and `allowed_ip_rules` are uninspected by design.** They are recorded, with a
   byte count, but nothing inside them is.
 - **Query strings are kept in the log**, so a credential passed as a query parameter is recorded

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -473,11 +473,17 @@ integrity-bound materials.
   CA, but a tool that consults none of them cannot be reached. The JVM (Java, Kotlin, Scala, ...) is
   one such case: it only reads its own `cacerts` file, which nothing here points anywhere, so it is
   not supported yet.
-- **The CA is added to a store that already exists, not created.** A `scratch`/distroless image, or a
-  bare `debian:bookworm-slim` before `ca-certificates` is installed, has nothing for the wrapper to
-  add to. This only matters to a tool that needs TLS trust for something: `apt`'s own archive is
-  plain HTTP by default and authenticates by GPG signature, not TLS, so installing `ca-certificates`
-  itself needs no CA at all — the gap only shows up once something _else_ in that layer needs one.
+- **The system store is added to if one already exists, never created.** A `scratch`/distroless
+  image, or a bare `debian:bookworm-slim` before `ca-certificates` is installed, has nothing for the
+  wrapper to add to. This only affects the variables that mean "the system store" — `REQUESTS_CA_BUNDLE`,
+  `PIP_CERT`, `SSL_CERT_FILE` — and anything reading the store directly (`apt`, `curl`) once
+  something in that layer needs TLS trust: `apt`'s own archive is plain HTTP by default and
+  authenticates by GPG signature, not TLS, so installing `ca-certificates` itself needs no CA at all.
+  `NODE_EXTRA_CA_CERTS` and `DENO_CERT` are unaffected either way: they add to a tool's own built-in
+  set through a dedicated file the wrapper writes itself, so Node and Deno trust the proxy's CA even
+  in a layer with no system store at all — the common case is a `node:*-slim` image, which never
+  carries one, and where the gap would otherwise go unnoticed because Node reads its own bundled
+  roots for everything else.
 - **`allow_tls_rules` and `allowed_ip_rules` are uninspected by design.** They are recorded, with a
   byte count, but nothing inside them is.
 - **Query strings are kept in the log**, so a credential passed as a query parameter is recorded


### PR DESCRIPTION
## Summary

- `inject()` in the `inspect` engine's `buildkit-runc` wrapper aborted entirely when the rootfs had no system CA store (`findSystemStore` error), which also skipped setting `NODE_EXTRA_CA_CERTS`/`DENO_CERT` even though those don't need one.
- Base images like `node:*-slim` have no OS CA store but Node itself does TLS fine normally (it uses its own bundled roots), so this only surfaced once the `inspect` engine tried to make the step trust the proxy's CA — e.g. `corepack enable` failing with `SELF_SIGNED_CERT_IN_CHAIN`.
- Now only the variables that actually need the system store (`REQUESTS_CA_BUNDLE`, `PIP_CERT`, `SSL_CERT_FILE`, and the store itself as an append target) are skipped when it's absent; `NODE_EXTRA_CA_CERTS`/`DENO_CERT` still get their own dedicated CA file regardless.
- Updated `docs/inspect-engine.md`'s Limitations section to describe the new, narrower scope of this gap.
