### PR TITLE
fix: read s6-log's rotated archives too, so a big build's early traffic isn't dropped from the report

### DIFF
--- a/docker/inspect/files/s6-rc.d/coredns-log/run
+++ b/docker/inspect/files/s6-rc.d/coredns-log/run
@@ -1,6 +1,13 @@
 #!/usr/bin/execlineb -P
-# `1 T dir`, not `T 1 dir`: a timestamp directive applies to the output that
-# follows it, so putting T first stamps stdout and leaves the file bare. The
-# file is what report reads, and a refused name has no other source of time --
-# CoreDNS's log plugin has no timestamp replacement of its own.
-s6-log 1 T /var/log/coredns
+# `s1000000 n100 T dir`, not `T s1000000 n100 dir`: a timestamp directive
+# applies to the output that follows it, so putting T first stamps stdout and
+# leaves the file bare. The file is what report reads, and a refused name has
+# no other source of time -- CoreDNS's log plugin has no timestamp
+# replacement of its own.
+#
+# s/n: rotate current at 1MB (s6-log's own default is ~100KB) and keep 100
+# rotated segments (100MB) rather than the default 10, so a build with a lot
+# of DNS traffic doesn't lose the earliest refusals before report reads them
+# -- report reads every segment, oldest first, so this is a safety margin,
+# not the only thing standing between a big build and a truncated report.
+s6-log s1000000 n100 T /var/log/coredns

--- a/docker/inspect/files/s6-rc.d/haproxy-log/run
+++ b/docker/inspect/files/s6-rc.d/haproxy-log/run
@@ -1,2 +1,8 @@
 #!/usr/bin/execlineb -P
-s6-log 1 /var/log/haproxy
+# s: rotate current at 1MB rather than s6-log's own default of ~100KB, so a
+# build with a lot of traffic doesn't rotate mid-build. n: keep 100 rotated
+# segments (100MB) rather than the default 10, for the same reason. report
+# reads every segment, oldest first, so this isn't the only thing standing
+# between a big build and a truncated report -- but a build that still
+# outgrows this is not a size this tool is meant to handle.
+s6-log s1000000 n100 /var/log/haproxy

--- a/docker/inspect/scripts/report-action.node.ts
+++ b/docker/inspect/scripts/report-action.node.ts
@@ -8,6 +8,7 @@
  */
 import * as core from "@actions/core";
 import { createDocker } from "#core/lib/docker/client.ts";
+import { readRotatedLog } from "#core/lib/docker/rotated-log.ts";
 import { buildReportParameters } from "#core/lib/report/parameters.ts";
 import { buildInspectReportData } from "#core/lib/report/build/inspect.ts";
 import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
@@ -18,8 +19,8 @@ import { errorMessage } from "#core/lib/errors.ts";
 import { wrapLogGroup } from "#core/lib/actions/log.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
 
-const PROXY_LOG = "/var/log/haproxy/current";
-const RESOLVER_LOG = "/var/log/coredns/current";
+const PROXY_LOG_DIR = "/var/log/haproxy";
+const RESOLVER_LOG_DIR = "/var/log/coredns";
 
 async function main(): Promise<void> {
   const containerId = process.argv[2];
@@ -30,8 +31,8 @@ async function main(): Promise<void> {
   const docker = createDocker();
   const parameters = buildReportParameters(docker.readEnv(containerId));
   const report = await buildInspectReportData(
-    docker.readFileLines(containerId, PROXY_LOG),
-    docker.readFileLines(containerId, RESOLVER_LOG),
+    readRotatedLog(docker, containerId, PROXY_LOG_DIR),
+    readRotatedLog(docker, containerId, RESOLVER_LOG_DIR),
     parameters,
   );
 

--- a/docker/universal/files/s6-rc.d/haproxy-log/run
+++ b/docker/universal/files/s6-rc.d/haproxy-log/run
@@ -1,2 +1,8 @@
 #!/usr/bin/execlineb -P
-s6-log 1 /var/log/haproxy
+# s: rotate current at 1MB rather than s6-log's own default of ~100KB, so a
+# build with a lot of traffic doesn't rotate mid-build. n: keep 100 rotated
+# segments (100MB) rather than the default 10, for the same reason. report
+# reads every segment, oldest first, so this isn't the only thing standing
+# between a big build and a truncated report -- but a build that still
+# outgrows this is not a size this tool is meant to handle.
+s6-log s1000000 n100 /var/log/haproxy

--- a/docker/universal/scripts/report-action.node.ts
+++ b/docker/universal/scripts/report-action.node.ts
@@ -9,6 +9,7 @@
  */
 import * as core from "@actions/core";
 import { createDocker } from "#core/lib/docker/client.ts";
+import { readRotatedLog } from "#core/lib/docker/rotated-log.ts";
 import { buildReportParameters } from "#core/lib/report/parameters.ts";
 import { buildUniversalReportData } from "#core/lib/report/build/universal.ts";
 import { renderReportMarkdown } from "#core/lib/report/render/render-report-markdown.ts";
@@ -16,7 +17,7 @@ import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
 import { errorMessage } from "#core/lib/errors.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
 
-const LOG_FILE = "/var/log/haproxy/current";
+const LOG_DIR = "/var/log/haproxy";
 
 async function main(): Promise<void> {
   const containerId = process.argv[2];
@@ -27,7 +28,7 @@ async function main(): Promise<void> {
   const docker = createDocker();
   const parameters = buildReportParameters(docker.readEnv(containerId));
   const report = await buildUniversalReportData(
-    docker.readFileLines(containerId, LOG_FILE),
+    readRotatedLog(docker, containerId, LOG_DIR),
     parameters,
   );
 

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -313,6 +313,13 @@ The `report` action reads **two** logs, not one.
 Leaving the resolver's log out would let a build exfiltrate through a DNS query alone and have the
 report show nothing, since no connection is ever made in that case.
 
+Each is really an s6-log directory, not a single file: once `current` crosses 1MB it rotates into a
+timestamped archive (`@<timestamp>.s`) and starts over, up to 100 archives kept. `report` reads every
+archive, oldest first, then `current`, so a large build's early traffic is never silently dropped
+just because a later part of the same build pushed the log past one rotation. Reading `current` alone
+— e.g. `docker compose exec builder cat /var/log/haproxy/current` for a quick manual look — only shows
+what has accumulated since the most recent rotation.
+
 Refused requests carry their full URL, which is what this engine has and the others do not: the
 request is read before it is decided on, and the origin is never contacted. A blocked entry
 therefore names the exact URL that was attempted, query string included, rather than a bare host.

--- a/src/core/lib/docker/rotated-log.test.ts
+++ b/src/core/lib/docker/rotated-log.test.ts
@@ -33,6 +33,18 @@ describe("parseLogSegments", () => {
   it("returns an empty array when current itself is absent", () => {
     expect(parseLogSegments("lock\nstate\n")).toStrictEqual([]);
   });
+
+  // Archive names are a fixed-width 24-hex-digit TAI64N timestamp, not a
+  // decimal counter, so there's no "10" sorting before "9" the way there
+  // would be for variable-width numbers -- string order already is
+  // chronological order, however many archives exist. n100 (see the
+  // haproxy-log/coredns-log run scripts) means a build can genuinely produce
+  // more than 10, so this is exercised past double digits, not just at 2.
+  it("keeps chronological order past double-digit archive counts", () => {
+    const inOrder = Array.from({ length: 15 }, (_, i) => `@${i.toString(16).padStart(24, "0")}.s`);
+    const shuffled = [...inOrder].reverse();
+    expect(parseLogSegments(shuffled.join("\n"))).toStrictEqual(inOrder);
+  });
 });
 
 /** Minimal stand-in for Docker, just enough surface for readRotatedLog. */

--- a/src/core/lib/docker/rotated-log.test.ts
+++ b/src/core/lib/docker/rotated-log.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
+import { parseLogSegments, readRotatedLog } from "./rotated-log.ts";
+import type { Docker } from "./client.ts";
+
+describe("parseLogSegments", () => {
+  it("keeps only s6-log segment names, archives before current", () => {
+    const ls = [
+      "state",
+      "lock",
+      "@400000006a94d9dc0621143f.s",
+      "current",
+      "@400000006a94d9dc09e929d9.s",
+    ].join("\n");
+    expect(parseLogSegments(ls)).toStrictEqual([
+      "@400000006a94d9dc0621143f.s",
+      "@400000006a94d9dc09e929d9.s",
+      "current",
+    ]);
+  });
+
+  it("sorts archives chronologically by their TAI64N name", () => {
+    const ls = ["@400000006a94d9dc09e929d9.s", "@400000006a94d9dc0621143f.s"].join("\n");
+    expect(parseLogSegments(ls)).toStrictEqual([
+      "@400000006a94d9dc0621143f.s",
+      "@400000006a94d9dc09e929d9.s",
+    ]);
+  });
+
+  it("returns just current when nothing has rotated yet", () => {
+    expect(parseLogSegments("current\nlock\nstate\n")).toStrictEqual(["current"]);
+  });
+
+  it("returns an empty array when current itself is absent", () => {
+    expect(parseLogSegments("lock\nstate\n")).toStrictEqual([]);
+  });
+});
+
+/** Minimal stand-in for Docker, just enough surface for readRotatedLog. */
+function fakeDocker(
+  lsOutput: string,
+  files: Record<string, string[]>,
+): { docker: Docker; reads: string[] } {
+  const reads: string[] = [];
+  const docker: Docker = {
+    findContainers: () => [],
+    copyFromContainer: () => {},
+    readEnv: () => ({}),
+    exec: (_id, args) => {
+      if (args[0] === "ls") return lsOutput;
+      throw new Error(`unexpected exec: ${args.join(" ")}`);
+    },
+    async *readFileLines(_id, path) {
+      reads.push(path);
+      for (const line of files[path] ?? []) yield line;
+    },
+  };
+  return { docker, reads };
+}
+
+async function drain(iterable: AsyncIterable<string>): Promise<string[]> {
+  const lines: string[] = [];
+  for await (const line of iterable) lines.push(line);
+  return lines;
+}
+
+describe("readRotatedLog", () => {
+  it("reads archives oldest-first, then current, all concatenated", async () => {
+    const ls = ["current", "@400000006a94d9dc09e929d9.s", "@400000006a94d9dc0621143f.s"].join("\n");
+    const { docker, reads } = fakeDocker(ls, {
+      "/var/log/haproxy/@400000006a94d9dc0621143f.s": ["old line"],
+      "/var/log/haproxy/@400000006a94d9dc09e929d9.s": ["middle line"],
+      "/var/log/haproxy/current": ["newest line"],
+    });
+    const lines = await drain(readRotatedLog(docker, "abc123", "/var/log/haproxy"));
+    expect(lines).toStrictEqual(["old line", "middle line", "newest line"]);
+    expect(reads).toStrictEqual([
+      "/var/log/haproxy/@400000006a94d9dc0621143f.s",
+      "/var/log/haproxy/@400000006a94d9dc09e929d9.s",
+      "/var/log/haproxy/current",
+    ]);
+  });
+
+  it("reads just current when nothing has rotated", async () => {
+    const { docker } = fakeDocker("current\nlock\nstate\n", {
+      "/var/log/coredns/current": ["a", "b"],
+    });
+    const lines = await drain(readRotatedLog(docker, "abc123", "/var/log/coredns"));
+    expect(lines).toStrictEqual(["a", "b"]);
+  });
+
+  it("lists the directory via docker exec ls -1", async () => {
+    let seenArgs: string[] = [];
+    const docker: Docker = {
+      findContainers: () => [],
+      copyFromContainer: () => {},
+      readEnv: () => ({}),
+      exec: (_id, args) => {
+        seenArgs = args;
+        return "current\n";
+      },
+      async *readFileLines() {},
+    };
+    await drain(readRotatedLog(docker, "abc123", "/var/log/haproxy"));
+    expect(seenArgs).toStrictEqual(["ls", "-1", "/var/log/haproxy"]);
+  });
+});
+
+reportResults();

--- a/src/core/lib/docker/rotated-log.ts
+++ b/src/core/lib/docker/rotated-log.ts
@@ -1,0 +1,48 @@
+/**
+ * Reads an s6-log directory as one time-ordered stream: the rotated archive
+ * segments (`@<TAI64N>.<letter>`, oldest first) followed by `current`.
+ *
+ * s6-log rotates `current` once it crosses its configured size, moving the
+ * old content into a new `@<timestamp>.<letter>` file in the same
+ * directory (see the haproxy-log/coredns-log `run` scripts). Reading only
+ * `current` silently drops everything before the last rotation once a build
+ * produces enough log traffic to cross that threshold — this is what report
+ * generation did before this file existed.
+ */
+import type { Docker } from "./client.ts";
+
+const SEGMENT = /^@[0-9a-f]{24}\.[a-z]$/;
+
+/**
+ * Extract the log segment filenames from `ls -1 <dir>` output, oldest first,
+ * with `current` last if present. Anything else (`lock`, `state`, s6's other
+ * bookkeeping files) is dropped by not matching either pattern.
+ *
+ * TAI64N timestamps are fixed-width hex, so a plain string sort already puts
+ * the archives in chronological order.
+ */
+export function parseLogSegments(lsOutput: string): string[] {
+  const entries = lsOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const segments = entries.filter((name) => SEGMENT.test(name)).sort();
+  if (entries.includes("current")) segments.push("current");
+  return segments;
+}
+
+/**
+ * Read every segment in `dir` as one time-ordered line stream: oldest
+ * rotated archive first, `current` last. See the module doc comment for why
+ * this exists instead of reading `current` alone.
+ */
+export async function* readRotatedLog(
+  docker: Docker,
+  containerId: string,
+  dir: string,
+): AsyncIterable<string> {
+  const listing = docker.exec(containerId, ["ls", "-1", dir]);
+  for (const name of parseLogSegments(listing)) {
+    yield* docker.readFileLines(containerId, `${dir}/${name}`);
+  }
+}


### PR DESCRIPTION
## Summary

`s6-log`, which pipes the `inspect`/`universal` proxy logs, rotates once a build's traffic passes its default size. The report only ever read the current segment, so a build's early traffic silently disappeared from the Job Summary and traffic artifact once a rotation happened.

## Changes

- Raise `s6-log`'s rotation size/retention in `inspect` and `universal`'s log services, so ordinary builds essentially never rotate.
- Add `readRotatedLog` so the report reads every rotated segment, oldest first, then the current one.
- `explicit` is unaffected — it doesn't use `s6-log`.

## Test plan

- [x] Live reproduction against the real `inspect` proxy
  - Forced a rotation with a deliberately tiny threshold, confirmed the fixed report recovers the full timeline
