### PR TITLE
Name the reporting action in the report footer

### DIFF
--- a/src/core/lib/report/render/render-report-markdown.test.ts
+++ b/src/core/lib/report/render/render-report-markdown.test.ts
@@ -70,7 +70,9 @@ describe("renderReportMarkdown — universal", () => {
 
   it("uses the real actionRepo in the footer, not a placeholder", () => {
     const md = renderReportMarkdown(base, "buildcage/docker", "v2");
-    expect(md).toMatch(/Reported by \[Buildcage\]\(https:\/\/github\.com\/buildcage\/docker\)/);
+    expect(md).toMatch(
+      /Reported by \[buildcage\/docker\]\(https:\/\/github\.com\/buildcage\/docker\)/,
+    );
     assertNotMatch(md, /GITHUB_ACTION_REPOSITORY/);
   });
 

--- a/src/core/lib/report/render/render-report-markdown.ts
+++ b/src/core/lib/report/render/render-report-markdown.ts
@@ -66,6 +66,6 @@ export function renderReportMarkdown(
       "\n<sub>*Note: HTTP rules are based on the Host header, HTTPS rules on SNI, and IP rules on the destination IP address.*</sub>\n";
   }
 
-  markdown += `\n*Reported by [Buildcage](https://github.com/${actionRepo})*\n`;
+  markdown += `\n*Reported by [${actionRepo}](https://github.com/${actionRepo})*\n`;
   return markdown;
 }

--- a/src/core/lib/report/render/truncate-communication-details.test.ts
+++ b/src/core/lib/report/render/truncate-communication-details.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, reportResults } from "#core/lib/test/test-shim.ts
 import { truncateForStepSummary } from "./truncate-communication-details.ts";
 
 const HEADER = "## Outbound Traffic Report (restrict mode)\n\n### ✅ Allowed Hosts\n\n";
-const FOOTER = "\n*Reported by [Buildcage](https://github.com/buildcage/docker)*\n";
+const FOOTER = "\n*Reported by [buildcage/docker](https://github.com/buildcage/docker)*\n";
 
 function withCommunicationDetails(lines: string[]): string {
   return (


### PR DESCRIPTION
## Summary
A workflow can run both `buildcage/docker` and `buildcage/isolated-run`, and their reports land side by side in the same Job Summary. Both footers read `Reported by Buildcage`, so there was nothing telling the two reports apart.

The footer now uses the action's own repository as the link text, so this repo's reports say `Reported by buildcage/docker`. The link target is unchanged (`actionRepo`, i.e. `GITHUB_ACTION_REPOSITORY`), so a fork still points at whichever action actually ran.
