### PR TITLE
feat: echo configured allow_tls_rules/allowed_ip_rules into the restrict-mode example

### DIFF
--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -457,10 +457,13 @@ alternatives are listing every URL, which nobody can maintain, or clustering the
 permissions nobody observed. Such a rule still constrains the method, which no host-level rule can.
 
 The rules are a starting point, not an answer. A URL carrying a version or a date will not match the
-next run, and anything reached through `allow_tls_rules` or `allowed_ip_rules` is absent, having
-never been inspected. `make test_integration_buildkit_inspect_roundtrip` runs an audit build, feeds
-its own generated rules back as `restrict`, and checks both halves: that every request still passes,
-and that a path, method, host or port the build never used is refused.
+next run. `allow_tls_rules` and `allowed_ip_rules` aren't derived from what the build reached either
+way -- a passthrough is never decrypted, so there is nothing in the traffic to build them from --
+they're carried over unchanged from whatever the audit run was configured with, since the same rule
+applies as-is under `restrict` (only enforcement differs; see [Audit mode](#audit-mode)).
+`make test_integration_buildkit_inspect_roundtrip` runs an audit build, feeds its own generated rules
+back as `restrict`, and checks both halves: that every request still passes, and that a path, method,
+host or port the build never used is refused.
 
 A `~` regex rule cannot be split into a host and a path, so it cannot be matched by an engine that
 matches the two separately. The generator warns and emits nothing for it; such a rule needs an

--- a/src/core/lib/report/build/explicit.test.ts
+++ b/src/core/lib/report/build/explicit.test.ts
@@ -9,6 +9,7 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
+    allowTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/build/inspect.test.ts
+++ b/src/core/lib/report/build/inspect.test.ts
@@ -14,6 +14,7 @@ const PARAMS: GenReportParameters = {
   allowedHttpsRules: [],
   allowedHttpRules: [],
   allowedIpRules: [],
+  allowTlsRules: [],
   knownBlockedRules: [],
 };
 

--- a/src/core/lib/report/build/universal.test.ts
+++ b/src/core/lib/report/build/universal.test.ts
@@ -8,6 +8,7 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
+    allowTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/outcome/emit.test.ts
+++ b/src/core/lib/report/outcome/emit.test.ts
@@ -21,6 +21,7 @@ function parameters(overrides: Partial<GenReportParameters> = {}): GenReportPara
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
+    allowTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/parameters.test.ts
+++ b/src/core/lib/report/parameters.test.ts
@@ -9,6 +9,7 @@ describe("buildReportParameters", () => {
         ALLOWED_HTTPS_RULES: "a.com:443 b.com:443",
         ALLOWED_HTTP_RULES: "c.com:80",
         ALLOWED_IP_RULES: "",
+        ALLOW_TLS_RULES: "d.example.com:8443",
         KNOWN_BLOCKED_RULES: "noisy.example.com:443",
       }),
     ).toStrictEqual({
@@ -16,6 +17,7 @@ describe("buildReportParameters", () => {
       allowedHttpsRules: ["a.com:443", "b.com:443"],
       allowedHttpRules: ["c.com:80"],
       allowedIpRules: [],
+      allowTlsRules: ["d.example.com:8443"],
       knownBlockedRules: ["noisy.example.com:443"],
     });
   });
@@ -29,6 +31,7 @@ describe("buildReportParameters", () => {
     expect(params.allowedHttpsRules).toStrictEqual([]);
     expect(params.allowedHttpRules).toStrictEqual([]);
     expect(params.allowedIpRules).toStrictEqual([]);
+    expect(params.allowTlsRules).toStrictEqual([]);
     expect(params.knownBlockedRules).toStrictEqual([]);
   });
 });

--- a/src/core/lib/report/parameters.ts
+++ b/src/core/lib/report/parameters.ts
@@ -14,6 +14,7 @@ export function buildReportParameters(
     allowedHttpsRules: splitRuleTokens(env.ALLOWED_HTTPS_RULES),
     allowedHttpRules: splitRuleTokens(env.ALLOWED_HTTP_RULES),
     allowedIpRules: splitRuleTokens(env.ALLOWED_IP_RULES),
+    allowTlsRules: splitRuleTokens(env.ALLOW_TLS_RULES),
     knownBlockedRules: splitRuleTokens(env.KNOWN_BLOCKED_RULES),
   };
 }

--- a/src/core/lib/report/render/inspect-example.test.ts
+++ b/src/core/lib/report/render/inspect-example.test.ts
@@ -223,14 +223,42 @@ describe("buildInspectRestrictExample", () => {
     );
   });
 
-  it("says what the rules do not cover", () => {
-    const md = buildInspectRestrictExample(requests, "buildcage/docker", "v2");
-    expect(md.includes("allow_tls_rules")).toBe(true);
-  });
-
-  it("renders nothing when nothing was observed", () => {
+  it("renders nothing when nothing was observed and no tls/ip rules were configured", () => {
     expect(buildInspectRestrictExample([], "buildcage/docker", "v2")).toBe("");
     expect(buildInspectRestrictExample(null, "buildcage/docker", "v2")).toBe("");
+  });
+
+  it("echoes allow_tls_rules and allowed_ip_rules as configured, not derived from traffic", () => {
+    // Neither is ever decrypted, so there is nothing in `requests` to build
+    // them from -- they are the same values the audit run was given.
+    const md = buildInspectRestrictExample(requests, "buildcage/docker", "v2", undefined, [
+      "10.0.0.5:5432",
+    ]);
+    expect(/allowed_ip_rules: \|\n\s+10\.0\.0\.5:5432\n/.test(md)).toBe(true);
+
+    const md2 = buildInspectRestrictExample(
+      requests,
+      "buildcage/docker",
+      "v2",
+      undefined,
+      [],
+      ["db.internal.example.com:8443"],
+    );
+    expect(/allow_tls_rules: \|\n\s+db\.internal\.example\.com:8443\n/.test(md2)).toBe(true);
+  });
+
+  it("still renders a section for tls/ip rules alone, with no observed traffic", () => {
+    const md = buildInspectRestrictExample(
+      [],
+      "buildcage/docker",
+      "v2",
+      undefined,
+      ["10.0.0.5:5432"],
+      ["db.internal.example.com:8443"],
+    );
+    expect(md.includes("allowed_url_rules")).toBe(false);
+    expect(/allowed_ip_rules: \|\n\s+10\.0\.0\.5:5432\n/.test(md)).toBe(true);
+    expect(/allow_tls_rules: \|\n\s+db\.internal\.example\.com:8443\n/.test(md)).toBe(true);
   });
 
   it("appends the version as a trailing comment when known", () => {

--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -143,20 +143,26 @@ export function buildUrlRuleLines(requests: TrafficEvent[]): string[] {
 }
 
 /**
- * Render the rules as a collapsed markdown section, or "" if nothing was
- * observed.
+ * Render the rules as a collapsed markdown section, or "" if there is nothing
+ * to show.
  *
  * `actionRef` is the ref this action was invoked with; `actionVersion`, if
- * known, is appended as a trailing `# 3.1.4` comment.
+ * known, is appended as a trailing `# 3.1.4` comment. `allowedIpRules` and
+ * `allowTlsRules` are not derived from `requests` -- a passthrough is never
+ * decrypted, so there is nothing in the traffic to build them from -- they
+ * are the same values the audit run was configured with, echoed back as-is,
+ * since they apply unchanged under `restrict` (only enforcement differs).
  */
 export function buildInspectRestrictExample(
   requests: TrafficEvent[] | null | undefined,
   actionRepo: string,
   actionRef?: string,
   actionVersion?: string,
+  allowedIpRules: string[] = [],
+  allowTlsRules: string[] = [],
 ): string {
   const lines = buildUrlRuleLines(requests ?? []);
-  if (lines.length === 0) return "";
+  if (lines.length === 0 && allowedIpRules.length === 0 && allowTlsRules.length === 0) return "";
 
   let yaml = "- name: Start Buildcage\n";
   yaml += `  uses: ${actionRepo}@${actionRef}${actionVersion ? ` # ${actionVersion}` : ""}\n`;
@@ -165,8 +171,18 @@ export function buildInspectRestrictExample(
   yaml += "    proxy_engine: inspect\n";
   // A literal block, not a folded one: a URL rule contains a space, so the
   // rules are separated by newlines and folding would join them into one.
-  yaml += "    allowed_url_rules: |\n";
-  for (const line of lines) yaml += `      ${line}\n`;
+  if (lines.length > 0) {
+    yaml += "    allowed_url_rules: |\n";
+    for (const line of lines) yaml += `      ${line}\n`;
+  }
+  if (allowTlsRules.length > 0) {
+    yaml += "    allow_tls_rules: |\n";
+    for (const rule of allowTlsRules) yaml += `      ${rule}\n`;
+  }
+  if (allowedIpRules.length > 0) {
+    yaml += "    allowed_ip_rules: |\n";
+    for (const rule of allowedIpRules) yaml += `      ${rule}\n`;
+  }
 
   // GitHub Actions' own indentation convention (jobs: -> <id>: -> steps: ->
   // "- name:") always puts a step 6 spaces in, so the generated snippet can
@@ -182,10 +198,8 @@ export function buildInspectRestrictExample(
   md += "```yaml\n";
   md += yaml;
   md += "```\n\n";
-  md +=
-    "These rules permit exactly what this build did, so read them before using them: a URL that\n";
-  md += "carried a version or a date will not match the next run, and anything reached through\n";
-  md += "`allow_tls_rules` or `allowed_ip_rules` is not here, because it was never inspected.\n\n";
+  md += "These rules permit exactly what this build did, so read them before using them: a URL\n";
+  md += "that carried a version or a date will not match the next run.\n\n";
   md += "</details>\n";
   return md;
 }

--- a/src/core/lib/report/render/render-report-markdown.test.ts
+++ b/src/core/lib/report/render/render-report-markdown.test.ts
@@ -8,6 +8,7 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
+    allowTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/render/render-report-markdown.ts
+++ b/src/core/lib/report/render/render-report-markdown.ts
@@ -40,7 +40,14 @@ export function renderReportMarkdown(
     // be that much narrower than one built from hosts alone.
     markdown +=
       report.engine === "inspect"
-        ? buildInspectRestrictExample(report.timeline, actionRepo, actionRef, actionVersion)
+        ? buildInspectRestrictExample(
+            report.timeline,
+            actionRepo,
+            actionRef,
+            actionVersion,
+            report.parameters.allowedIpRules,
+            report.parameters.allowTlsRules,
+          )
         : buildRestrictExample(report.passed, actionRepo, actionRef, actionVersion);
   }
   if (report.blocked.length > 0) {

--- a/src/core/lib/report/types.ts
+++ b/src/core/lib/report/types.ts
@@ -10,6 +10,7 @@ export interface GenReportParameters {
   allowedHttpsRules: string[];
   allowedHttpRules: string[];
   allowedIpRules: string[];
+  allowTlsRules: string[];
   /** Also drives whether the "Expected" column is shown (length > 0). */
   knownBlockedRules: string[];
 }

--- a/test/assert-inspect-audit.sh
+++ b/test/assert-inspect-audit.sh
@@ -84,7 +84,17 @@ else
   fail "no restrict-mode URL rule example was rendered"
 fi
 
-RULES=$(sed -n '/allowed_url_rules: |/,/```/p' <<< "$REPORT_MARKDOWN" | sed '1d;$d' | sed 's/^ *//')
+RULES=$(
+  awk '
+    # Stops at the next top-level key (allow_tls_rules/allowed_ip_rules are
+    # now echoed into the same fenced block, see inspect-example.ts) as well
+    # as the closing fence, so only the allowed_url_rules value is captured.
+    /allowed_url_rules: \|/ { capture=1; next }
+    capture && /^ *(allow_tls_rules|allowed_ip_rules): \|/ { exit }
+    capture && /```/ { exit }
+    capture { print }
+  ' <<< "$REPORT_MARKDOWN" | sed 's/^ *//'
+)
 echo "  ---- generated rules ----"
 sed 's/^/  /' <<< "$RULES"
 

--- a/test/run-inspect-roundtrip.sh
+++ b/test/run-inspect-roundtrip.sh
@@ -45,7 +45,15 @@ build test/Dockerfile.inspect-audit
 
 RULES=$(
   COMPOSE_FILE="$BASE_COMPOSE" GITHUB_STEP_SUMMARY= node report/src/main.ts 2>&1 |
-    sed -n '/allowed_url_rules: |/,/```/p' | sed '1d;$d' | sed 's/^ *//'
+    # Stops at the next top-level key (allow_tls_rules/allowed_ip_rules are
+    # now echoed into the same fenced block, see inspect-example.ts) as well
+    # as the closing fence, so only the allowed_url_rules value is captured.
+    awk '
+      /allowed_url_rules: \|/ { capture=1; next }
+      capture && /^ *(allow_tls_rules|allowed_ip_rules): \|/ { exit }
+      capture && /```/ { exit }
+      capture { print }
+    ' | sed 's/^ *//'
 )
 
 if [ -z "$RULES" ]; then


### PR DESCRIPTION
## Summary
- `allow_tls_rules` / `allowed_ip_rules` are action inputs, not traffic the `inspect` engine ever decrypts — there was nothing in the observed traffic to derive them from, so the generated "Switch to restrict mode" snippet simply dropped them, with a footnote saying they weren't included.
- Carry the values the audit run was configured with straight through into the generated snippet instead, since the same rule applies unchanged under `restrict` (only enforcement differs).
- The example section now also renders when there is no `allowed_url_rules` to show (no HTTP(S) traffic observed) but `allow_tls_rules`/`allowed_ip_rules` were configured — previously that case rendered nothing at all.

Note: no dist change — this logic ships inside the proxy image via `docker/{universal,inspect,explicit}/scripts/report-action.node.ts`, not the two dist bundles this repo commits.