### PR TITLE
feat: annotate the restrict-mode example's uses: line with its version

### DIFF
--- a/docker/explicit/scripts/report-action.node.ts
+++ b/docker/explicit/scripts/report-action.node.ts
@@ -80,7 +80,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "buildcage/docker",
     process.env.GITHUB_ACTION_REF || "v2",
-    { actionVersion: readActionVersion(docker, containerId) },
+    { actionVersion: readActionVersion(docker, containerId, "explicit") },
   );
 
   await writeStepSummary(markdown);

--- a/docker/explicit/scripts/report-action.node.ts
+++ b/docker/explicit/scripts/report-action.node.ts
@@ -17,6 +17,7 @@ import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
 import { errorMessage } from "#core/lib/errors.ts";
 import { wrapLogGroup } from "#core/lib/actions/log.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
+import { readActionVersion } from "../../lib/read-action-version.ts";
 import { selectAllRefs } from "#core/lib/log/build-histories.ts";
 import { parseVertexAllowedLog, type VertexAllowedEntry } from "#core/lib/log/vertex.ts";
 
@@ -79,6 +80,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "buildcage/docker",
     process.env.GITHUB_ACTION_REF || "v2",
+    { actionVersion: readActionVersion(docker, containerId) },
   );
 
   await writeStepSummary(markdown);

--- a/docker/inspect/scripts/report-action.node.ts
+++ b/docker/inspect/scripts/report-action.node.ts
@@ -18,6 +18,7 @@ import { writeTrafficFile, buildTrafficRecords } from "#core/lib/report/outcome/
 import { errorMessage } from "#core/lib/errors.ts";
 import { wrapLogGroup } from "#core/lib/actions/log.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
+import { readActionVersion } from "../../lib/read-action-version.ts";
 
 const PROXY_LOG_DIR = "/var/log/haproxy";
 const RESOLVER_LOG_DIR = "/var/log/coredns";
@@ -47,6 +48,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "buildcage/docker",
     process.env.GITHUB_ACTION_REF || "v2",
+    { actionVersion: readActionVersion(docker, containerId) },
   );
 
   // The report action uploads this file as an artifact if asked; the upload

--- a/docker/inspect/scripts/report-action.node.ts
+++ b/docker/inspect/scripts/report-action.node.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "buildcage/docker",
     process.env.GITHUB_ACTION_REF || "v2",
-    { actionVersion: readActionVersion(docker, containerId) },
+    { actionVersion: readActionVersion(docker, containerId, "inspect") },
   );
 
   // The report action uploads this file as an artifact if asked; the upload

--- a/docker/lib/read-action-version.ts
+++ b/docker/lib/read-action-version.ts
@@ -1,10 +1,23 @@
 import type { Docker } from "#core/lib/docker/client.ts";
 
-/** Best-effort `org.opencontainers.image.version` label read — a `docker
- *  inspect` failure here must not fail the whole report over one comment. */
-export function readActionVersion(docker: Docker, containerId: string): string | undefined {
+/**
+ * Best-effort `org.opencontainers.image.version` label read, converted back
+ * into the `vX.Y.Z` git tag it was published from (the label itself is the
+ * bare Docker tag, e.g. `3.1.4-inspect` for a non-universal engine — see
+ * image-tag.ts). A `docker inspect` failure here must not fail the whole
+ * report over one comment.
+ */
+export function readActionVersion(
+  docker: Docker,
+  containerId: string,
+  proxyEngine: string,
+): string | undefined {
   try {
-    return docker.readLabels(containerId)["org.opencontainers.image.version"];
+    const label = docker.readLabels(containerId)["org.opencontainers.image.version"];
+    if (!label) return undefined;
+    const suffix = `-${proxyEngine}`;
+    const version = label.endsWith(suffix) ? label.slice(0, -suffix.length) : label;
+    return `v${version}`;
   } catch {
     return undefined;
   }

--- a/docker/lib/read-action-version.ts
+++ b/docker/lib/read-action-version.ts
@@ -1,0 +1,11 @@
+import type { Docker } from "#core/lib/docker/client.ts";
+
+/** Best-effort `org.opencontainers.image.version` label read — a `docker
+ *  inspect` failure here must not fail the whole report over one comment. */
+export function readActionVersion(docker: Docker, containerId: string): string | undefined {
+  try {
+    return docker.readLabels(containerId)["org.opencontainers.image.version"];
+  } catch {
+    return undefined;
+  }
+}

--- a/docker/universal/scripts/report-action.node.ts
+++ b/docker/universal/scripts/report-action.node.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "buildcage/docker",
     process.env.GITHUB_ACTION_REF || "v2",
-    { actionVersion: readActionVersion(docker, containerId) },
+    { actionVersion: readActionVersion(docker, containerId, "universal") },
   );
 
   await writeStepSummary(markdown);

--- a/docker/universal/scripts/report-action.node.ts
+++ b/docker/universal/scripts/report-action.node.ts
@@ -16,6 +16,7 @@ import { renderReportMarkdown } from "#core/lib/report/render/render-report-mark
 import { emitBlockedOutcome } from "#core/lib/report/outcome/emit.ts";
 import { errorMessage } from "#core/lib/errors.ts";
 import { writeStepSummary } from "../../lib/write-step-summary.ts";
+import { readActionVersion } from "../../lib/read-action-version.ts";
 
 const LOG_DIR = "/var/log/haproxy";
 
@@ -36,6 +37,7 @@ async function main(): Promise<void> {
     report,
     process.env.GITHUB_ACTION_REPOSITORY || "buildcage/docker",
     process.env.GITHUB_ACTION_REF || "v2",
+    { actionVersion: readActionVersion(docker, containerId) },
   );
 
   await writeStepSummary(markdown);

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -12153,6 +12153,11 @@ function parseDockerInspectEnv(inspectOutput) {
 	}
 	return env;
 }
+/** Parses `docker inspect <id> --format '{{json .Config.Labels}}'`'s output
+*  into a lookup map; `null` (no labels) becomes `{}`. */
+function parseDockerInspectLabels(inspectOutput) {
+	return JSON.parse(inspectOutput) ?? {};
+}
 //#endregion
 //#region src/core/lib/docker/client.ts
 /** `docker ps --format '{{.ID}}'` prints one ID per line, possibly with
@@ -12251,6 +12256,14 @@ function createDocker(run = defaultRunCommand, spawnDocker = defaultSpawnCommand
 				containerId,
 				"--format",
 				"{{json .Config.Env}}"
+			]));
+		},
+		readLabels(containerId) {
+			return parseDockerInspectLabels(run([
+				"inspect",
+				containerId,
+				"--format",
+				"{{json .Config.Labels}}"
 			]));
 		},
 		exec(containerId, args) {

--- a/src/core/lib/docker/client.test.ts
+++ b/src/core/lib/docker/client.test.ts
@@ -61,6 +61,18 @@ describe("createDocker", () => {
     expect(calls).toStrictEqual([["inspect", "abc123", "--format", "{{json .Config.Env}}"]]);
   });
 
+  it("readLabels runs docker inspect and parses the Labels JSON object", () => {
+    const { run, calls } = fakeRun(['{"org.opencontainers.image.version":"3.1.4"}']);
+    const labels = createDocker(run).readLabels("abc123");
+    expect(labels).toStrictEqual({ "org.opencontainers.image.version": "3.1.4" });
+    expect(calls).toStrictEqual([["inspect", "abc123", "--format", "{{json .Config.Labels}}"]]);
+  });
+
+  it("readLabels returns an empty object for a container with no labels", () => {
+    const { run } = fakeRun(["null"]);
+    expect(createDocker(run).readLabels("abc123")).toStrictEqual({});
+  });
+
   it("exec runs docker exec with the given argv and returns its stdout", () => {
     const { run, calls } = fakeRun(["histories output"]);
     const out = createDocker(run).exec("abc123", [

--- a/src/core/lib/docker/client.ts
+++ b/src/core/lib/docker/client.ts
@@ -2,7 +2,7 @@ import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import { createInterface } from "node:readline";
 import { buildDockerCpArgs } from "./args.ts";
-import { parseDockerInspectEnv } from "./container-env.ts";
+import { parseDockerInspectEnv, parseDockerInspectLabels } from "./container-env.ts";
 
 /** `docker ps --format '{{.ID}}'` prints one ID per line, possibly with
  *  trailing blank lines. */
@@ -112,6 +112,8 @@ export interface Docker {
   readFileLines(containerId: string, path: string): AsyncIterable<string>;
   /** `docker inspect <containerId>`'s own env, as a lookup map. */
   readEnv(containerId: string): Record<string, string>;
+  /** `docker inspect <containerId>`'s own labels, as a lookup map. */
+  readLabels(containerId: string): Record<string, string>;
   /** `docker exec <containerId> <...args>` — raw stdout, for anything else
    *  (e.g. buildctl). */
   exec(containerId: string, args: string[]): string;
@@ -143,6 +145,11 @@ export function createDocker(
     readEnv(containerId) {
       return parseDockerInspectEnv(
         run(["inspect", containerId, "--format", "{{json .Config.Env}}"]),
+      );
+    },
+    readLabels(containerId) {
+      return parseDockerInspectLabels(
+        run(["inspect", containerId, "--format", "{{json .Config.Labels}}"]),
       );
     },
     exec(containerId, args) {

--- a/src/core/lib/docker/container-env.test.ts
+++ b/src/core/lib/docker/container-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, reportResults } from "../test/test-shim.ts";
-import { parseDockerInspectEnv } from "./container-env.ts";
+import { parseDockerInspectEnv, parseDockerInspectLabels } from "./container-env.ts";
 
 describe("parseDockerInspectEnv", () => {
   it("parses a JSON array of KEY=VALUE strings into a map", () => {
@@ -25,6 +25,22 @@ describe("parseDockerInspectEnv", () => {
 
   it("skips entries with no '='", () => {
     expect(parseDockerInspectEnv('["MALFORMED","OK=1"]')).toStrictEqual({ OK: "1" });
+  });
+});
+
+describe("parseDockerInspectLabels", () => {
+  it("parses a JSON object into a map", () => {
+    expect(
+      parseDockerInspectLabels('{"org.opencontainers.image.version":"3.1.4","foo":"bar"}'),
+    ).toStrictEqual({ "org.opencontainers.image.version": "3.1.4", foo: "bar" });
+  });
+
+  it("returns an empty object for the literal 'null' (a container with no labels)", () => {
+    expect(parseDockerInspectLabels("null")).toStrictEqual({});
+  });
+
+  it("returns an empty object for '{}'", () => {
+    expect(parseDockerInspectLabels("{}")).toStrictEqual({});
   });
 });
 

--- a/src/core/lib/docker/container-env.ts
+++ b/src/core/lib/docker/container-env.ts
@@ -14,3 +14,9 @@ export function parseDockerInspectEnv(inspectOutput: string): Record<string, str
   }
   return env;
 }
+
+/** Parses `docker inspect <id> --format '{{json .Config.Labels}}'`'s output
+ *  into a lookup map; `null` (no labels) becomes `{}`. */
+export function parseDockerInspectLabels(inspectOutput: string): Record<string, string> {
+  return JSON.parse(inspectOutput) ?? {};
+}

--- a/src/core/lib/docker/rotated-log.test.ts
+++ b/src/core/lib/docker/rotated-log.test.ts
@@ -57,6 +57,7 @@ function fakeDocker(
     findContainers: () => [],
     copyFromContainer: () => {},
     readEnv: () => ({}),
+    readLabels: () => ({}),
     exec: (_id, args) => {
       if (args[0] === "ls") return lsOutput;
       throw new Error(`unexpected exec: ${args.join(" ")}`);
@@ -106,6 +107,7 @@ describe("readRotatedLog", () => {
       findContainers: () => [],
       copyFromContainer: () => {},
       readEnv: () => ({}),
+      readLabels: () => ({}),
       exec: (_id, args) => {
         seenArgs = args;
         return "current\n";

--- a/src/core/lib/report/render/build-example.test.ts
+++ b/src/core/lib/report/render/build-example.test.ts
@@ -160,6 +160,23 @@ describe("buildRestrictExample", () => {
       ),
     );
   });
+
+  it("appends the actionVersion as a trailing comment when known", () => {
+    const rows = [{ host: "example.com", port: "443", ruleType: "HTTPS", count: 1 }];
+    const sha = "abc1234567890def1234567890abcdef12345678";
+    expect(buildRestrictExample(rows, REPO, sha, "3.1.4")).toBe(
+      wrap(
+        [
+          "- name: Start Buildcage",
+          `  uses: ${REPO}@${sha} # 3.1.4`,
+          "  with:",
+          "    proxy_mode: restrict",
+          "    allowed_https_rules: >-",
+          "      example.com:443",
+        ].join("\n") + "\n",
+      ),
+    );
+  });
 });
 
 reportResults();

--- a/src/core/lib/report/render/build-example.ts
+++ b/src/core/lib/report/render/build-example.ts
@@ -14,12 +14,14 @@ export type AuditedRow = Pick<AggregatedEntry, "host" | "port" | "ruleType">;
  *
  * actionRef is the ref (tag or commit SHA) this action was invoked with.
  * setup's action.yml lives at the repo root (not a subdirectory), so the
- * example's `uses:` never has an action-name path segment.
+ * example's `uses:` never has an action-name path segment. actionVersion,
+ * if known, is appended as a trailing `# 3.1.4` comment.
  */
 export function buildRestrictExample(
   auditedRows: AuditedRow[] | null | undefined,
   actionRepo: string,
   actionRef?: string,
+  actionVersion?: string,
 ): string {
   if (!auditedRows || auditedRows.length === 0) return "";
 
@@ -37,7 +39,7 @@ export function buildRestrictExample(
   // Build YAML lines
   let yaml = "";
   yaml += "- name: Start Buildcage\n";
-  yaml += `  uses: ${actionRepo}@${actionRef}\n`;
+  yaml += `  uses: ${actionRepo}@${actionRef}${actionVersion ? ` # ${actionVersion}` : ""}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";
   for (const [param, rules] of groups) {

--- a/src/core/lib/report/render/inspect-example.test.ts
+++ b/src/core/lib/report/render/inspect-example.test.ts
@@ -232,6 +232,19 @@ describe("buildInspectRestrictExample", () => {
     expect(buildInspectRestrictExample([], "buildcage/docker", "v2")).toBe("");
     expect(buildInspectRestrictExample(null, "buildcage/docker", "v2")).toBe("");
   });
+
+  it("appends the version as a trailing comment when known", () => {
+    const sha = "a".repeat(40);
+    const md = buildInspectRestrictExample(requests, "buildcage/docker", sha, "3.1.4");
+    expect(md.includes(`@${sha} # 3.1.4\n`)).toBe(true);
+  });
+
+  it("omits the comment when the version is not known", () => {
+    const sha = "a".repeat(40);
+    const md = buildInspectRestrictExample(requests, "buildcage/docker", sha);
+    expect(md.includes(`@${sha}\n`)).toBe(true);
+    expect(md.includes("#")).toBe(false);
+  });
 });
 
 reportResults();

--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -146,18 +146,20 @@ export function buildUrlRuleLines(requests: TrafficEvent[]): string[] {
  * Render the rules as a collapsed markdown section, or "" if nothing was
  * observed.
  *
- * `actionRef` is the ref this action was invoked with.
+ * `actionRef` is the ref this action was invoked with; `actionVersion`, if
+ * known, is appended as a trailing `# 3.1.4` comment.
  */
 export function buildInspectRestrictExample(
   requests: TrafficEvent[] | null | undefined,
   actionRepo: string,
   actionRef?: string,
+  actionVersion?: string,
 ): string {
   const lines = buildUrlRuleLines(requests ?? []);
   if (lines.length === 0) return "";
 
   let yaml = "- name: Start Buildcage\n";
-  yaml += `  uses: ${actionRepo}@${actionRef}\n`;
+  yaml += `  uses: ${actionRepo}@${actionRef}${actionVersion ? ` # ${actionVersion}` : ""}\n`;
   yaml += "  with:\n";
   yaml += "    proxy_mode: restrict\n";
   yaml += "    proxy_engine: inspect\n";

--- a/src/core/lib/report/render/render-report-markdown.ts
+++ b/src/core/lib/report/render/render-report-markdown.ts
@@ -10,6 +10,8 @@ export interface RenderReportMarkdownOptions {
    *  Defaults to a bare "Outbound Traffic Report", which is what both
    *  engines' report scripts use. */
   title?: string;
+  /** Version to annotate the restrict-mode example's `uses:` line with. */
+  actionVersion?: string;
 }
 
 /** Branches on `report.engine`/`report.parameters.mode` rather than being
@@ -19,7 +21,7 @@ export function renderReportMarkdown(
   report: ReportData,
   actionRepo: string,
   actionRef: string,
-  { title = "Outbound Traffic Report" }: RenderReportMarkdownOptions = {},
+  { title = "Outbound Traffic Report", actionVersion }: RenderReportMarkdownOptions = {},
 ): string {
   const isAudit = report.parameters.mode === "audit";
   const showExpected = report.parameters.knownBlockedRules.length > 0;
@@ -38,8 +40,8 @@ export function renderReportMarkdown(
     // be that much narrower than one built from hosts alone.
     markdown +=
       report.engine === "inspect"
-        ? buildInspectRestrictExample(report.timeline, actionRepo, actionRef)
-        : buildRestrictExample(report.passed, actionRepo, actionRef);
+        ? buildInspectRestrictExample(report.timeline, actionRepo, actionRef, actionVersion)
+        : buildRestrictExample(report.passed, actionRepo, actionRef, actionVersion);
   }
   if (report.blocked.length > 0) {
     if (report.passed.length > 0) markdown += "\n";


### PR DESCRIPTION
## Summary

The "Switch to restrict mode" snippet's `uses:` line shows the exact ref the workflow invoked buildcage with — often a 40-char commit SHA once pinned per GitHub's own security guidance, which reads as an opaque hash. The pulled image already carries the release it was built from as its own `org.opencontainers.image.version` label (set by `docker/metadata-action` at publish time), so this reads it locally and appends it as a trailing comment.

## Changes

- Add `Docker.readLabels()` (`docker inspect --format '{{json .Config.Labels}}'`), mirroring the existing `readEnv()`.
- Add `docker/lib/read-action-version.ts` — a best-effort read; a `docker inspect` failure there must not fail report generation over one comment. The label itself is the bare Docker tag (e.g. `3.1.4-inspect` for the inspect engine), not the git tag the action was released under, so this strips the `-<engine>` suffix and restores the `v` prefix before use.
- Thread `actionVersion` through `renderReportMarkdown` / `buildInspectRestrictExample` / `buildRestrictExample`; when known, the generated `uses: repo@sha` line gets ` # v3.1.4` appended.
- Wire it into all three engines' `report-action.node.ts`.

## Test plan

- [x] Pulled `ghcr.io/buildcage/docker:3.1.4-inspect` and confirmed `org.opencontainers.image.version` is really set on it (`3.1.4-inspect`), then verified `readActionVersion`'s suffix-strip/`v`-prefix logic turns that into `v3.1.4`.