### PR TITLE
feat: downgrade unsupported url/tls rules to a warning in audit mode

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -666,6 +666,30 @@ function buildUrlRules(rulesInput) {
 	return splitUrlRuleLines(rulesInput).map(convertUrlRule);
 }
 //#endregion
+//#region src/lib/engine-rule-support.ts
+/**
+* Only `inspect` terminates TLS, so it's the only engine that can see an HTTP
+* method or a path — `allowed_url_rules` and `allow_tls_rules` are no-ops on
+* `universal` / `explicit`. Called once at setup, before the container starts,
+* so a mismatch is caught immediately instead of silently not enforcing.
+*
+* In `restrict` mode this is an error: a rule that looks like it protects the
+* build but can't actually be enforced is worse than no rule at all. In
+* `audit` mode nothing is enforced anyway, so it's a warning — the build
+* still runs, with these rules ignored.
+*/
+function checkUrlAndTlsRuleSupport({ proxyEngine, proxyMode, urlRules, tlsRules }, warn) {
+	if (proxyEngine === "inspect") return;
+	let unsupported = [];
+	if (urlRules.length > 0 && unsupported.push("allowed_url_rules"), tlsRules.length > 0 && unsupported.push("allow_tls_rules"), unsupported.length === 0) return;
+	let list = unsupported.join(" and "), reason = `${list} ${unsupported.length > 1 ? "have" : "has"} no effect with proxy_engine: ${proxyEngine} — this engine only sees the host and port, never a method or a path.`;
+	if (proxyMode === "audit") {
+		warn(`${reason} They are ignored for this run. Switch to proxy_engine: inspect if you need to enforce a method or a path.`);
+		return;
+	}
+	throw new SetupError(`${reason} In restrict mode that means ${list} would not actually be enforced — the build would look protected but isn't. Switch to proxy_engine: inspect, or remove ${list} from your workflow.`, "INVALID_PROXY_ENGINE");
+}
+//#endregion
 //#region src/core/lib/provenance/errors.ts
 var VerifyImageError = class extends Error {
 	code;
@@ -7803,17 +7827,21 @@ async function main() {
 		proxyEngine
 	});
 	console.log(`buildcage: image: ${imageRef}`);
-	let rules = buildACLRules({
+	let proxyMode = getInput("proxy_mode") || "restrict", rules = buildACLRules({
 		httpsRulesInput: getInput("allowed_https_rules"),
 		httpRulesInput: getInput("allowed_http_rules"),
 		ipRulesInput: getInput("allowed_ip_rules")
 	}), knownBlockedRules = parseRulesOrThrow(getInput("known_blocked_rules")), urlRulesInput = getInput("allowed_url_rules"), tlsRules = parseRulesOrThrow(getInput("allow_tls_rules")), urlRules = buildUrlRules(urlRulesInput).map((r) => r.raw);
-	if (proxyEngine !== "inspect" && (urlRules.length > 0 || tlsRules.length > 0)) throw new SetupError(`allowed_url_rules and allow_tls_rules need proxy_engine: inspect. The ${proxyEngine} engine cannot see a method or a path.`, "INVALID_PROXY_ENGINE");
-	console.log("::group::buildcage: Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("URL", urlRules), logRules("TLS", tlsRules), logRules("Known blocked", knownBlockedRules), console.log("::endgroup::");
+	checkUrlAndTlsRuleSupport({
+		proxyEngine,
+		proxyMode,
+		urlRules,
+		tlsRules
+	}, (message) => console.log(`::warning::${message}`)), console.log("::group::buildcage: Configured ACL Rules"), logRules("HTTPS", rules.httpsRules), logRules("HTTP", rules.httpRules), logRules("IP", rules.ipRules), logRules("URL", urlRules), logRules("TLS", tlsRules), logRules("Known blocked", knownBlockedRules), console.log("::endgroup::");
 	let builderName = getInput("builder_name") || "buildcage", projectName = deriveProjectName(builderName), composeEnv = {
 		...env,
 		BUILDER_NAME: builderName,
-		PROXY_MODE: getInput("proxy_mode") || "restrict",
+		PROXY_MODE: proxyMode,
 		PROXY_ENGINE: proxyEngine,
 		ALLOWED_HTTPS_RULES: rules.httpsRules.join("\n"),
 		ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),

--- a/src/lib/engine-rule-support.test.ts
+++ b/src/lib/engine-rule-support.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { checkUrlAndTlsRuleSupport } from "./engine-rule-support.ts";
+import { SetupError } from "./errors.ts";
+
+describe("checkUrlAndTlsRuleSupport", () => {
+  it("does nothing on inspect, regardless of mode or rules", () => {
+    const warn = vi.fn();
+    expect(() =>
+      checkUrlAndTlsRuleSupport(
+        {
+          proxyEngine: "inspect",
+          proxyMode: "restrict",
+          urlRules: ["GET https://example.com"],
+          tlsRules: ["example.com:443"],
+        },
+        warn,
+      ),
+    ).not.toThrow();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no url/tls rules are given, regardless of engine or mode", () => {
+    const warn = vi.fn();
+    expect(() =>
+      checkUrlAndTlsRuleSupport(
+        { proxyEngine: "universal", proxyMode: "restrict", urlRules: [], tlsRules: [] },
+        warn,
+      ),
+    ).not.toThrow();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("throws INVALID_PROXY_ENGINE in restrict mode when the engine can't enforce url rules", () => {
+    const warn = vi.fn();
+    expect(() =>
+      checkUrlAndTlsRuleSupport(
+        {
+          proxyEngine: "universal",
+          proxyMode: "restrict",
+          urlRules: ["GET https://example.com"],
+          tlsRules: [],
+        },
+        warn,
+      ),
+    ).toThrow(SetupError);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("throws in explicit engine too, mentioning only the rule inputs actually set", () => {
+    expect(() =>
+      checkUrlAndTlsRuleSupport(
+        {
+          proxyEngine: "explicit",
+          proxyMode: "restrict",
+          urlRules: [],
+          tlsRules: ["example.com:443"],
+        },
+        vi.fn(),
+      ),
+    ).toThrow(/allow_tls_rules/);
+  });
+
+  it("mentions both inputs when both are set", () => {
+    try {
+      checkUrlAndTlsRuleSupport(
+        {
+          proxyEngine: "universal",
+          proxyMode: "restrict",
+          urlRules: ["GET https://example.com"],
+          tlsRules: ["example.com:443"],
+        },
+        vi.fn(),
+      );
+      expect.unreachable();
+    } catch (e) {
+      expect((e as Error).message).toMatch(/allowed_url_rules and allow_tls_rules/);
+    }
+  });
+
+  it("warns instead of throwing in audit mode", () => {
+    const warn = vi.fn();
+    expect(() =>
+      checkUrlAndTlsRuleSupport(
+        {
+          proxyEngine: "universal",
+          proxyMode: "audit",
+          urlRules: ["GET https://example.com"],
+          tlsRules: [],
+        },
+        warn,
+      ),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/allowed_url_rules/);
+  });
+});

--- a/src/lib/engine-rule-support.ts
+++ b/src/lib/engine-rule-support.ts
@@ -1,0 +1,56 @@
+import { SetupError } from "./errors.ts";
+import type { ProxyEngine } from "../main.ts";
+
+/**
+ * Only `inspect` terminates TLS, so it's the only engine that can see an HTTP
+ * method or a path — `allowed_url_rules` and `allow_tls_rules` are no-ops on
+ * `universal` / `explicit`. Called once at setup, before the container starts,
+ * so a mismatch is caught immediately instead of silently not enforcing.
+ *
+ * In `restrict` mode this is an error: a rule that looks like it protects the
+ * build but can't actually be enforced is worse than no rule at all. In
+ * `audit` mode nothing is enforced anyway, so it's a warning — the build
+ * still runs, with these rules ignored.
+ */
+export function checkUrlAndTlsRuleSupport(
+  {
+    proxyEngine,
+    proxyMode,
+    urlRules,
+    tlsRules,
+  }: {
+    proxyEngine: ProxyEngine;
+    proxyMode: string;
+    urlRules: string[];
+    tlsRules: string[];
+  },
+  warn: (message: string) => void,
+): void {
+  if (proxyEngine === "inspect") return;
+
+  const unsupported: string[] = [];
+  if (urlRules.length > 0) unsupported.push("allowed_url_rules");
+  if (tlsRules.length > 0) unsupported.push("allow_tls_rules");
+  if (unsupported.length === 0) return;
+
+  const list = unsupported.join(" and ");
+  const verb = unsupported.length > 1 ? "have" : "has";
+  const reason =
+    `${list} ${verb} no effect with proxy_engine: ${proxyEngine} — this engine only sees the ` +
+    `host and port, never a method or a path.`;
+
+  if (proxyMode === "audit") {
+    warn(
+      `${reason} They are ignored for this run. Switch to proxy_engine: inspect if you need to ` +
+        `enforce a method or a path.`,
+    );
+    return;
+  }
+
+  throw new SetupError(
+    `${reason} In restrict mode that means ${list} would not actually be enforced — the build ` +
+      `would look protected but isn't. Switch to proxy_engine: inspect, or remove ${list} from ` +
+      `your workflow.`,
+    "INVALID_PROXY_ENGINE",
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { SetupError } from "./lib/errors.ts";
 import { ActionError, errorMessage } from "#core/lib/errors.ts";
 import { buildACLRules, parseRulesOrThrow } from "#core/lib/acl/rules.ts";
 import { buildUrlRules } from "#core/lib/acl/url-rules.ts";
+import { checkUrlAndTlsRuleSupport } from "./lib/engine-rule-support.ts";
 import {
   verifyImageDigestOrThrow,
   type VerifyImageDigestOptions,
@@ -73,6 +74,8 @@ async function main(): Promise<void> {
     localOverride ?? (await resolveVerifiedImage({ actionRef, actionRepo, proxyEngine }));
   console.log(`buildcage: image: ${imageRef}`);
 
+  const proxyMode = core.getInput("proxy_mode") || "restrict";
+
   const rules = buildACLRules({
     httpsRulesInput: core.getInput("allowed_https_rules"),
     httpRulesInput: core.getInput("allowed_http_rules"),
@@ -84,13 +87,9 @@ async function main(): Promise<void> {
   const urlRulesInput = core.getInput("allowed_url_rules");
   const tlsRules = parseRulesOrThrow(core.getInput("allow_tls_rules"));
   const urlRules = buildUrlRules(urlRulesInput).map((r) => r.raw);
-  if (proxyEngine !== "inspect" && (urlRules.length > 0 || tlsRules.length > 0)) {
-    throw new SetupError(
-      "allowed_url_rules and allow_tls_rules need proxy_engine: inspect. " +
-        `The ${proxyEngine} engine cannot see a method or a path.`,
-      "INVALID_PROXY_ENGINE",
-    );
-  }
+  checkUrlAndTlsRuleSupport({ proxyEngine, proxyMode, urlRules, tlsRules }, (message) =>
+    console.log(`::warning::${message}`),
+  );
 
   console.log("::group::buildcage: Configured ACL Rules");
   logRules("HTTPS", rules.httpsRules);
@@ -112,7 +111,7 @@ async function main(): Promise<void> {
   const composeEnv = {
     ...env,
     BUILDER_NAME: builderName,
-    PROXY_MODE: core.getInput("proxy_mode") || "restrict",
+    PROXY_MODE: proxyMode,
     PROXY_ENGINE: proxyEngine,
     ALLOWED_HTTPS_RULES: rules.httpsRules.join("\n"),
     ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),


### PR DESCRIPTION
## Summary
- `allowed_url_rules` / `allow_tls_rules` need `proxy_engine: inspect` to be enforced (only it can see a method or a path); using them with `universal` / `explicit` used to always fail setup, regardless of `proxy_mode`.
- In `restrict` mode this stays an error (a rule that looks like it protects the build but can't be enforced is worse than no rule), with a clearer message about why and what to do.
- In `audit` mode it's now a `::warning::` instead — audit doesn't enforce anything anyway, so the build proceeds with those rules ignored.
