### PR TITLE
fix: make the restrict-mode example actually pasteable

### DIFF
--- a/src/core/lib/report/render/build-example.test.ts
+++ b/src/core/lib/report/render/build-example.test.ts
@@ -5,11 +5,17 @@ const REPO = "buildcage/docker";
 const REF = "v2";
 
 function wrap(yaml: string) {
+  // Mirrors the production code's own 6-space step-indent transform, so the
+  // test cases below can stay written as an unindented, readable fragment.
+  const indented = yaml
+    .split("\n")
+    .map((line) => (line ? `      ${line}` : line))
+    .join("\n");
   return (
     "\n<details>\n" +
     "<summary>🛡️ Switch to restrict mode</summary>\n\n" +
     "```yaml\n" +
-    yaml +
+    indented +
     "```\n\n" +
     "</details>\n"
   );

--- a/src/core/lib/report/render/build-example.test.ts
+++ b/src/core/lib/report/render/build-example.test.ts
@@ -33,7 +33,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: ${REPO}@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
@@ -53,7 +53,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: ${REPO}@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
@@ -71,7 +71,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: ${REPO}@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
@@ -91,7 +91,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, REPO, REF)).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: ${REPO}@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
@@ -111,7 +111,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, "myorg/myrepo", REF)).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: myorg/myrepo@${REF}`,
           "  with:",
           "    proxy_mode: restrict",
@@ -127,7 +127,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, REPO, "v2.1.0")).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: ${REPO}@v2.1.0`,
           "  with:",
           "    proxy_mode: restrict",
@@ -144,7 +144,7 @@ describe("buildRestrictExample", () => {
     expect(buildRestrictExample(rows, REPO, sha)).toBe(
       wrap(
         [
-          "- name: Start Buildcage in restrict mode",
+          "- name: Start Buildcage",
           `  uses: ${REPO}@<sha>`,
           "  with:",
           "    proxy_mode: restrict",

--- a/src/core/lib/report/render/build-example.test.ts
+++ b/src/core/lib/report/render/build-example.test.ts
@@ -138,14 +138,14 @@ describe("buildRestrictExample", () => {
     );
   });
 
-  it("renders a commit SHA actionRef as a <sha> placeholder", () => {
+  it("renders a commit SHA actionRef as-is, same as a tag", () => {
     const rows = [{ host: "example.com", port: "443", ruleType: "HTTPS", count: 1 }];
     const sha = "abc1234567890def1234567890abcdef12345678";
     expect(buildRestrictExample(rows, REPO, sha)).toBe(
       wrap(
         [
           "- name: Start Buildcage",
-          `  uses: ${REPO}@<sha>`,
+          `  uses: ${REPO}@${sha}`,
           "  with:",
           "    proxy_mode: restrict",
           "    allowed_https_rules: >-",

--- a/src/core/lib/report/render/build-example.ts
+++ b/src/core/lib/report/render/build-example.ts
@@ -23,10 +23,6 @@ export function buildRestrictExample(
 ): string {
   if (!auditedRows || auditedRows.length === 0) return "";
 
-  // A 40-char SHA is opaque to the reader and specific to this run, so show a
-  // placeholder instead; a tag (e.g. v2, v2.1.0) is stable and useful as-is.
-  const ref = /^[0-9a-f]{40}$/i.test(actionRef!) ? "<sha>" : actionRef;
-
   // Group by ruleType, preserving order of first appearance
   const groups = new Map<string, string[]>();
   for (const r of auditedRows) {
@@ -41,7 +37,7 @@ export function buildRestrictExample(
   // Build YAML lines
   let yaml = "";
   yaml += "- name: Start Buildcage\n";
-  yaml += `  uses: ${actionRepo}@${ref}\n`;
+  yaml += `  uses: ${actionRepo}@${actionRef}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";
   for (const [param, rules] of groups) {

--- a/src/core/lib/report/render/build-example.ts
+++ b/src/core/lib/report/render/build-example.ts
@@ -47,6 +47,15 @@ export function buildRestrictExample(
     }
   }
 
+  // GitHub Actions' own indentation convention (jobs: -> <id>: -> steps: ->
+  // "- name:") always puts a step 6 spaces in, so the generated snippet can
+  // be pasted directly into an existing steps: list without re-indenting it.
+  const STEP_INDENT = "      ";
+  yaml = yaml
+    .split("\n")
+    .map((line) => (line ? STEP_INDENT + line : line))
+    .join("\n");
+
   let md = "\n<details>\n";
   md += "<summary>🛡️ Switch to restrict mode</summary>\n\n";
   md += "```yaml\n";

--- a/src/core/lib/report/render/build-example.ts
+++ b/src/core/lib/report/render/build-example.ts
@@ -40,7 +40,7 @@ export function buildRestrictExample(
 
   // Build YAML lines
   let yaml = "";
-  yaml += "- name: Start Buildcage in restrict mode\n";
+  yaml += "- name: Start Buildcage\n";
   yaml += `  uses: ${actionRepo}@${ref}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";

--- a/src/core/lib/report/render/inspect-example.test.ts
+++ b/src/core/lib/report/render/inspect-example.test.ts
@@ -211,9 +211,10 @@ describe("buildInspectRestrictExample", () => {
     expect(md.includes("proxy_engine: inspect")).toBe(true);
   });
 
-  it("shows a placeholder for a commit sha, which is opaque and run-specific", () => {
-    const md = buildInspectRestrictExample(requests, "buildcage/docker", "a".repeat(40));
-    expect(md.includes("@<sha>")).toBe(true);
+  it("renders a commit sha as-is, same as a tag", () => {
+    const sha = "a".repeat(40);
+    const md = buildInspectRestrictExample(requests, "buildcage/docker", sha);
+    expect(md.includes(`@${sha}`)).toBe(true);
   });
 
   it("keeps a tag as written, since it is stable", () => {

--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -146,9 +146,7 @@ export function buildUrlRuleLines(requests: TrafficEvent[]): string[] {
  * Render the rules as a collapsed markdown section, or "" if nothing was
  * observed.
  *
- * `actionRef` is the ref this action was invoked with. A 40-character SHA is
- * specific to this run and opaque to the reader, so it is shown as a
- * placeholder; a tag is stable and useful as written.
+ * `actionRef` is the ref this action was invoked with.
  */
 export function buildInspectRestrictExample(
   requests: TrafficEvent[] | null | undefined,
@@ -158,10 +156,8 @@ export function buildInspectRestrictExample(
   const lines = buildUrlRuleLines(requests ?? []);
   if (lines.length === 0) return "";
 
-  const ref = actionRef && /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef;
-
   let yaml = "- name: Start Buildcage\n";
-  yaml += `  uses: ${actionRepo}@${ref}\n`;
+  yaml += `  uses: ${actionRepo}@${actionRef}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";
   yaml += "    proxy_engine: inspect\n";

--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -166,6 +166,15 @@ export function buildInspectRestrictExample(
   yaml += "    allowed_url_rules: |\n";
   for (const line of lines) yaml += `      ${line}\n`;
 
+  // GitHub Actions' own indentation convention (jobs: -> <id>: -> steps: ->
+  // "- name:") always puts a step 6 spaces in, so the generated snippet can
+  // be pasted directly into an existing steps: list without re-indenting it.
+  const STEP_INDENT = "      ";
+  yaml = yaml
+    .split("\n")
+    .map((line) => (line ? STEP_INDENT + line : line))
+    .join("\n");
+
   let md = "\n<details>\n";
   md += "<summary>🛡️ Switch to restrict mode</summary>\n\n";
   md += "```yaml\n";

--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -160,7 +160,7 @@ export function buildInspectRestrictExample(
 
   const ref = actionRef && /^[0-9a-f]{40}$/i.test(actionRef) ? "<sha>" : actionRef;
 
-  let yaml = "- name: Start Buildcage in restrict mode\n";
+  let yaml = "- name: Start Buildcage\n";
   yaml += `  uses: ${actionRepo}@${ref}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";


### PR DESCRIPTION
## Summary

The audit report's "Switch to restrict mode" snippet had two things wrong: it showed a literal `<sha>` instead of the real ref when `actionRef` was a commit sha, and its indentation only worked as a standalone fragment, not when pasted into an existing `steps:` list in a real workflow.

## Changes

- Show the real `actionRef` instead of a `<sha>` placeholder.
- Indent the whole snippet 6 spaces, matching where a step actually sits under `jobs.<id>.steps:`.
- Drop the redundant "in restrict mode" from the step name (`with:` already carries `proxy_mode: restrict`).

## Test plan

- [x] Spliced the generated output into a real workflow file and verified with `actionlint`
