### PR TITLE
feat: support # comments and blank lines in allowed_url_rules

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -649,15 +649,10 @@ function convertUrlRule(rule) {
 	};
 }
 /**
-* Split a rules input into rule lines.
-*
-* Newline-separated, because a rule contains a space between its method list
-* and its URL. A line whose first non-whitespace character is `#` is a
-* comment and is dropped, same as a blank line — useful for grouping and
-* annotating rules once the list gets long. Only a full-line `#` counts: a
-* URL never legitimately contains one (a fragment is never sent to a
-* server), but a `~` rule's own regex might, so a trailing `#` is left
-* alone rather than silently truncating someone's pattern.
+* Split a rules input into rule lines. Newline-separated, because a rule
+* contains a space between its method list and its URL. A blank line, or a
+* line starting with `#`, is dropped — only a full-line `#`, since a `~`
+* rule's own regex might legitimately contain one.
 */
 function splitUrlRuleLines(rulesInput) {
 	return rulesInput?.split(/\r?\n/).map((line) => line.trim()).filter((line) => line !== "" && !line.startsWith("#")) ?? [];

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -652,10 +652,15 @@ function convertUrlRule(rule) {
 * Split a rules input into rule lines.
 *
 * Newline-separated, because a rule contains a space between its method list
-* and its URL.
+* and its URL. A line whose first non-whitespace character is `#` is a
+* comment and is dropped, same as a blank line — useful for grouping and
+* annotating rules once the list gets long. Only a full-line `#` counts: a
+* URL never legitimately contains one (a fragment is never sent to a
+* server), but a `~` rule's own regex might, so a trailing `#` is left
+* alone rather than silently truncating someone's pattern.
 */
 function splitUrlRuleLines(rulesInput) {
-	return rulesInput?.split(/\r?\n/).map((line) => line.trim()).filter(Boolean) ?? [];
+	return rulesInput?.split(/\r?\n/).map((line) => line.trim()).filter((line) => line !== "" && !line.startsWith("#")) ?? [];
 }
 /**
 * Compile a newline-separated URL rules input.

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -72,12 +72,16 @@ Injection never touches LLB and happens at exec time, so it cannot affect a cach
 ## Rule syntax
 
 A rule is a method list, a space, then a URL pattern. Because a rule contains a space, this input is
-newline separated.
+newline separated. A blank line, or a line starting with `#`, is ignored — useful for grouping and
+annotating rules once the list gets long.
 
 ```yaml
 allowed_url_rules: |
+  # npm installs
   GET https://registry.npmjs.org/@myorg/**
   GET|HEAD https://example.com/public/*
+
+  # internal write access
   POST,PUT https://api.internal.example.com/v1/*
   * https://internal.example.com
 ```

--- a/src/core/lib/acl/url-rules.test.ts
+++ b/src/core/lib/acl/url-rules.test.ts
@@ -114,6 +114,18 @@ describe("buildUrlRules", () => {
     expect(buildUrlRules(undefined).length).toBe(0);
     expect(buildUrlRules("   ").length).toBe(0);
   });
+
+  it("drops a full-line comment, same as a blank line", () => {
+    const rules = buildUrlRules(
+      "# npm packages\nGET https://a.com/x\n\n  # cdn assets\nGET https://b.com/y\n",
+    );
+    expect(rules.map((r) => r.raw)).toStrictEqual(["GET https://a.com/x", "GET https://b.com/y"]);
+  });
+
+  it("does not treat a mid-line # as a comment marker", () => {
+    const rules = buildUrlRules("GET ~^https://a\\.com/x#frag$");
+    expect(rules[0].raw).toBe("GET ~^https://a\\.com/x#frag$");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/lib/acl/url-rules.ts
+++ b/src/core/lib/acl/url-rules.ts
@@ -203,14 +203,19 @@ export function convertUrlRule(rule: string): UrlRule {
  * Split a rules input into rule lines.
  *
  * Newline-separated, because a rule contains a space between its method list
- * and its URL.
+ * and its URL. A line whose first non-whitespace character is `#` is a
+ * comment and is dropped, same as a blank line — useful for grouping and
+ * annotating rules once the list gets long. Only a full-line `#` counts: a
+ * URL never legitimately contains one (a fragment is never sent to a
+ * server), but a `~` rule's own regex might, so a trailing `#` is left
+ * alone rather than silently truncating someone's pattern.
  */
 export function splitUrlRuleLines(rulesInput: string | undefined): string[] {
   return (
     rulesInput
       ?.split(/\r?\n/)
       .map((line) => line.trim())
-      .filter(Boolean) ?? []
+      .filter((line) => line !== "" && !line.startsWith("#")) ?? []
   );
 }
 

--- a/src/core/lib/acl/url-rules.ts
+++ b/src/core/lib/acl/url-rules.ts
@@ -200,15 +200,10 @@ export function convertUrlRule(rule: string): UrlRule {
 }
 
 /**
- * Split a rules input into rule lines.
- *
- * Newline-separated, because a rule contains a space between its method list
- * and its URL. A line whose first non-whitespace character is `#` is a
- * comment and is dropped, same as a blank line — useful for grouping and
- * annotating rules once the list gets long. Only a full-line `#` counts: a
- * URL never legitimately contains one (a fragment is never sent to a
- * server), but a `~` rule's own regex might, so a trailing `#` is left
- * alone rather than silently truncating someone's pattern.
+ * Split a rules input into rule lines. Newline-separated, because a rule
+ * contains a space between its method list and its URL. A blank line, or a
+ * line starting with `#`, is dropped — only a full-line `#`, since a `~`
+ * rule's own regex might legitimately contain one.
  */
 export function splitUrlRuleLines(rulesInput: string | undefined): string[] {
   return (


### PR DESCRIPTION
## Summary

allowed_url_rules gets hard to read once a step allow-lists more than a handful of URLs. A line whose first non-whitespace character is `#` is now dropped, same as an already-ignored blank line, so rules can be grouped and annotated.

Only a full-line `#` counts — a `~` rule's own regex could legitimately contain one, so a trailing `#` on a rule line is left alone rather than silently truncating someone's pattern.

## Changes

- `splitUrlRuleLines()` drops a line starting with `#` in addition to a blank one.
- Document `#` comments in the Rule syntax section.

## Test plan

- [x] Added cases: a full-line `#` comment (and one with leading whitespace) is dropped; a `~` regex rule containing a mid-line `#` is preserved as-is.