### PR TITLE
feat: carry the resolved destination in the traffic artifact

### DIFF
--- a/src/core/lib/report/outcome/traffic-output.test.ts
+++ b/src/core/lib/report/outcome/traffic-output.test.ts
@@ -27,6 +27,7 @@ const EVENTS: TrafficEvent[] = [
     url: "https://a.example.com/pkg",
     status: 200,
     bytes: 708,
+    destination: "203.0.113.10",
   },
   {
     time: t + 1,
@@ -60,6 +61,16 @@ describe("buildTrafficRecords", () => {
     expect(r.url).toBe("https://a.example.com/pkg");
     expect(r.status).toBe(200);
     expect(r.bytes).toBe(708);
+  });
+
+  it("carries the resolved destination when the event has one", () => {
+    const r = records.find((r) => r.host === "a.example.com" && r.protocol === "https")!;
+    expect(r.destination).toBe("203.0.113.10");
+  });
+
+  it("omits destination when the event has none", () => {
+    const blocked = records.find((r) => r.action === "block" && r.protocol === "https")!;
+    expect("destination" in blocked).toBe(false);
   });
 
   it("keeps millisecond precision, not just whole seconds", () => {

--- a/src/core/lib/report/outcome/traffic-output.ts
+++ b/src/core/lib/report/outcome/traffic-output.ts
@@ -37,6 +37,8 @@ export interface TrafficRecord {
   bytes?: number;
   /** Present only when action is `block`. */
   reason?: string;
+  /** Address it was actually sent to. Absent for dns. */
+  destination?: string;
 }
 
 /**
@@ -67,6 +69,7 @@ export function buildTrafficRecords(
       if (e.status !== undefined) record.status = e.status;
       if (e.bytes !== undefined) record.bytes = e.bytes;
       if (e.reason !== undefined) record.reason = e.reason;
+      if (e.destination !== undefined) record.destination = e.destination;
       return record;
     });
 }


### PR DESCRIPTION
## Summary
- `traffic.json` (from `upload_traffic_artifact`) now includes a `destination` field with the address each request was actually sent to, absent for `dns` — mirroring the field isolated-run already writes into its own traffic artifact.
- The inspect log parser already resolved this value (`TrafficEvent.destination`); `buildTrafficRecords` was dropping it before serializing to `traffic.json`.

## Test plan
- [x] Run an `inspect`-engine build with `upload_traffic_artifact: true` and confirm the downloaded `traffic.json` includes `destination` on requests.