### PR TITLE
fix: fall back all CA-trust variables to proxy-CA-only trust when there is no system CA store

### DIFF
--- a/docker/inspect/buildkit-runc/inject.go
+++ b/docker/inspect/buildkit-runc/inject.go
@@ -11,23 +11,31 @@ import (
 // tool needs one of its own. Removed again when the step ends.
 const ownCAPath = "/etc/buildcage-ca.pem"
 
-// How each variable is treated when the image or Dockerfile did not set it.
+// How each variable is treated when the image or Dockerfile did not set it,
+// and what it falls back to when there is no system CA store to work with.
 //
-// The distinction is what the variable means to the tool that reads it:
-// NODE_EXTRA_CA_CERTS and DENO_CERT are added to a built-in set, so pointing
-// them at a file holding only this CA leaves everything else trusted. The
-// others replace the bundle outright, so pointing them at that file would
-// leave the tool trusting nothing but this CA. Those are pointed at the
-// system store instead, which by then already carries it, and curl needs
-// nothing at all because that store is what it reads by default.
+// The distinction between the kinds is what the variable means to the tool
+// that reads it: NODE_EXTRA_CA_CERTS and DENO_CERT are added to a built-in
+// set, so pointing them at a file holding only this CA leaves everything
+// else trusted, store or no store. The others replace the bundle outright:
+// with a store, they are pointed at it (which by then carries the CA plus
+// the real public roots); with no store there is nothing left that still
+// carries those roots, so they fall back to the same proxy-CA-only file
+// NODE_EXTRA_CA_CERTS/DENO_CERT use. That covers ordinary HTTP(S) traffic
+// (inspect re-signs all of it with this same CA) but not a passthrough
+// connection's real certificate — see "No system CA store" in
+// docs/inspect-engine.md for exactly which requests that leaves unable to
+// verify.
 type unsetBehaviour int
 
 const (
-	// Leave it alone: the tool already reads the system store.
+	// The tool reads the system store on its own; with no store, falls back
+	// to proxy-CA-only trust the same way pointAtSystemStore does.
 	leaveUnset unsetBehaviour = iota
 	// Point at a file holding only this CA, added to the tool's own set.
 	pointAtOwnCA
-	// Point at the system store, which replaces the tool's bundle.
+	// Point at the system store, which replaces the tool's bundle; with no
+	// store, falls back to the same proxy-CA-only file as pointAtOwnCA.
 	pointAtSystemStore
 )
 
@@ -122,15 +130,13 @@ func inject(bundle string, ca []byte) (func(), error) {
 		return nil, err
 	}
 
-	// A store's absence is not fatal: only the variables that need one
-	// (pointAtSystemStore below, and the store itself as an append target)
-	// are affected. NODE_EXTRA_CA_CERTS and DENO_CERT get their own file
-	// regardless, so a scratch/distroless image, or a base before
-	// ca-certificates is installed, still gets those working.
+	// A store's absence is not fatal: the store itself is simply not an
+	// append target, and every otherwise-unset variable falls back to the
+	// proxy-CA-only file instead (see the unsetBehaviour comment above).
 	systemStore, systemStorePath, storeErr := findSystemStore(s.rootfs)
 	haveSystemStore := storeErr == nil
 	if !haveSystemStore {
-		logf("no system CA store in %s (%v); only variables independent of it will be set", s.rootfs, storeErr)
+		logf("no system CA store in %s (%v); falling back to proxy-CA-only trust", s.rootfs, storeErr)
 	}
 
 	// Every bundle the CA has to go into, keyed by resolved path so a file
@@ -141,6 +147,30 @@ func inject(bundle string, ca []byte) (func(), error) {
 	}
 	newEnv := map[string]string{}
 	createdOwnCA := ""
+
+	// setOwnCA points variableName at ownCAPath, writing it once and sharing
+	// it across every variable that falls back to it.
+	setOwnCA := func(variableName string) {
+		resolved, err := resolveInRoot(s.rootfs, ownCAPath)
+		if err != nil {
+			logf("cannot place %s: %v", ownCAPath, err)
+			return
+		}
+		// More than one variable can take this path, and all of them share
+		// the file: only the first to get here writes it.
+		if createdOwnCA == "" {
+			if _, err := os.Stat(resolved); err == nil {
+				logf("%s already exists; not setting %s", ownCAPath, variableName)
+				return
+			}
+			if err := os.WriteFile(resolved, ca, 0o644); err != nil {
+				logf("cannot write %s: %v", ownCAPath, err)
+				return
+			}
+			createdOwnCA = resolved
+		}
+		newEnv[variableName] = ownCAPath
+	}
 
 	for _, variable := range caVariables {
 		if value, set := s.env[variable.name]; set && value != "" {
@@ -158,31 +188,17 @@ func inject(bundle string, ca []byte) (func(), error) {
 		}
 		switch variable.whenUnset {
 		case leaveUnset:
-		case pointAtSystemStore:
 			if !haveSystemStore {
-				continue
+				setOwnCA(variable.name)
 			}
-			newEnv[variable.name] = systemStorePath
+		case pointAtSystemStore:
+			if haveSystemStore {
+				newEnv[variable.name] = systemStorePath
+			} else {
+				setOwnCA(variable.name)
+			}
 		case pointAtOwnCA:
-			resolved, err := resolveInRoot(s.rootfs, ownCAPath)
-			if err != nil {
-				logf("cannot place %s: %v", ownCAPath, err)
-				continue
-			}
-			// More than one variable takes this branch, and all of them share
-			// the file: only the first to get here writes it.
-			if createdOwnCA == "" {
-				if _, err := os.Stat(resolved); err == nil {
-					logf("%s already exists; not setting %s", ownCAPath, variable.name)
-					continue
-				}
-				if err := os.WriteFile(resolved, ca, 0o644); err != nil {
-					logf("cannot write %s: %v", ownCAPath, err)
-					continue
-				}
-				createdOwnCA = resolved
-			}
-			newEnv[variable.name] = ownCAPath
+			setOwnCA(variable.name)
 		}
 	}
 

--- a/docker/inspect/buildkit-runc/inject_test.go
+++ b/docker/inspect/buildkit-runc/inject_test.go
@@ -181,13 +181,15 @@ func TestInjectRestoreUndoesTheFilesOnly(t *testing.T) {
 	}
 }
 
-
 // A base image with no CA store of its own (node:*-slim before
 // ca-certificates is installed, or a scratch/distroless image) must not lose
-// the additive variables just because the system store is missing: they get
-// their own file regardless of it. This is the corepack/node:22-slim failure
-// mode under the inspect engine.
-func TestInjectWithoutSystemStoreStillSetsAdditiveVariables(t *testing.T) {
+// every variable just because the system store is missing: all six fall back
+// to the same proxy-CA-only file. This is the corepack/node:22-slim and
+// apt-install-then-curl/debian:bookworm-slim failure modes under the inspect
+// engine — see docs/inspect-engine.md's "No system CA store" for what this
+// fallback does and does not cover (ordinary MITM'd traffic works; a
+// passthrough connection's real certificate still does not verify).
+func TestInjectWithoutSystemStoreFallsBackToOwnCAForEveryVariable(t *testing.T) {
 	bundle, rootfs := newBundleNoStore(t, []string{"PATH=/usr/bin"})
 
 	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
@@ -197,9 +199,12 @@ func TestInjectWithoutSystemStoreStillSetsAdditiveVariables(t *testing.T) {
 
 	env := loadEnv(t, bundle)
 
-	for _, additive := range []string{"NODE_EXTRA_CA_CERTS", "DENO_CERT"} {
-		if env[additive] != ownCAPath {
-			t.Errorf("%s = %q, want %q", additive, env[additive], ownCAPath)
+	for _, variable := range []string{
+		"NODE_EXTRA_CA_CERTS", "DENO_CERT",
+		"CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "PIP_CERT", "SSL_CERT_FILE",
+	} {
+		if env[variable] != ownCAPath {
+			t.Errorf("%s = %q, want %q", variable, env[variable], ownCAPath)
 		}
 	}
 	own, err := os.ReadFile(filepath.Join(rootfs, strings.TrimPrefix(ownCAPath, "/")))
@@ -208,13 +213,6 @@ func TestInjectWithoutSystemStoreStillSetsAdditiveVariables(t *testing.T) {
 	}
 	if string(own) != "BUILDCAGE-CA" {
 		t.Fatalf("own CA file = %q", own)
-	}
-
-	// Nowhere to point these: no system store exists for them to replace.
-	for _, replacing := range []string{"REQUESTS_CA_BUNDLE", "PIP_CERT", "SSL_CERT_FILE"} {
-		if _, set := env[replacing]; set {
-			t.Errorf("%s should be left unset; there is no system store to point it at", replacing)
-		}
 	}
 
 	restore()

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -473,37 +473,47 @@ integrity-bound materials.
   CA, but a tool that consults none of them cannot be reached. The JVM (Java, Kotlin, Scala, ...) is
   one such case: it only reads its own `cacerts` file, which nothing here points anywhere, so it is
   not supported yet.
-- **The system store is added to if one already exists, never created.** A `scratch`/distroless
-  image, or a bare `debian:bookworm-slim` before `ca-certificates` is installed, has nothing for the
-  wrapper to add to. This only affects the variables that mean "the system store" — `REQUESTS_CA_BUNDLE`,
-  `PIP_CERT`, `SSL_CERT_FILE` — and anything reading the store directly (`apt`, `curl`) once
-  something in that layer needs TLS trust: `apt`'s own archive is plain HTTP by default and
-  authenticates by GPG signature, not TLS, so installing `ca-certificates` itself needs no CA at all.
-  `NODE_EXTRA_CA_CERTS` and `DENO_CERT` are unaffected either way: they add to a tool's own built-in
-  set through a dedicated file the wrapper writes itself, so Node and Deno trust the proxy's CA even
-  in a layer with no system store at all — the common case is a `node:*-slim` image, which never
-  carries one, and where the gap would otherwise go unnoticed because Node reads its own bundled
-  roots for everything else.
-- **Injection is computed once, from the rootfs as it stood when the step started.** The wrapper
-  does not revisit that decision as the step's script runs, so creating the system store and relying
-  on it in the same `RUN` step does not work. Installing `ca-certificates` and then running `pip` in
-  one step still fails, because `PIP_CERT` was already fixed as unset before `apt-get` had created
-  anything for it to point at:
+- **No system CA store: every variable still gets set, but only to a file that trusts the proxy's
+  own CA — not a passthrough connection's real certificate.** A `scratch`/distroless image, or a
+  bare `debian:bookworm-slim` before `ca-certificates` is installed, has no system store for the
+  wrapper to add the CA to. `NODE_EXTRA_CA_CERTS`, `DENO_CERT`, `CURL_CA_BUNDLE`,
+  `REQUESTS_CA_BUNDLE`, `PIP_CERT` and `SSL_CERT_FILE` are then all pointed at one dedicated file
+  holding only the proxy's own CA, no public roots. That is enough for ordinary HTTP(S) traffic,
+  because `inspect` re-signs all of it with this same CA — but it is **not** enough to verify a
+  connection that presents its real, unmodified certificate: an `allow_tls_rules` or
+  `allowed_ip_rules` passthrough destination, or any other TLS use these variables happen to govern
+  outside of HTTP(S) through the proxy. That request fails certificate verification, and there is no
+  way to tell from the failure alone that the cause is "no store," because the same fallback file is
+  used whether or not one ever shows up.
+
+  This decision is made once, from the rootfs as the step began, and is never revisited as the
+  step's script runs — so installing `ca-certificates` partway through the same step does not
+  change anything for a passthrough connection made later in that same script, even though the
+  store that `apt-get` just created genuinely does have the right roots by then:
 
   ```dockerfile
-  RUN apt-get install -y ca-certificates && pip install requests   # still fails
+  RUN apt-get install -y ca-certificates && \
+      curl https://internal.example.com/pkg.tgz -o pkg.tgz   # allow_tls_rules passthrough: still fails,
+                                                                # CURL_CA_BUNDLE was already fixed to the
+                                                                # proxy-CA-only fallback before apt-get ran
   ```
 
-  Splitting it into two steps fixes it — the store `apt-get` creates in the first is part of the
-  rootfs the second one starts from, so that step's own injection finds it:
+  The same one-shot timing is what makes ordinary (inspected) traffic in that same step work,
+  though — `CURL_CA_BUNDLE` there is the proxy-CA-only fallback from the moment the step starts, so
+  a plain `curl` of an `inspect`-terminated URL right after `apt-get install ca-certificates` in one
+  `RUN` succeeds without needing a second step.
+
+  What a passthrough connection in a store-less step actually needs is a real store already in
+  place _before_ the step starts, so its variables get pointed at that store (public roots plus the
+  proxy's CA) instead of the fallback:
 
   ```dockerfile
   RUN apt-get install -y ca-certificates
-  RUN pip install requests   # this step's injection sees the store the previous one created
+  RUN curl https://internal.example.com/pkg.tgz -o pkg.tgz   # this step starts with a store, so
+                                                                # CURL_CA_BUNDLE points at it (real
+                                                                # roots + the proxy's CA), not at the
+                                                                # proxy-CA-only fallback
   ```
-
-  `NODE_EXTRA_CA_CERTS`/`DENO_CERT` are unaffected: their file is written unconditionally at the same
-  instant regardless of what the store looks like.
 
 - **`allow_tls_rules` and `allowed_ip_rules` are uninspected by design.** They are recorded, with a
   byte count, but nothing inside them is.
@@ -520,16 +530,18 @@ integrity-bound materials.
 
 If a variable below is already set — by the base image or the Dockerfile — the wrapper appends the
 CA to whatever file it already points at, rather than redirecting the variable elsewhere. If it is
-unset, where the wrapper points it depends on what the variable means to the tool that reads it:
-some add to a built-in set, so pointing them at a file holding only this CA leaves everything else
-trusted; others replace the bundle outright, so those are pointed at the system store instead, which
-already carries the CA by then.
+unset and a system CA store exists, where the wrapper points it depends on what the variable means
+to the tool that reads it: some add to a built-in set, so pointing them at a file holding only this
+CA leaves everything else trusted; others replace the bundle outright, so those are pointed at the
+system store instead, which already carries the CA by then. If it is unset and **no** system store
+exists, all six fall back to the same dedicated proxy-CA-only file — see "No system CA store" above
+for exactly what that does and does not cover.
 
-| Variable              | Read by                                                                                                 | If unset                                          |
-| --------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `NODE_EXTRA_CA_CERTS` | Node.js                                                                                                 | Additive — pointed at a file holding only this CA |
-| `DENO_CERT`           | Deno                                                                                                    | Additive — pointed at a file holding only this CA |
-| `CURL_CA_BUNDLE`      | curl                                                                                                    | Left unset — curl already reads the system store  |
-| `REQUESTS_CA_BUNDLE`  | Python `requests`                                                                                       | Replaces the bundle — pointed at the system store |
-| `PIP_CERT`            | pip                                                                                                     | Replaces the bundle — pointed at the system store |
-| `SSL_CERT_FILE`       | OpenSSL, and anything reading it (Go's `crypto/x509` on Unix, Ruby, wget, Rust's `rustls-native-certs`) | Replaces the bundle — pointed at the system store |
+| Variable              | Read by                                                                                                 | If unset, with a store                            | If unset, with no store     |
+| --------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | --------------------------- |
+| `NODE_EXTRA_CA_CERTS` | Node.js                                                                                                 | Additive — pointed at a file holding only this CA | same, store or no store     |
+| `DENO_CERT`           | Deno                                                                                                    | Additive — pointed at a file holding only this CA | same, store or no store     |
+| `CURL_CA_BUNDLE`      | curl                                                                                                    | Left unset — curl already reads the system store  | proxy-CA-only fallback file |
+| `REQUESTS_CA_BUNDLE`  | Python `requests`                                                                                       | Replaces the bundle — pointed at the system store | proxy-CA-only fallback file |
+| `PIP_CERT`            | pip                                                                                                     | Replaces the bundle — pointed at the system store | proxy-CA-only fallback file |
+| `SSL_CERT_FILE`       | OpenSSL, and anything reading it (Go's `crypto/x509` on Unix, Ruby, wget, Rust's `rustls-native-certs`) | Replaces the bundle — pointed at the system store | proxy-CA-only fallback file |


### PR DESCRIPTION
## Summary

- When a `RUN` step's rootfs has no system CA store, `REQUESTS_CA_BUNDLE`/`PIP_CERT`/`SSL_CERT_FILE` were previously left unset entirely (nothing safe to point them at), and `CURL_CA_BUNDLE` was never set at all. This is what let `debian:bookworm-slim` + `apt install ca-certificates ... && curl ...` still fail: `curl` reads whatever the step's own `apt-get` just installed, but that plain store never gets the proxy's CA appended (injection only targets the store found at step start).
- All six CA-trust variables (`NODE_EXTRA_CA_CERTS`, `DENO_CERT`, `CURL_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, `PIP_CERT`, `SSL_CERT_FILE`) now fall back to the same dedicated proxy-CA-only file (`/etc/buildcage-ca.pem`) when no system store exists at step start. This covers ordinary `inspect`-terminated HTTP(S) traffic (the common case, and the two previously-reported failures: `node:*-slim` + corepack, `debian:bookworm-slim` + apt-installed curl).
- This means a real, documented gap remains and is called out explicitly in `docs/inspect-engine.md`: in a step that starts with **no** system store, a passthrough connection (`allow_tls_rules`/`allowed_ip_rules`, undecrypted, real certificate) made via one of these variables still fails certificate verification — even if that same step installs `ca-certificates` earlier in its own script — because the fallback file was fixed before the script started and is never revisited. The fix is a real system store in place *before* the step starts (an earlier, separate `RUN`).
