### PR TITLE
inspect: full regex port matching for ~ rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ Direct IP access bypasses DNS resolution, so it is handled separately: put those
 Prefix a rule with `~` to use a regular expression, matched against `domain:port`. Include a port
 pattern if you want to restrict by port — a range of addresses can be matched this way.
 
-| Rule                             | Effect                                                     |
-| -------------------------------- | ---------------------------------------------------------- |
-| `~^example\.com:443$`            | Matches `example.com` on port 443 only                     |
-| `~^example\.com:\d+$`            | Matches `example.com` on any port                          |
-| `~^.*\.example\.com:{443,8443}$` | Matches any subdomain of `example.com` on port 443 or 8443 |
-| `~^192\.168\.1\.\d+:80$`         | Matches a range of IP addresses (in `allowed_ip_rules`)    |
+| Rule                     | Effect                                                  |
+| ------------------------ | ------------------------------------------------------- |
+| `~^example\.com:443$`    | Matches `example.com` on port 443 only                  |
+| `~^example\.com:\d+$`    | Matches `example.com` on any port                       |
+| `~^.*\.example\.com:(443 | 8443)$`                                                 | Matches any subdomain of `example.com` on port 443 or 8443 |
+| `~^192\.168\.1\.\d+:80$` | Matches a range of IP addresses (in `allowed_ip_rules`) |
 
 ### Together
 

--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ Direct IP access bypasses DNS resolution, so it is handled separately: put those
 Prefix a rule with `~` to use a regular expression, matched against `domain:port`. Include a port
 pattern if you want to restrict by port — a range of addresses can be matched this way.
 
-| Rule                     | Effect                                                  |
-| ------------------------ | ------------------------------------------------------- |
-| `~^example\.com:443$`    | Matches `example.com` on port 443 only                  |
-| `~^example\.com:\d+$`    | Matches `example.com` on any port                       |
-| `~^.*\.example\.com:(443 | 8443)$`                                                 | Matches any subdomain of `example.com` on port 443 or 8443 |
-| `~^192\.168\.1\.\d+:80$` | Matches a range of IP addresses (in `allowed_ip_rules`) |
+| Rule                              | Effect                                                     |
+| --------------------------------- | ---------------------------------------------------------- |
+| `~^example\.com:443$`             | Matches `example.com` on port 443 only                     |
+| `~^example\.com:\d+$`             | Matches `example.com` on any port                          |
+| `~^.*\.example\.com:(443\|8443)$` | Matches any subdomain of `example.com` on port 443 or 8443 |
+| `~^192\.168\.1\.\d+:80$`          | Matches a range of IP addresses (in `allowed_ip_rules`)    |
 
 ### Together
 

--- a/compose.test-inspect.yaml
+++ b/compose.test-inspect.yaml
@@ -43,6 +43,10 @@ services:
         # Reuses blocked.example.com (see [Blocked host]), so it needs no cert
         # or DNS entry of its own.
         GET ~^https://blocked\.example\.com:9443/public/.*$
+
+        # No port at all: matches only the scheme's default (443), not 9443
+        # above -- a ~ URL rule's port is optional, unlike the other kinds.
+        GET ~^https://blocked\.example\.com/defaultport/.*$
     volumes:
       - ./test/test-server-inspect/cert.pem:/test-fixtures/test-server-cert.pem:ro
     networks:

--- a/compose.test-inspect.yaml
+++ b/compose.test-inspect.yaml
@@ -20,6 +20,9 @@ services:
       # host regex that was mangled as a wildcard would break the existing
       # :443 rule too, not just fail to add the new port.
       ALLOW_TLS_RULES: "tlspass.example.com:443 ~^tlspass\\.example\\.com:8443$"
+      # 9080 is distinct from the :80 the URL rule below already allows, so
+      # reaching it proves this rule's own doing.
+      ALLOWED_IP_RULES: "~^10\\.200\\.0\\.\\d+:9080$"
       ALLOWED_URL_RULES: |
         GET https://allowed.example.com/public/**
         GET https://allowed.example.com:9443/public/**

--- a/compose.test-inspect.yaml
+++ b/compose.test-inspect.yaml
@@ -16,7 +16,10 @@ services:
       # compose directly, tests the same ones. audit ignores them all.
       ALLOWED_HTTPS_RULES: "sub.wildcard.example.com:443 absent.example.com:443 metadata.example.com:443"
       ALLOWED_HTTP_RULES: allowed.example.com:80
-      ALLOW_TLS_RULES: tlspass.example.com:443
+      # The ~regex rule reuses tlspass.example.com on a second port, so a
+      # host regex that was mangled as a wildcard would break the existing
+      # :443 rule too, not just fail to add the new port.
+      ALLOW_TLS_RULES: "tlspass.example.com:443 ~^tlspass\\.example\\.com:8443$"
       ALLOWED_URL_RULES: |
         GET https://allowed.example.com/public/**
         GET https://allowed.example.com:9443/public/**

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -521,6 +521,30 @@ function wildcardToRegexPartial(pattern) {
 	let colonIndex = pattern.lastIndexOf(":"), domain = pattern.slice(0, colonIndex), port = pattern.slice(colonIndex + 1);
 	return `${domainToRegexPartial(domain)}:${port === "*" ? "\\d+" : port}`;
 }
+/**
+* Where a port pattern starts in a `<host>[:<port>]` regex fragment written
+* by a user: a bare `:`, or the `(` of a group opening right at the colon
+* (`(:8443)?`, `(:443|:8443)`). Splitting there, rather than at the last `:`
+* in the whole fragment, keeps a port group's own `(` out of the host half
+* so both halves stay balanced regexes on their own.
+*/
+const PORT_PATTERN_START = /\(:|:/;
+/**
+* Split a `<host>[:<port>]` regex fragment -- a `~` rule's own text, minus
+* any scheme/path around it -- into its domain-only prefix and the port
+* pattern (including its own leading `:` or `(`). `portPattern` is `null`
+* when the fragment names no port at all.
+*/
+function splitDomainFromPortPattern(hostPlusPort) {
+	let match = PORT_PATTERN_START.exec(hostPlusPort);
+	return match ? {
+		domain: hostPlusPort.slice(0, match.index),
+		portPattern: hostPlusPort.slice(match.index)
+	} : {
+		domain: hostPlusPort,
+		portPattern: null
+	};
+}
 //#endregion
 //#region src/core/lib/acl/url-rules.ts
 /**
@@ -600,9 +624,10 @@ const SLASH_TOKEN = /\\?\//, SCHEME_SEP = /:(?:\\?\/){2}/;
 * tries it against the connection's host both bare and with the real port,
 * so a pattern with no port at all matches only the scheme's default port,
 * and one ending in an optional port group (`(:8443)?`) matches either.
-* `authorityRegex` is the same host half with anything from its own `:`
-* onward dropped, for the resolver's allowlist, which has no notion of a
-* port to match against either way.
+* `authorityRegex` is the same host half with its port pattern dropped --
+* from its own `:`, or the `(` opening a group right at the colon -- for
+* the resolver's allowlist, which has no notion of a port to match against
+* either way; see splitDomainFromPortPattern.
 *
 * @throws {Error} if the text can't be split into a host and a path, or a
 *   resulting half fails to compile as a regex on its own
@@ -612,7 +637,7 @@ function splitRawRegexUrl(regex, rule) {
 	if (!schemeSep) throw Error(`Invalid regex in rule "${rule}": expected "://" (or an escaped equivalent like ":\\/\\/ ") separating the scheme from the host, so the host and path can be matched separately`);
 	let hostStart = schemeSep.index + schemeSep[0].length, pathSep = SLASH_TOKEN.exec(regex.slice(hostStart));
 	if (!pathSep) throw Error(`Invalid regex in rule "${rule}": expected a "/" (or "\\/") after "://" to start the path; a host-only rule belongs in allowed_https_rules instead`);
-	let pathStart = hostStart + pathSep.index, hostPart = regex.slice(hostStart, pathStart), colonIdx = hostPart.indexOf(":"), hostOnly = colonIdx === -1 ? hostPart : hostPart.slice(0, colonIdx), hostRegex = `^${hostPart}$`, authorityRegex = `^${hostOnly}$`, pathRegex = `^${regex.slice(pathStart)}`;
+	let pathStart = hostStart + pathSep.index, hostPart = regex.slice(hostStart, pathStart), { domain: hostOnly } = splitDomainFromPortPattern(hostPart), hostRegex = `^${hostPart}$`, authorityRegex = `^${hostOnly}$`, pathRegex = `^${regex.slice(pathStart)}`;
 	for (let [label, fragment] of [
 		["host", hostRegex],
 		["host-only", authorityRegex],

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -596,31 +596,34 @@ const SLASH_TOKEN = /\\?\//, SCHEME_SEP = /:(?:\\?\/){2}/;
 * expressions, never as one full-URL regex (see haproxy-config.ts's
 * ruleBlock), so the regex has to be cut at the first `/` after `://`.
 *
-* HAProxy's `dst_port` ACL only accepts a literal number, never a regex, so
-* a `:` in the host half is honoured only when followed by one; otherwise
-* the rule matches any port.
+* The host half's port is optional, exactly as in a literal URL: the proxy
+* tries it against the connection's host both bare and with the real port,
+* so a pattern with no port at all matches only the scheme's default port,
+* and one ending in an optional port group (`(:8443)?`) matches either.
+* `authorityRegex` is the same host half with anything from its own `:`
+* onward dropped, for the resolver's allowlist, which has no notion of a
+* port to match against either way.
 *
-* @throws {Error} if the text can't be split into a host and a path, its
-*   port isn't a literal number, or either half fails to compile alone
+* @throws {Error} if the text can't be split into a host and a path, or a
+*   resulting half fails to compile as a regex on its own
 */
 function splitRawRegexUrl(regex, rule) {
 	let schemeSep = SCHEME_SEP.exec(regex);
 	if (!schemeSep) throw Error(`Invalid regex in rule "${rule}": expected "://" (or an escaped equivalent like ":\\/\\/ ") separating the scheme from the host, so the host and path can be matched separately`);
 	let hostStart = schemeSep.index + schemeSep[0].length, pathSep = SLASH_TOKEN.exec(regex.slice(hostStart));
 	if (!pathSep) throw Error(`Invalid regex in rule "${rule}": expected a "/" (or "\\/") after "://" to start the path; a host-only rule belongs in allowed_https_rules instead`);
-	let pathStart = hostStart + pathSep.index, hostPart = regex.slice(hostStart, pathStart), port = null, colonIdx = hostPart.indexOf(":");
-	if (colonIdx !== -1) {
-		let portText = hostPart.slice(colonIdx + 1);
-		if (!/^\d+$/.test(portText)) throw Error(`Invalid regex in rule "${rule}": the port after ":" in the host ("${portText}") must be a literal number, since the destination port cannot be matched with a regex; write a plain number (e.g. "https://host:8443/x") or omit the port entirely to allow any port`);
-		port = portText, hostPart = hostPart.slice(0, colonIdx);
-	}
-	let authorityRegex = `^${hostPart}:${port ?? "[0-9]+"}$`, pathRegex = `^${regex.slice(pathStart)}`;
-	for (let [label, fragment] of [["host", `^${hostPart}$`], ["path", pathRegex]]) try {
+	let pathStart = hostStart + pathSep.index, hostPart = regex.slice(hostStart, pathStart), colonIdx = hostPart.indexOf(":"), hostOnly = colonIdx === -1 ? hostPart : hostPart.slice(0, colonIdx), hostRegex = `^${hostPart}$`, authorityRegex = `^${hostOnly}$`, pathRegex = `^${regex.slice(pathStart)}`;
+	for (let [label, fragment] of [
+		["host", hostRegex],
+		["host-only", authorityRegex],
+		["path", pathRegex]
+	]) try {
 		new RegExp(fragment);
 	} catch (e) {
 		throw Error(`Invalid regex in rule "${rule}": the ${label} part "${fragment}" does not compile on its own: ${e.message}`);
 	}
 	return {
+		hostRegex,
 		authorityRegex,
 		pathRegex
 	};
@@ -646,12 +649,14 @@ function compileUrl(url, rule) {
 		} catch (e) {
 			throw Error(`Invalid regex in rule "${rule}": ${e.message}`);
 		}
-		let { authorityRegex, pathRegex } = splitRawRegexUrl(regex, rule);
+		let { hostRegex, authorityRegex, pathRegex } = splitRawRegexUrl(regex, rule);
 		return {
 			scheme: "https",
 			regex,
 			authorityRegex,
-			pathRegex
+			pathRegex,
+			hostRegex,
+			isRegex: !0
 		};
 	}
 	let { scheme, authority, path } = splitUrl(url, rule), colonIndex = authority.lastIndexOf(":"), hasPort = colonIndex !== -1 && !authority.slice(colonIndex + 1).includes("]"), host = hasPort ? authority.slice(0, colonIndex) : authority, port = hasPort ? authority.slice(colonIndex + 1) : "";
@@ -662,7 +667,9 @@ function compileUrl(url, rule) {
 		scheme,
 		regex: `^${scheme}://${hostRegex}${portRegex}${pathRegex}$`,
 		authorityRegex,
-		pathRegex: path === "" ? "^/" : `^${pathRegex}$`
+		pathRegex: path === "" ? "^/" : `^${pathRegex}$`,
+		hostRegex,
+		isRegex: !1
 	};
 }
 /**
@@ -676,13 +683,15 @@ function convertUrlRule(rule) {
 	let methodSpec = trimmed.slice(0, separator.index), url = trimmed.slice(separator.index + separator[0].length).trim();
 	if (url === "") throw Error(`Invalid rule "${trimmed}": missing URL`);
 	if (/\s/.test(url)) throw Error(`Invalid rule "${trimmed}": URL must not contain whitespace`);
-	let methods = parseMethods(methodSpec, trimmed), { scheme, regex, authorityRegex, pathRegex } = compileUrl(url, trimmed);
+	let methods = parseMethods(methodSpec, trimmed), { scheme, regex, authorityRegex, pathRegex, hostRegex, isRegex } = compileUrl(url, trimmed);
 	return {
 		methods,
 		scheme,
 		regex,
 		authorityRegex,
 		pathRegex,
+		hostRegex,
+		isRegex,
 		raw: trimmed
 	};
 }

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -582,9 +582,10 @@ function splitDomainFromPortPattern(hostPlusPort) {
 * decodes %-escapes before matching, so that guard catches the encoded forms
 * too; see the squid config generator.
 */
+/** The scheme's own port, tried without being spelled out at all in a `~` URL rule's host half. */
 const DEFAULT_PORT = {
-	http: "80",
-	https: "443"
+	https: "443",
+	http: "80"
 };
 /**
 * Parse the method list preceding a URL.

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -98,9 +98,11 @@ no default, so a rule always states what it permits and nobody has to guess what
 
 **A `~` rule is split at the first `/` after `://`, not applied to the whole URL.** Everything before
 that `/` is the host, everything from it onward is the path — so `GET ~^https://example\.com/pub/.*$`
-becomes a host match on `example\.com` and a path match on `/pub/.*$`. A port in the host part must
-be a literal number (`example\.com:8443`); a regex there is not supported, since the destination port
-cannot be matched with one.
+becomes a host match on `example\.com` and a path match on `/pub/.*$`. The host half's own port
+pattern, if any, can be any regex (`example\.com:(443|8443)`, `example\.com:\d+`), matched against
+the connection's actual `host:port`. Omit it entirely and the rule matches only the scheme's default
+port (443 for `https`, 80 for `http`) — there is no implicit "any port"; write the port pattern
+yourself (e.g. `example\.com:.*`) to allow more than the default.
 
 **A wildcard may sit among literal text here**, in a path segment as in a domain label:
 `abc*.amazonaws.com`, `/pkg-*/**`. The other engines require a label containing `*` to be exactly
@@ -120,9 +122,10 @@ ever reaches an origin. Writing the host half as narrowly as the name actually n
 narrows the DNS-layer exposure; the path half narrows only the HTTP-layer one.
 
 `allowed_https_rules` and `allowed_http_rules` keep their existing `host:port` syntax and meaning,
-and are equivalent to a URL rule with any method and any path. Their own `~` regex, and
-`allow_tls_rules`'s, is checked the same way as a URL rule's: the destination port can never be
-matched with a regex, so a port must be a literal number or omitted, on penalty of the same error.
+and are equivalent to a URL rule with any method and any path. Their own `~` regex works unlike a URL
+rule's: the whole pattern is matched as one expression against `host:port` together, so the port can
+be any regex, but — unlike a URL rule — it can never be omitted; a `~` rule with no `:` at all is
+rejected. `allow_tls_rules` follows the same `~` rule.
 
 A rule may name an address rather than a name, in `allowed_url_rules` or the host rules. The proxy
 resolves the Host header to decide where to connect, and no resolver can answer an address, so one
@@ -141,8 +144,9 @@ the destination port are checked and the connection is passed through undecrypte
 validates the origin's own certificate. The name is still resolved here, so a passthrough goes where
 we resolved it and not where the client aimed. `allowed_ip_rules` covers the same for a destination
 with no name at all, and additionally accepts CIDR notation (`192.168.1.0/24:443`) directly; its `~`
-regex is checked the same literal-number-only way as the host rules above, matched against the
-destination stringified rather than HAProxy's IP-typed `dst` fetch, which a regex cannot match
+regex follows the same rule as the host rules above — a mandatory port, matched as part of one
+`address:port` expression — against the destination stringified rather than HAProxy's IP-typed `dst`
+fetch, which a regex cannot match
 directly.
 
 ## How a request is handled

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -139,7 +139,11 @@ a passthrough destination in practice.
 `allow_tls_rules` takes the same `host:port` syntax and covers TLS that is not HTTPS: the SNI and
 the destination port are checked and the connection is passed through undecrypted, so the build
 validates the origin's own certificate. The name is still resolved here, so a passthrough goes where
-we resolved it and not where the client aimed. `allowed_ip_rules` covers the same for a destination with no name at all.
+we resolved it and not where the client aimed. `allowed_ip_rules` covers the same for a destination
+with no name at all, and additionally accepts CIDR notation (`192.168.1.0/24:443`) directly; its `~`
+regex is checked the same literal-number-only way as the host rules above, matched against the
+destination stringified rather than HAProxy's IP-typed `dst` fetch, which a regex cannot match
+directly.
 
 ## How a request is handled
 

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -120,7 +120,9 @@ ever reaches an origin. Writing the host half as narrowly as the name actually n
 narrows the DNS-layer exposure; the path half narrows only the HTTP-layer one.
 
 `allowed_https_rules` and `allowed_http_rules` keep their existing `host:port` syntax and meaning,
-and are equivalent to a URL rule with any method and any path.
+and are equivalent to a URL rule with any method and any path. Their own `~` regex, and
+`allow_tls_rules`'s, is checked the same way as a URL rule's: the destination port can never be
+matched with a regex, so a port must be a literal number or omitted, on penalty of the same error.
 
 A rule may name an address rather than a name, in `allowed_url_rules` or the host rules. The proxy
 resolves the Host header to decide where to connect, and no resolver can answer an address, so one

--- a/src/core/lib/acl/coredns-config.test.ts
+++ b/src/core/lib/acl/coredns-config.test.ts
@@ -79,6 +79,14 @@ describe("allowlist scope", () => {
     ).toBe(true);
   });
 
+  it("takes the host from a ~regex host rule instead of mangling it as a wildcard", () => {
+    const result = generateCorednsConfig({
+      ...BASE,
+      tlsRules: ["~^.*\\.example\\.com:8443$"],
+    });
+    expect(exprLine(result.config).includes(".*\\\\.example\\\\.com")).toBe(true);
+  });
+
   it("takes the host from a ~regex url rule, with its port stripped from the host match", () => {
     const result = generateCorednsConfig({
       ...BASE,

--- a/src/core/lib/acl/coredns-config.ts
+++ b/src/core/lib/acl/coredns-config.ts
@@ -70,8 +70,12 @@ function hostRegexOfHostRule(pattern: string): string {
 
 /** The host half of a compiled URL rule, as a regex. */
 function hostRegexOfUrlRule(rule: UrlRule): string {
-  // authorityRegex is `^<hostRegex>:<port>$`.
+  // For a ~ rule, authorityRegex is already host-only (`^<host>$`): its port,
+  // if it named one, is optional and matched separately -- see
+  // haproxy-config.ts -- so there is nothing left to strip here.
   const inner = rule.authorityRegex.slice(1, -1);
+  if (rule.isRegex) return inner;
+  // Otherwise it is `^<hostRegex>:<port>$`.
   return inner.slice(0, inner.lastIndexOf(":"));
 }
 

--- a/src/core/lib/acl/coredns-config.ts
+++ b/src/core/lib/acl/coredns-config.ts
@@ -19,7 +19,7 @@
  */
 
 import type { UrlRule } from "./url-rules.ts";
-import { wildcardToRegexPartial } from "./partial-wildcard.ts";
+import { splitRawRegexHost, wildcardToRegexPartial } from "./partial-wildcard.ts";
 
 export interface CorednsConfigOptions {
   /** Host rules (`host:port` wildcards). Only the host half is used here. */
@@ -61,8 +61,9 @@ export function escapeForCel(regex: string): string {
   return regex.replace(/\\/g, "\\\\");
 }
 
-/** The host half of a `host:port` wildcard, as a regex. */
+/** The host half of a `host:port` wildcard, or a `~` regex, as a regex. */
 function hostRegexOfHostRule(pattern: string): string {
+  if (pattern.startsWith("~")) return splitRawRegexHost(pattern).host;
   const combined = wildcardToRegexPartial(pattern);
   return combined.slice(0, combined.lastIndexOf(":"));
 }

--- a/src/core/lib/acl/haproxy-config.test.ts
+++ b/src/core/lib/acl/haproxy-config.test.ts
@@ -302,6 +302,19 @@ describe("rules", () => {
     expect(config.includes("acl s0_port dst_port 8443")).toBe(true);
   });
 
+  it("matches a ~regex host rule's host and port as one expression", () => {
+    const config = gen({ httpsRules: ["~^.*\\.example\\.com:(443|8443)$"] });
+    expect(config.includes("set-var-fmt(txn.host_port) %[hdr(host),host_only]:%[dst_port]")).toBe(
+      true,
+    );
+    expect(
+      config.includes("acl s0_host var(txn.host_port) -m reg -i ^.*\\.example\\.com:(443|8443)$"),
+    ).toBe(true);
+    // The pattern's own port coverage replaces dst_port entirely.
+    expect(config.includes("s0_port")).toBe(false);
+    expect(config.includes("http-request deny unless s0_host s0_path")).toBe(true);
+  });
+
   it("omits the port acl only when the rule names every port", () => {
     const config = gen({ httpsRules: ["a.com:*"] });
     expect(config.includes("s0_port")).toBe(false);
@@ -369,6 +382,20 @@ describe("passthrough", () => {
     ).toBe(true);
   });
 
+  it("matches a ~regex tls rule's host and port as one expression against the SNI stringified", () => {
+    const result = generateHaproxyConfig({ tlsRules: ["~^.*\\.example\\.com:(5432|5433)$"] });
+    expect(result.config.includes("set-var-fmt(txn.sni_port) %[req.ssl_sni]:%[dst_port]")).toBe(
+      true,
+    );
+    expect(
+      result.config.includes(
+        "acl tls0_sni var(txn.sni_port) -m reg -i ^.*\\.example\\.com:(5432|5433)$",
+      ),
+    ).toBe(true);
+    // The pattern's own port coverage replaces dst_port entirely.
+    expect(result.config.includes("tls0_port")).toBe(false);
+  });
+
   it("also scopes the early do-resolve trigger by port, not just the backend selection", () => {
     // Regression: this used to set txn.tlsrule from the SNI ACL alone, so an
     // SNI matching db.example.com on a *different* port than the rule names
@@ -420,14 +447,19 @@ describe("passthrough", () => {
     expect(result.config.includes("ip0_dst")).toBe(false);
   });
 
-  it("matches a ~regex ip rule against the destination stringified, not as a literal address", () => {
-    const result = generateHaproxyConfig({ ipRules: ["~^192\\.168\\.1\\.\\d+:8080$"] });
+  it("matches a ~regex ip rule's address and port as one expression against the destination stringified", () => {
+    const result = generateHaproxyConfig({
+      ipRules: ["~^192\\.168\\.1\\.\\d+:(8080|8081)$"],
+    });
     expect(result.warnings.length).toBe(0);
-    expect(result.config.includes("set-var-fmt(txn.dst_str) %[dst]")).toBe(true);
+    expect(result.config.includes("set-var-fmt(txn.dst_str) %[dst]:%[dst_port]")).toBe(true);
     expect(
-      result.config.includes("acl ip0_dst var(txn.dst_str) -m reg ^192\\.168\\.1\\.\\d+$"),
+      result.config.includes(
+        "acl ip0_dst var(txn.dst_str) -m reg ^192\\.168\\.1\\.\\d+:(8080|8081)$",
+      ),
     ).toBe(true);
-    expect(result.config.includes("acl ip0_port dst_port 8080")).toBe(true);
+    // The pattern's own port coverage replaces dst_port entirely.
+    expect(result.config.includes("ip0_port")).toBe(false);
     // A literal rule still matches dst directly -- no need to stringify it.
     expect(
       generateHaproxyConfig({ ipRules: ["10.0.0.5:5432"] }).config.includes(
@@ -464,24 +496,48 @@ describe("audit mode", () => {
 });
 
 // ---------------------------------------------------------------------------
-// ~regex rules split at the first / after :// into a host and path ACL
+// ~regex url rules: host half matched bare/full, path stays a separate ACL
 // ---------------------------------------------------------------------------
-describe("regex rules", () => {
-  it("emits a host and path ACL, with no port ACL when the rule names none", () => {
+describe("regex url rules", () => {
+  it("builds the shared bare/full host variables and the default-port gate", () => {
     const result = generateHaproxyConfig({ urlRules: buildUrlRules("GET ~^https://a\\.com/x$") });
     expect(result.warnings.length).toBe(0);
     const segment = frontendSegment(result.config, "https_in");
-    expect(segment.includes("-m reg -i ^a\\.com$")).toBe(true);
+    expect(segment.includes("acl is_default_port dst_port 443")).toBe(true);
+    expect(segment.includes("set-var(txn.host_bare) hdr(host),host_only")).toBe(true);
+    expect(segment.includes("set-var-fmt(txn.host_full) %[hdr(host),host_only]:%[dst_port]")).toBe(
+      true,
+    );
+  });
+
+  it("ORs a bare (default-port-only) match with a full (real-port) match per rule", () => {
+    const result = generateHaproxyConfig({ urlRules: buildUrlRules("GET ~^https://a\\.com/x$") });
+    const segment = frontendSegment(result.config, "https_in");
+    expect(segment.includes("set-var(txn.s0_ok) bool(false)")).toBe(true);
+    expect(
+      segment.includes(
+        "set-var(txn.s0_ok) bool(true) if is_default_port { var(txn.host_bare) -m reg -i ^a\\.com$ }",
+      ),
+    ).toBe(true);
+    expect(
+      segment.includes(
+        "set-var(txn.s0_ok) bool(true) if { var(txn.host_full) -m reg -i ^a\\.com$ }",
+      ),
+    ).toBe(true);
+    expect(segment.includes("acl s0_host var(txn.s0_ok) -m bool")).toBe(true);
     expect(segment.includes("path -m reg ^/x$")).toBe(true);
+    expect(segment.includes("http-request deny unless s0_host s0_path s0_method")).toBe(true);
+    // No dst_port ACL at all: the bare/full duality covers the port.
     expect(segment.includes("s0_port")).toBe(false);
   });
 
-  it("emits a real dst_port ACL when the rule names a literal port", () => {
+  it("allows a non-literal port in the host half, matched as written", () => {
     const result = generateHaproxyConfig({
-      urlRules: buildUrlRules("GET ~^https://a\\.com:8443/x$"),
+      urlRules: buildUrlRules("GET ~^https://a\\.com:(443|8443)/x$"),
     });
+    expect(result.warnings.length).toBe(0);
     const segment = frontendSegment(result.config, "https_in");
-    expect(segment.includes("dst_port 8443")).toBe(true);
+    expect(segment.includes("-m reg -i ^a\\.com:(443|8443)$")).toBe(true);
   });
 });
 

--- a/src/core/lib/acl/haproxy-config.test.ts
+++ b/src/core/lib/acl/haproxy-config.test.ts
@@ -419,6 +419,22 @@ describe("passthrough", () => {
     expect(result.warnings.length).toBe(1);
     expect(result.config.includes("ip0_dst")).toBe(false);
   });
+
+  it("matches a ~regex ip rule against the destination stringified, not as a literal address", () => {
+    const result = generateHaproxyConfig({ ipRules: ["~^192\\.168\\.1\\.\\d+:8080$"] });
+    expect(result.warnings.length).toBe(0);
+    expect(result.config.includes("set-var-fmt(txn.dst_str) %[dst]")).toBe(true);
+    expect(
+      result.config.includes("acl ip0_dst var(txn.dst_str) -m reg ^192\\.168\\.1\\.\\d+$"),
+    ).toBe(true);
+    expect(result.config.includes("acl ip0_port dst_port 8080")).toBe(true);
+    // A literal rule still matches dst directly -- no need to stringify it.
+    expect(
+      generateHaproxyConfig({ ipRules: ["10.0.0.5:5432"] }).config.includes(
+        "set-var-fmt(txn.dst_str)",
+      ),
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -179,12 +179,19 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
     l.push(
       "    # Captured now, since the request buffer is gone by log time.",
       "    tcp-request content set-var(txn.sni) req.ssl_sni",
-      "",
-      "    # Passed through untouched: judged before anything is decrypted.",
     );
+    if (ipRules.some((rule) => rule.isRegex)) {
+      // dst is IP-typed; -m reg needs it as a string first.
+      l.push("    tcp-request content set-var-fmt(txn.dst_str) %[dst]");
+    }
+    l.push("", "    # Passed through untouched: judged before anything is decrypted.");
     for (const rule of ipRules) {
       l.push(`    # ${rule.raw}`);
-      l.push(`    acl ${rule.id}_dst dst ${rule.address}`);
+      l.push(
+        rule.isRegex
+          ? `    acl ${rule.id}_dst var(txn.dst_str) -m reg ^${rule.address}$`
+          : `    acl ${rule.id}_dst dst ${rule.address}`,
+      );
       if (rule.port) l.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
     }
     for (const host of tlsHosts) {

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -25,6 +25,7 @@ import {
   type CompiledRule,
   type RuleInputs,
 } from "./haproxy-rules.ts";
+import { DEFAULT_PORT } from "./url-rules.ts";
 
 export interface HaproxyConfigOptions extends RuleInputs {
   /** `audit` records without enforcing, so nothing may be refused. */
@@ -62,9 +63,6 @@ export interface GeneratedHaproxyConfig {
   config: string;
   warnings: string[];
 }
-
-/** The scheme's own port, tried without being spelled out at all in a `~` URL rule's host half. */
-const DEFAULT_PORT: Record<"https" | "http", number> = { https: 443, http: 80 };
 
 /** Emit the rule ACLs and the single deny that enforces them. */
 function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"): string[] {

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -63,8 +63,11 @@ export interface GeneratedHaproxyConfig {
   warnings: string[];
 }
 
+/** The scheme's own port, tried without being spelled out at all in a `~` URL rule's host half. */
+const DEFAULT_PORT: Record<"https" | "http", number> = { https: 443, http: 80 };
+
 /** Emit the rule ACLs and the single deny that enforces them. */
-function ruleBlock(rules: CompiledRule[], mode: string): string[] {
+function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"): string[] {
   const lines: string[] = [];
   if (mode === "audit") {
     lines.push("    # audit records without enforcing, so nothing is refused here.", "");
@@ -78,12 +81,42 @@ function ruleBlock(rules: CompiledRule[], mode: string): string[] {
     );
     return lines;
   }
+
+  if (rules.some((r) => r.hostMatch === "hostPort")) {
+    // A ~ rule's own regex covers host and port together, so hdr(host) is
+    // stringified with the real port once here for every such rule to match.
+    lines.push("    http-request set-var-fmt(txn.host_port) %[hdr(host),host_only]:%[dst_port]");
+  }
+  if (rules.some((r) => r.hostMatch === "hostBareFull")) {
+    // A ~ URL rule's port is optional, exactly as in a literal URL: tried
+    // without a port on the scheme's own default, and with the real port
+    // otherwise -- see haproxy-rules.ts's HostMatch doc comment.
+    lines.push(
+      `    acl is_default_port dst_port ${DEFAULT_PORT[scheme]}`,
+      "    http-request set-var(txn.host_bare) hdr(host),host_only",
+      "    http-request set-var-fmt(txn.host_full) %[hdr(host),host_only]:%[dst_port]",
+    );
+  }
+
   for (const rule of rules) {
     lines.push(`    # ${rule.raw}`);
-    // -i, since a name is case-insensitive and do-resolve lowercases anyway.
-    lines.push(`    acl ${rule.id}_host hdr(host),host_only -m reg -i ${rule.hostRegex}`);
-    if (rule.port) {
-      lines.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
+    if (rule.hostMatch === "hostPort") {
+      lines.push(`    acl ${rule.id}_host var(txn.host_port) -m reg -i ${rule.hostRegex}`);
+    } else if (rule.hostMatch === "hostBareFull") {
+      lines.push(
+        `    http-request set-var(txn.${rule.id}_ok) bool(false)`,
+        `    http-request set-var(txn.${rule.id}_ok) bool(true) if is_default_port ` +
+          `{ var(txn.host_bare) -m reg -i ${rule.hostRegex} }`,
+        `    http-request set-var(txn.${rule.id}_ok) bool(true) if ` +
+          `{ var(txn.host_full) -m reg -i ${rule.hostRegex} }`,
+        `    acl ${rule.id}_host var(txn.${rule.id}_ok) -m bool`,
+      );
+    } else {
+      // -i, since a name is case-insensitive and do-resolve lowercases anyway.
+      lines.push(`    acl ${rule.id}_host hdr(host),host_only -m reg -i ${rule.hostRegex}`);
+      if (rule.port) {
+        lines.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
+      }
     }
     lines.push(`    acl ${rule.id}_path path -m reg ${rule.pathRegex}`);
     if (rule.methods) {
@@ -180,23 +213,31 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
       "    # Captured now, since the request buffer is gone by log time.",
       "    tcp-request content set-var(txn.sni) req.ssl_sni",
     );
-    if (ipRules.some((rule) => rule.isRegex)) {
-      // dst is IP-typed; -m reg needs it as a string first.
-      l.push("    tcp-request content set-var-fmt(txn.dst_str) %[dst]");
+    if (ipRules.some((rule) => rule.hostMatch === "hostPort")) {
+      // dst is IP-typed; a ~ rule's own regex covers address and port
+      // together, so dst is stringified with the real port to match it.
+      l.push("    tcp-request content set-var-fmt(txn.dst_str) %[dst]:%[dst_port]");
+    }
+    if (tlsHosts.some((host) => host.hostMatch === "hostPort")) {
+      l.push("    tcp-request content set-var-fmt(txn.sni_port) %[req.ssl_sni]:%[dst_port]");
     }
     l.push("", "    # Passed through untouched: judged before anything is decrypted.");
     for (const rule of ipRules) {
       l.push(`    # ${rule.raw}`);
       l.push(
-        rule.isRegex
-          ? `    acl ${rule.id}_dst var(txn.dst_str) -m reg ^${rule.address}$`
+        rule.hostMatch === "hostPort"
+          ? `    acl ${rule.id}_dst var(txn.dst_str) -m reg ${rule.address}`
           : `    acl ${rule.id}_dst dst ${rule.address}`,
       );
       if (rule.port) l.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
     }
     for (const host of tlsHosts) {
       l.push(`    # ${host.raw}`);
-      l.push(`    acl ${host.id}_sni req.ssl_sni -m reg -i ${host.hostRegex}`);
+      l.push(
+        host.hostMatch === "hostPort"
+          ? `    acl ${host.id}_sni var(txn.sni_port) -m reg -i ${host.hostRegex}`
+          : `    acl ${host.id}_sni req.ssl_sni -m reg -i ${host.hostRegex}`,
+      );
       if (host.port) l.push(`    acl ${host.id}_port dst_port ${host.port}`);
     }
     const conds = [
@@ -287,7 +328,7 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
     name: string,
     port: number,
     bindExtra: string,
-    scheme: string,
+    scheme: "https" | "http",
     rules: CompiledRule[],
     backend: string,
   ) => {
@@ -323,7 +364,7 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
     // allow reaches the do-resolve below, so a name a request would be denied
     // for never triggers a real DNS query -- do-resolve is the only place a
     // real query leaves this proxy, and it must never run ahead of a deny.
-    l.push(...ruleBlock(rules, opts.mode ?? "restrict"));
+    l.push(...ruleBlock(rules, opts.mode ?? "restrict", scheme));
     if (resolvers.length > 0) {
       l.push(
         "    # Connect where WE resolve the Host, discarding the client's address,",

--- a/src/core/lib/acl/haproxy-rules.test.ts
+++ b/src/core/lib/acl/haproxy-rules.test.ts
@@ -7,12 +7,18 @@ describe("host and url rule compilation", () => {
     // The port belongs to the connection, so a header omitting a default port
     // cannot make host:9443 also permit host on 443.
     const [rule] = compileRuleSet({ httpsRules: ["a.com:9443"] }).https;
+    expect(rule.hostMatch).toBe("wildcard");
     expect(rule.hostRegex).toBe("^a\\.com$");
     expect(rule.port).toBe("9443");
   });
 
   it("reports any-port as null rather than a literal", () => {
     expect(compileRuleSet({ httpsRules: ["a.com:*"] }).https[0].port).toBe(null);
+  });
+
+  it("rejects a host rule with no port at all", () => {
+    expect(() => compileRuleSet({ httpsRules: ["a.com"] })).toThrow(/missing port/);
+    expect(() => compileRuleSet({ httpRules: ["a.com"] })).toThrow(/missing port/);
   });
 
   it("gives a host rule any path and no method", () => {
@@ -49,26 +55,31 @@ describe("host and url rule compilation", () => {
     expect(set.http[0].id).toBe("p0");
   });
 
-  it("splits a ~regex rule into a host and path match, with no port restriction", () => {
+  it("gives a ~regex url rule's host half bare/full matching, with no port acl", () => {
     const set = compileRuleSet({ urlRules: buildUrlRules("GET ~^https://a\\.com/x$") });
     expect(set.warnings.length).toBe(0);
     expect(set.https.length).toBe(1);
+    expect(set.https[0].hostMatch).toBe("hostBareFull");
     expect(set.https[0].hostRegex).toBe("^a\\.com$");
     expect(set.https[0].port).toBe(null);
     expect(set.https[0].pathRegex).toBe("^/x$");
     expect(set.https[0].methods?.join()).toBe("GET");
   });
 
-  it("carries a literal port in a ~regex rule through to a real port restriction", () => {
-    const set = compileRuleSet({ urlRules: buildUrlRules("GET ~^https://a\\.com:8443/x$") });
-    expect(set.https[0].hostRegex).toBe("^a\\.com$");
-    expect(set.https[0].port).toBe("8443");
+  it("keeps a ~regex url rule's own port pattern in the host half untouched", () => {
+    // No literal-only restriction any more: the whole host half, port
+    // pattern included, is matched as one expression -- see haproxy-config.ts.
+    const set = compileRuleSet({ urlRules: buildUrlRules("GET ~^https://a\\.com:(443|8443)/x$") });
+    expect(set.https[0].hostMatch).toBe("hostBareFull");
+    expect(set.https[0].hostRegex).toBe("^a\\.com:(443|8443)$");
+    expect(set.https[0].port).toBe(null);
   });
 });
 
 describe("ip rule compilation", () => {
   it("keeps an address and its port", () => {
     const [rule] = compileRuleSet({ ipRules: ["10.0.0.5:5432"] }).ip;
+    expect(rule.hostMatch).toBe("wildcard");
     expect(rule.address).toBe("10.0.0.5");
     expect(rule.port).toBe("5432");
   });
@@ -93,33 +104,28 @@ describe("ip rule compilation", () => {
     expect(compileRuleSet({ ipRules: ["10.0.0.0/24:5432"] }).ip[0].address).toBe("10.0.0.0/24");
   });
 
-  it("passes a ~regex ip rule through instead of requiring a literal address", () => {
-    const [rule] = compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+$"] }).ip;
-    expect(rule.address).toBe("192\\.168\\.1\\.\\d+");
-    expect(rule.isRegex).toBe(true);
+  it("matches a ~regex ip rule's address and port as one expression", () => {
+    const [rule] = compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+:(8080|8081)$"] }).ip;
+    expect(rule.hostMatch).toBe("hostPort");
+    expect(rule.address).toBe("^192\\.168\\.1\\.\\d+:(8080|8081)$");
     expect(rule.port).toBe(null);
   });
 
-  it("carries a literal port in a ~regex ip rule through to a real port restriction", () => {
-    const [rule] = compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+:8080$"] }).ip;
-    expect(rule.address).toBe("192\\.168\\.1\\.\\d+");
-    expect(rule.port).toBe("8080");
-  });
-
-  it("rejects a non-literal port in a ~regex ip rule", () => {
-    expect(() => compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+:\\d+$"] })).toThrow(
-      /literal number/,
+  it("rejects a ~regex ip rule with no port at all", () => {
+    expect(() => compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+$"] })).toThrow(
+      /port is always required/,
     );
   });
 
   it("does not treat a literal address as a regex", () => {
-    expect(compileRuleSet({ ipRules: ["10.0.0.5:5432"] }).ip[0].isRegex).toBe(false);
+    expect(compileRuleSet({ ipRules: ["10.0.0.5:5432"] }).ip[0].hostMatch).toBe("wildcard");
   });
 });
 
 describe("tls rule compilation", () => {
   it("keeps the host and the port it names", () => {
     const [rule] = compileRuleSet({ tlsRules: ["db.example.com:5432"] }).tls;
+    expect(rule.hostMatch).toBe("wildcard");
     expect(rule.hostRegex).toBe("^db\\.example\\.com$");
     expect(rule.port).toBe("5432");
   });
@@ -128,26 +134,18 @@ describe("tls rule compilation", () => {
     expect(compileRuleSet({ tlsRules: ["db.example.com:*"] }).tls[0].port).toBe(null);
   });
 
-  it("passes a ~regex host rule through instead of treating it as a wildcard", () => {
+  it("matches a ~regex host rule's host and port as one expression", () => {
     // "." and "*" would otherwise be rewritten by domainToRegexPartial's own
     // wildcard vocabulary; a ~ rule must skip that and use the regex as-is.
-    const [rule] = compileRuleSet({ tlsRules: ["~^.*\\.example\\.com$"] }).tls;
-    expect(rule.hostRegex).toBe("^.*\\.example\\.com$");
+    const [rule] = compileRuleSet({ tlsRules: ["~^.*\\.example\\.com:(443|8443)$"] }).tls;
+    expect(rule.hostMatch).toBe("hostPort");
+    expect(rule.hostRegex).toBe("^.*\\.example\\.com:(443|8443)$");
     expect(rule.port).toBe(null);
   });
 
-  it("carries a literal port in a ~regex host rule through to a real port restriction", () => {
-    const [rule] = compileRuleSet({ tlsRules: ["~^example\\.com:8443$"] }).tls;
-    expect(rule.hostRegex).toBe("^example\\.com$");
-    expect(rule.port).toBe("8443");
-  });
-
-  it("rejects a non-literal port in a ~regex host rule", () => {
-    // Neither a \d+ shorthand nor an alternation is a literal number, and
-    // HAProxy's dst_port ACL cannot match either as a regex.
-    expect(() => compileRuleSet({ tlsRules: ["~^example\\.com:\\d+$"] })).toThrow(/literal number/);
-    expect(() => compileRuleSet({ tlsRules: ["~^example\\.com:(443|8443)$"] })).toThrow(
-      /literal number/,
+  it("rejects a ~regex host rule with no port at all", () => {
+    expect(() => compileRuleSet({ tlsRules: ["~^example\\.com$"] })).toThrow(
+      /port is always required/,
     );
   });
 });

--- a/src/core/lib/acl/haproxy-rules.test.ts
+++ b/src/core/lib/acl/haproxy-rules.test.ts
@@ -104,6 +104,29 @@ describe("tls rule compilation", () => {
   it("reports any-port as null", () => {
     expect(compileRuleSet({ tlsRules: ["db.example.com:*"] }).tls[0].port).toBe(null);
   });
+
+  it("passes a ~regex host rule through instead of treating it as a wildcard", () => {
+    // "." and "*" would otherwise be rewritten by domainToRegexPartial's own
+    // wildcard vocabulary; a ~ rule must skip that and use the regex as-is.
+    const [rule] = compileRuleSet({ tlsRules: ["~^.*\\.example\\.com$"] }).tls;
+    expect(rule.hostRegex).toBe("^.*\\.example\\.com$");
+    expect(rule.port).toBe(null);
+  });
+
+  it("carries a literal port in a ~regex host rule through to a real port restriction", () => {
+    const [rule] = compileRuleSet({ tlsRules: ["~^example\\.com:8443$"] }).tls;
+    expect(rule.hostRegex).toBe("^example\\.com$");
+    expect(rule.port).toBe("8443");
+  });
+
+  it("rejects a non-literal port in a ~regex host rule", () => {
+    // Neither a \d+ shorthand nor an alternation is a literal number, and
+    // HAProxy's dst_port ACL cannot match either as a regex.
+    expect(() => compileRuleSet({ tlsRules: ["~^example\\.com:\\d+$"] })).toThrow(/literal number/);
+    expect(() => compileRuleSet({ tlsRules: ["~^example\\.com:(443|8443)$"] })).toThrow(
+      /literal number/,
+    );
+  });
 });
 
 reportResults();

--- a/src/core/lib/acl/haproxy-rules.test.ts
+++ b/src/core/lib/acl/haproxy-rules.test.ts
@@ -92,6 +92,29 @@ describe("ip rule compilation", () => {
   it("accepts a CIDR block", () => {
     expect(compileRuleSet({ ipRules: ["10.0.0.0/24:5432"] }).ip[0].address).toBe("10.0.0.0/24");
   });
+
+  it("passes a ~regex ip rule through instead of requiring a literal address", () => {
+    const [rule] = compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+$"] }).ip;
+    expect(rule.address).toBe("192\\.168\\.1\\.\\d+");
+    expect(rule.isRegex).toBe(true);
+    expect(rule.port).toBe(null);
+  });
+
+  it("carries a literal port in a ~regex ip rule through to a real port restriction", () => {
+    const [rule] = compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+:8080$"] }).ip;
+    expect(rule.address).toBe("192\\.168\\.1\\.\\d+");
+    expect(rule.port).toBe("8080");
+  });
+
+  it("rejects a non-literal port in a ~regex ip rule", () => {
+    expect(() => compileRuleSet({ ipRules: ["~^192\\.168\\.1\\.\\d+:\\d+$"] })).toThrow(
+      /literal number/,
+    );
+  });
+
+  it("does not treat a literal address as a regex", () => {
+    expect(compileRuleSet({ ipRules: ["10.0.0.5:5432"] }).ip[0].isRegex).toBe(false);
+  });
 });
 
 describe("tls rule compilation", () => {

--- a/src/core/lib/acl/haproxy-rules.ts
+++ b/src/core/lib/acl/haproxy-rules.ts
@@ -40,12 +40,29 @@ export const INTERNAL_RANGES = [
   "fc00::/7",
 ];
 
+/**
+ * How a rule's host half is matched:
+ *
+ *  - "wildcard": `hostRegex` names the host alone; `port`, if any, is a
+ *    literal number matched separately (HAProxy's dst_port ACL).
+ *  - "hostPort": a `~` host/tls/ip rule. `hostRegex` is the user's whole
+ *    regex, covering host and port together, matched as one expression
+ *    against the connection stringified. `port` is always null -- the
+ *    pattern's own port coverage replaces it, and a port can never be
+ *    matched with a regex through dst_port.
+ *  - "hostBareFull": a `~` URL rule's host half. `hostRegex` covers the host
+ *    alone (port optional in the pattern), tried against two forms of the
+ *    connection: without a port when the connection is on the scheme's
+ *    default port, and with the real port otherwise. `port` is always null.
+ */
+export type HostMatch = "wildcard" | "hostPort" | "hostBareFull";
+
 /** A host/URL rule, matched on host, port, path and (for URL rules) method. */
 export interface CompiledRule {
   id: string;
-  /** Matches the name alone; the port is matched separately. */
+  hostMatch: HostMatch;
   hostRegex: string;
-  /** The port the rule names, or null for any port. */
+  /** The port the rule names, or null for any port. Only meaningful when `hostMatch` is "wildcard". */
   port: string | null;
   pathRegex: string;
   methods: string[] | null;
@@ -55,10 +72,9 @@ export interface CompiledRule {
 /** An IP rule, tunnelled at TCP level without inspection. */
 export interface CompiledIpRule {
   id: string;
-  /** A literal IPv4 address or CIDR block, or (when `isRegex`) an unanchored regex matching one as text. */
+  /** A literal IPv4 address or CIDR block, or (when `hostMatch` is "hostPort") the whole "address:port" regex. */
   address: string;
-  /** Whether `address` is a `~` rule's regex, matched against the destination stringified. */
-  isRegex: boolean;
+  hostMatch: "wildcard" | "hostPort";
   port: string | null;
   raw: string;
 }
@@ -66,6 +82,7 @@ export interface CompiledIpRule {
 /** A TLS rule, judged on SNI and passed through undecrypted. */
 export interface CompiledTlsRule {
   id: string;
+  hostMatch: "wildcard" | "hostPort";
   hostRegex: string;
   port: string | null;
   raw: string;
@@ -110,15 +127,29 @@ function splitHostAndPort(hostRegexWithPort: string): { hostRegex: string; port:
 }
 
 /** Turn a `host:port` wildcard, or a `~` regex, into a host matcher and the port it names. */
-function hostRuleToMatcher(pattern: string): { hostRegex: string; port: string | null } {
+function hostRuleToMatcher(pattern: string): {
+  hostMatch: "wildcard" | "hostPort";
+  hostRegex: string;
+  port: string | null;
+} {
   if (pattern.startsWith("~")) {
-    const { host, port } = splitRawRegexHost(pattern);
-    return { hostRegex: `^${host}$`, port };
+    // Validates: the regex compiles, it names a port, and the host half
+    // compiles alone -- the host half itself is only needed by
+    // coredns-config.ts, but the checks apply here just the same.
+    splitRawRegexHost(pattern);
+    return { hostMatch: "hostPort", hostRegex: pattern.slice(1), port: null };
   }
   const colonIndex = pattern.lastIndexOf(":");
-  const portText = colonIndex === -1 ? "*" : pattern.slice(colonIndex + 1);
-  const hostPattern = colonIndex === -1 ? pattern : pattern.slice(0, colonIndex);
+  if (colonIndex === -1) {
+    throw new Error(`Invalid rule "${pattern}": missing port`);
+  }
+  const portText = pattern.slice(colonIndex + 1);
+  const hostPattern = pattern.slice(0, colonIndex);
+  if (!/^(?:\d+|\*)$/.test(portText)) {
+    throw new Error(`Invalid port in rule "${pattern}": "${portText}"`);
+  }
   return {
+    hostMatch: "wildcard",
     hostRegex: `^${domainToRegexPartial(hostPattern)}$`,
     port: portText === "*" ? null : portText,
   };
@@ -142,8 +173,21 @@ function compileSchemeRules(
   }
   for (const rule of urlRules ?? []) {
     if (rule.scheme !== scheme) continue;
+    if (rule.isRegex) {
+      out.push({
+        id: "",
+        hostMatch: "hostBareFull",
+        hostRegex: rule.hostRegex,
+        port: null,
+        pathRegex: rule.pathRegex,
+        methods: rule.methods,
+        raw: rule.raw,
+      });
+      continue;
+    }
     out.push({
       id: "",
+      hostMatch: "wildcard",
       // authorityRegex is `^<hostRegex>:<port>$`.
       ...splitHostAndPort(rule.authorityRegex.slice(1, -1)),
       pathRegex: rule.pathRegex,
@@ -161,8 +205,16 @@ function compileIpRules(rules: string[] | undefined, warnings: string[]): Compil
   const out: CompiledIpRule[] = [];
   (rules ?? []).forEach((rule, index) => {
     if (rule.startsWith("~")) {
-      const { host, port } = splitRawRegexHost(rule);
-      out.push({ id: `ip${index}`, address: host, isRegex: true, port, raw: rule });
+      // Validates: the regex compiles and it names a port -- see
+      // hostRuleToMatcher for why this is checked here too.
+      splitRawRegexHost(rule);
+      out.push({
+        id: `ip${index}`,
+        address: rule.slice(1),
+        hostMatch: "hostPort",
+        port: null,
+        raw: rule,
+      });
       return;
     }
     const colonIndex = rule.lastIndexOf(":");
@@ -182,7 +234,7 @@ function compileIpRules(rules: string[] | undefined, warnings: string[]): Compil
     out.push({
       id: `ip${index}`,
       address,
-      isRegex: false,
+      hostMatch: "wildcard",
       port: port === "*" ? null : port,
       raw: rule,
     });

--- a/src/core/lib/acl/haproxy-rules.ts
+++ b/src/core/lib/acl/haproxy-rules.ts
@@ -55,7 +55,10 @@ export interface CompiledRule {
 /** An IP rule, tunnelled at TCP level without inspection. */
 export interface CompiledIpRule {
   id: string;
+  /** A literal IPv4 address or CIDR block, or (when `isRegex`) an unanchored regex matching one as text. */
   address: string;
+  /** Whether `address` is a `~` rule's regex, matched against the destination stringified. */
+  isRegex: boolean;
   port: string | null;
   raw: string;
 }
@@ -157,6 +160,11 @@ function compileSchemeRules(
 function compileIpRules(rules: string[] | undefined, warnings: string[]): CompiledIpRule[] {
   const out: CompiledIpRule[] = [];
   (rules ?? []).forEach((rule, index) => {
+    if (rule.startsWith("~")) {
+      const { host, port } = splitRawRegexHost(rule);
+      out.push({ id: `ip${index}`, address: host, isRegex: true, port, raw: rule });
+      return;
+    }
     const colonIndex = rule.lastIndexOf(":");
     if (colonIndex === -1) {
       warnings.push(`IP rule ${JSON.stringify(rule)} has no port. It is ignored.`);
@@ -171,7 +179,13 @@ function compileIpRules(rules: string[] | undefined, warnings: string[]): Compil
       );
       return;
     }
-    out.push({ id: `ip${index}`, address, port: port === "*" ? null : port, raw: rule });
+    out.push({
+      id: `ip${index}`,
+      address,
+      isRegex: false,
+      port: port === "*" ? null : port,
+      raw: rule,
+    });
   });
   return out;
 }

--- a/src/core/lib/acl/haproxy-rules.ts
+++ b/src/core/lib/acl/haproxy-rules.ts
@@ -5,7 +5,7 @@
  */
 
 import type { UrlRule } from "./url-rules.ts";
-import { domainToRegexPartial } from "./partial-wildcard.ts";
+import { domainToRegexPartial, splitRawRegexHost } from "./partial-wildcard.ts";
 
 /** An IPv4 address or CIDR block, which is what HAProxy's `dst` acl accepts. */
 const IPV4_OR_CIDR = /^\d{1,3}(?:\.\d{1,3}){3}(?:\/\d{1,2})?$/;
@@ -106,8 +106,12 @@ function splitHostAndPort(hostRegexWithPort: string): { hostRegex: string; port:
   };
 }
 
-/** Turn a `host:port` wildcard into a host matcher and the port it names. */
+/** Turn a `host:port` wildcard, or a `~` regex, into a host matcher and the port it names. */
 function hostRuleToMatcher(pattern: string): { hostRegex: string; port: string | null } {
+  if (pattern.startsWith("~")) {
+    const { host, port } = splitRawRegexHost(pattern);
+    return { hostRegex: `^${host}$`, port };
+  }
   const colonIndex = pattern.lastIndexOf(":");
   const portText = colonIndex === -1 ? "*" : pattern.slice(colonIndex + 1);
   const hostPattern = colonIndex === -1 ? pattern : pattern.slice(0, colonIndex);

--- a/src/core/lib/acl/partial-wildcard.ts
+++ b/src/core/lib/acl/partial-wildcard.ts
@@ -114,16 +114,16 @@ export function wildcardToRegexPartial(pattern: string): string {
 }
 
 /**
- * Split a `~` host rule's raw regex into an unanchored host fragment and its
- * port. Bypasses domainToRegexPartial/wildcardToRegexPartial entirely, since
- * those would mangle the user's own regex syntax. HAProxy's dst_port ACL only
- * accepts a literal number, never a regex, so the port is honoured only when
- * it is one.
+ * Extract the host-only fragment from a `~` host rule's raw regex, for the
+ * resolver's allowlist: a DNS query carries no port, so whatever follows the
+ * last ":" is dropped here regardless of its shape. Enforcement uses the raw
+ * regex directly instead (see haproxy-rules.ts), matched as one expression
+ * against the connection, so this function exists only for coredns-config.ts.
  *
- * @throws {Error} if the regex is invalid, its port is not a literal number,
- *   or the host half does not compile as a regex on its own
+ * @throws {Error} if the regex is invalid, it names no port at all (a port is
+ *   always required), or the host half does not compile as a regex on its own
  */
-export function splitRawRegexHost(pattern: string): { host: string; port: string | null } {
+export function splitRawRegexHost(pattern: string): { host: string } {
   const regex = pattern.slice(1);
   try {
     new RegExp(regex);
@@ -132,28 +132,14 @@ export function splitRawRegexHost(pattern: string): { host: string; port: string
   }
 
   const colonIndex = regex.lastIndexOf(":");
-  let host: string;
-  let port: string | null;
   if (colonIndex === -1) {
-    host = regex;
-    port = null;
-  } else {
-    host = regex.slice(0, colonIndex);
-    let portText = regex.slice(colonIndex + 1);
-    if (portText.endsWith("$")) portText = portText.slice(0, -1);
-    if (!/^\d+$/.test(portText)) {
-      throw new Error(
-        `Invalid regex in rule "${pattern}": the port after the last ":" ("${portText}") must be ` +
-          `a literal number, since the destination port cannot be matched with a regex; write a ` +
-          `plain number (e.g. "~^example\\.com:8443$") or omit the port entirely to allow any port`,
-      );
-    }
-    port = portText;
+    throw new Error(
+      `Invalid regex in rule "${pattern}": expected ":" separating the host from a port; a port ` +
+        `is always required`,
+    );
   }
-  // A leftover $ would close coredns-config.ts's larger alternation early;
-  // each caller re-anchors the host on its own terms instead.
+  let host = regex.slice(0, colonIndex);
   if (host.startsWith("^")) host = host.slice(1);
-  if (host.endsWith("$")) host = host.slice(0, -1);
 
   try {
     new RegExp(host);
@@ -163,5 +149,5 @@ export function splitRawRegexHost(pattern: string): { host: string; port: string
         `${(e as Error).message}`,
     );
   }
-  return { host, port };
+  return { host };
 }

--- a/src/core/lib/acl/partial-wildcard.ts
+++ b/src/core/lib/acl/partial-wildcard.ts
@@ -114,11 +114,38 @@ export function wildcardToRegexPartial(pattern: string): string {
 }
 
 /**
+ * Where a port pattern starts in a `<host>[:<port>]` regex fragment written
+ * by a user: a bare `:`, or the `(` of a group opening right at the colon
+ * (`(:8443)?`, `(:443|:8443)`). Splitting there, rather than at the last `:`
+ * in the whole fragment, keeps a port group's own `(` out of the host half
+ * so both halves stay balanced regexes on their own.
+ */
+const PORT_PATTERN_START = /\(:|:/;
+
+/**
+ * Split a `<host>[:<port>]` regex fragment -- a `~` rule's own text, minus
+ * any scheme/path around it -- into its domain-only prefix and the port
+ * pattern (including its own leading `:` or `(`). `portPattern` is `null`
+ * when the fragment names no port at all.
+ */
+export function splitDomainFromPortPattern(hostPlusPort: string): {
+  domain: string;
+  portPattern: string | null;
+} {
+  const match = PORT_PATTERN_START.exec(hostPlusPort);
+  if (!match) return { domain: hostPlusPort, portPattern: null };
+  return {
+    domain: hostPlusPort.slice(0, match.index),
+    portPattern: hostPlusPort.slice(match.index),
+  };
+}
+
+/**
  * Extract the host-only fragment from a `~` host rule's raw regex, for the
- * resolver's allowlist: a DNS query carries no port, so whatever follows the
- * last ":" is dropped here regardless of its shape. Enforcement uses the raw
- * regex directly instead (see haproxy-rules.ts), matched as one expression
- * against the connection, so this function exists only for coredns-config.ts.
+ * resolver's allowlist: a DNS query carries no port, so whatever names a port
+ * is dropped here regardless of its shape. Enforcement uses the raw regex
+ * directly instead (see haproxy-rules.ts), matched as one expression against
+ * the connection, so this function exists only for coredns-config.ts.
  *
  * @throws {Error} if the regex is invalid, it names no port at all (a port is
  *   always required), or the host half does not compile as a regex on its own
@@ -131,14 +158,14 @@ export function splitRawRegexHost(pattern: string): { host: string } {
     throw new Error(`Invalid regex in rule "${pattern}": ${(e as Error).message}`);
   }
 
-  const colonIndex = regex.lastIndexOf(":");
-  if (colonIndex === -1) {
+  const { domain, portPattern } = splitDomainFromPortPattern(regex);
+  if (portPattern === null) {
     throw new Error(
       `Invalid regex in rule "${pattern}": expected ":" separating the host from a port; a port ` +
         `is always required`,
     );
   }
-  let host = regex.slice(0, colonIndex);
+  let host = domain;
   if (host.startsWith("^")) host = host.slice(1);
 
   try {

--- a/src/core/lib/acl/partial-wildcard.ts
+++ b/src/core/lib/acl/partial-wildcard.ts
@@ -112,3 +112,56 @@ export function wildcardToRegexPartial(pattern: string): string {
   const port = pattern.slice(colonIndex + 1);
   return `${domainToRegexPartial(domain)}:${port === "*" ? "\\d+" : port}`;
 }
+
+/**
+ * Split a `~` host rule's raw regex into an unanchored host fragment and its
+ * port. Bypasses domainToRegexPartial/wildcardToRegexPartial entirely, since
+ * those would mangle the user's own regex syntax. HAProxy's dst_port ACL only
+ * accepts a literal number, never a regex, so the port is honoured only when
+ * it is one.
+ *
+ * @throws {Error} if the regex is invalid, its port is not a literal number,
+ *   or the host half does not compile as a regex on its own
+ */
+export function splitRawRegexHost(pattern: string): { host: string; port: string | null } {
+  const regex = pattern.slice(1);
+  try {
+    new RegExp(regex);
+  } catch (e) {
+    throw new Error(`Invalid regex in rule "${pattern}": ${(e as Error).message}`);
+  }
+
+  const colonIndex = regex.lastIndexOf(":");
+  let host: string;
+  let port: string | null;
+  if (colonIndex === -1) {
+    host = regex;
+    port = null;
+  } else {
+    host = regex.slice(0, colonIndex);
+    let portText = regex.slice(colonIndex + 1);
+    if (portText.endsWith("$")) portText = portText.slice(0, -1);
+    if (!/^\d+$/.test(portText)) {
+      throw new Error(
+        `Invalid regex in rule "${pattern}": the port after the last ":" ("${portText}") must be ` +
+          `a literal number, since the destination port cannot be matched with a regex; write a ` +
+          `plain number (e.g. "~^example\\.com:8443$") or omit the port entirely to allow any port`,
+      );
+    }
+    port = portText;
+  }
+  // A leftover $ would close coredns-config.ts's larger alternation early;
+  // each caller re-anchors the host on its own terms instead.
+  if (host.startsWith("^")) host = host.slice(1);
+  if (host.endsWith("$")) host = host.slice(0, -1);
+
+  try {
+    new RegExp(host);
+  } catch (e) {
+    throw new Error(
+      `Invalid regex in rule "${pattern}": the host part "${host}" does not compile on its own: ` +
+        `${(e as Error).message}`,
+    );
+  }
+  return { host, port };
+}

--- a/src/core/lib/acl/url-rules.test.ts
+++ b/src/core/lib/acl/url-rules.test.ts
@@ -100,13 +100,15 @@ describe("convertUrlRule regex escape hatch", () => {
 
   it("splits into a host half and a path half at the first / after ://", () => {
     const r = convertUrlRule("GET ~^https://a\\.com/x$");
-    expect(r.authorityRegex).toBe("^a\\.com:[0-9]+$");
+    expect(r.hostRegex).toBe("^a\\.com$");
+    expect(r.authorityRegex).toBe("^a\\.com$");
     expect(r.pathRegex).toBe("^/x$");
+    expect(r.isRegex).toBe(true);
   });
 
   it("recognises an escaped slash for either the scheme separator or the path start", () => {
     const r = convertUrlRule("GET ~^https:\\/\\/a\\.com\\/x$");
-    expect(r.authorityRegex).toBe("^a\\.com:[0-9]+$");
+    expect(r.hostRegex).toBe("^a\\.com$");
     expect(r.pathRegex).toBe("^\\/x$");
   });
 
@@ -118,15 +120,23 @@ describe("convertUrlRule regex escape hatch", () => {
     expect(() => convertUrlRule("GET ~^https://a\\.com$")).toThrow(/path/);
   });
 
-  it("carries a literal port in the host half through to authorityRegex", () => {
+  it("keeps the host half's own port pattern for enforcement, but drops it for the resolver", () => {
+    // hostRegex (matched against the connection, with and without a port --
+    // see haproxy-config.ts) keeps whatever the user wrote; authorityRegex
+    // (the resolver's allowlist, which has no notion of a port) never does.
     const r = convertUrlRule("GET ~^https://a\\.com:8443/x$");
-    expect(r.authorityRegex).toBe("^a\\.com:8443$");
+    expect(r.hostRegex).toBe("^a\\.com:8443$");
+    expect(r.authorityRegex).toBe("^a\\.com$");
     expect(r.pathRegex).toBe("^/x$");
   });
 
-  it("rejects a non-literal port after the host's :", () => {
-    expect(() => convertUrlRule("GET ~^https://a\\.com:\\d+/x$")).toThrow(/literal number/);
-    expect(() => convertUrlRule("GET ~^https://a\\.com(:\\d+)?/x$")).toThrow(/literal number/);
+  it("accepts a non-literal port in the host half, unlike the other rule kinds", () => {
+    // A URL rule's port is optional, so its host half is matched with and
+    // without one rather than folded into a single dst_port ACL -- any
+    // regex is fine there, literal or not.
+    const r = convertUrlRule("GET ~^https://a\\.com:(443|8443)/x$");
+    expect(r.hostRegex).toBe("^a\\.com:(443|8443)$");
+    expect(r.authorityRegex).toBe("^a\\.com$");
   });
 });
 

--- a/src/core/lib/acl/url-rules.ts
+++ b/src/core/lib/acl/url-rules.ts
@@ -46,9 +46,10 @@ export interface UrlRule {
   /** Regex matching the full URL, without anchors. */
   regex: string;
   /**
-   * Regex matching the authority (`host:port`), which the proxy and resolver
-   * configs are both built from. See splitRawRegexUrl for how a `~` rule
-   * derives this.
+   * Host-only regex (no port), which the resolver's allowlist is built from:
+   * a DNS query carries no port to match against. For a `~` rule, this is
+   * `hostRegex` with anything after its own `:` discarded; see
+   * splitRawRegexUrl.
    */
   authorityRegex: string;
   /**
@@ -57,6 +58,16 @@ export interface UrlRule {
    * rather than `regex`.
    */
   pathRegex: string;
+  /**
+   * For a `~` rule: the host half's own regex, port included verbatim if the
+   * user wrote one. The proxy matches this against the connection's host
+   * both with and without a port, since the pattern's port (if any) is
+   * optional -- see haproxy-config.ts. Meaningless when `isRegex` is false,
+   * since a wildcard rule's host and (literal) port are matched separately.
+   */
+  hostRegex: string;
+  /** Whether this is a `~` rule. */
+  isRegex: boolean;
   /** The rule exactly as the user wrote it, for reports and error messages. */
   raw: string;
 }
@@ -111,17 +122,21 @@ const SCHEME_SEP = /:(?:\\?\/){2}/;
  * expressions, never as one full-URL regex (see haproxy-config.ts's
  * ruleBlock), so the regex has to be cut at the first `/` after `://`.
  *
- * HAProxy's `dst_port` ACL only accepts a literal number, never a regex, so
- * a `:` in the host half is honoured only when followed by one; otherwise
- * the rule matches any port.
+ * The host half's port is optional, exactly as in a literal URL: the proxy
+ * tries it against the connection's host both bare and with the real port,
+ * so a pattern with no port at all matches only the scheme's default port,
+ * and one ending in an optional port group (`(:8443)?`) matches either.
+ * `authorityRegex` is the same host half with anything from its own `:`
+ * onward dropped, for the resolver's allowlist, which has no notion of a
+ * port to match against either way.
  *
- * @throws {Error} if the text can't be split into a host and a path, its
- *   port isn't a literal number, or either half fails to compile alone
+ * @throws {Error} if the text can't be split into a host and a path, or a
+ *   resulting half fails to compile as a regex on its own
  */
 function splitRawRegexUrl(
   regex: string,
   rule: string,
-): { authorityRegex: string; pathRegex: string } {
+): { hostRegex: string; authorityRegex: string; pathRegex: string } {
   const schemeSep = SCHEME_SEP.exec(regex);
   if (!schemeSep) {
     throw new Error(
@@ -140,28 +155,16 @@ function splitRawRegexUrl(
   }
   const pathStart = hostStart + pathSep.index;
 
-  let hostPart = regex.slice(hostStart, pathStart);
-  let port: string | null = null;
+  const hostPart = regex.slice(hostStart, pathStart);
   const colonIdx = hostPart.indexOf(":");
-  if (colonIdx !== -1) {
-    const portText = hostPart.slice(colonIdx + 1);
-    if (!/^\d+$/.test(portText)) {
-      throw new Error(
-        `Invalid regex in rule "${rule}": the port after ":" in the host ("${portText}") must be ` +
-          `a literal number, since the destination port cannot be matched with a regex; write a ` +
-          `plain number (e.g. "https://host:8443/x") or omit the port entirely to allow any port`,
-      );
-    }
-    port = portText;
-    hostPart = hostPart.slice(0, colonIdx);
-  }
+  const hostOnly = colonIdx === -1 ? hostPart : hostPart.slice(0, colonIdx);
 
-  // "[0-9]+" is the existing any-port sentinel (splitHostAndPort in
-  // haproxy-rules.ts, hostRegexOfUrlRule in coredns-config.ts).
-  const authorityRegex = `^${hostPart}:${port ?? "[0-9]+"}$`;
+  const hostRegex = `^${hostPart}$`;
+  const authorityRegex = `^${hostOnly}$`;
   const pathRegex = `^${regex.slice(pathStart)}`;
   for (const [label, fragment] of [
-    ["host", `^${hostPart}$`],
+    ["host", hostRegex],
+    ["host-only", authorityRegex],
     ["path", pathRegex],
   ] as const) {
     try {
@@ -174,7 +177,7 @@ function splitRawRegexUrl(
     }
   }
 
-  return { authorityRegex, pathRegex };
+  return { hostRegex, authorityRegex, pathRegex };
 }
 
 /**
@@ -193,7 +196,14 @@ function splitRawRegexUrl(
 function compileUrl(
   url: string,
   rule: string,
-): { scheme: string; regex: string; authorityRegex: string; pathRegex: string } {
+): {
+  scheme: string;
+  regex: string;
+  authorityRegex: string;
+  pathRegex: string;
+  hostRegex: string;
+  isRegex: boolean;
+} {
   if (url.startsWith("~")) {
     const regex = url.slice(1);
     try {
@@ -203,8 +213,8 @@ function compileUrl(
     }
     // A raw regex governs its own scheme; callers that bucket by scheme treat
     // it as https, the stricter of the two.
-    const { authorityRegex, pathRegex } = splitRawRegexUrl(regex, rule);
-    return { scheme: "https", regex, authorityRegex, pathRegex };
+    const { hostRegex, authorityRegex, pathRegex } = splitRawRegexUrl(regex, rule);
+    return { scheme: "https", regex, authorityRegex, pathRegex, hostRegex, isRegex: true };
   }
 
   const { scheme, authority, path } = splitUrl(url, rule);
@@ -246,6 +256,8 @@ function compileUrl(
     authorityRegex,
     // A rule with no path allows any, which is what the URL regex says too.
     pathRegex: path === "" ? "^/" : `^${pathRegex}$`,
+    hostRegex, // unused: a wildcard rule's host and port are matched separately.
+    isRegex: false,
   };
 }
 
@@ -272,8 +284,8 @@ export function convertUrlRule(rule: string): UrlRule {
   }
 
   const methods = parseMethods(methodSpec, trimmed);
-  const { scheme, regex, authorityRegex, pathRegex } = compileUrl(url, trimmed);
-  return { methods, scheme, regex, authorityRegex, pathRegex, raw: trimmed };
+  const { scheme, regex, authorityRegex, pathRegex, hostRegex, isRegex } = compileUrl(url, trimmed);
+  return { methods, scheme, regex, authorityRegex, pathRegex, hostRegex, isRegex, raw: trimmed };
 }
 
 /**

--- a/src/core/lib/acl/url-rules.ts
+++ b/src/core/lib/acl/url-rules.ts
@@ -34,7 +34,11 @@
  * too; see the squid config generator.
  */
 
-import { pathToRegexPartial, wildcardToRegexPartial } from "./partial-wildcard.ts";
+import {
+  pathToRegexPartial,
+  splitDomainFromPortPattern,
+  wildcardToRegexPartial,
+} from "./partial-wildcard.ts";
 
 const DEFAULT_PORT: Record<string, string> = { http: "80", https: "443" };
 
@@ -126,9 +130,10 @@ const SCHEME_SEP = /:(?:\\?\/){2}/;
  * tries it against the connection's host both bare and with the real port,
  * so a pattern with no port at all matches only the scheme's default port,
  * and one ending in an optional port group (`(:8443)?`) matches either.
- * `authorityRegex` is the same host half with anything from its own `:`
- * onward dropped, for the resolver's allowlist, which has no notion of a
- * port to match against either way.
+ * `authorityRegex` is the same host half with its port pattern dropped --
+ * from its own `:`, or the `(` opening a group right at the colon -- for
+ * the resolver's allowlist, which has no notion of a port to match against
+ * either way; see splitDomainFromPortPattern.
  *
  * @throws {Error} if the text can't be split into a host and a path, or a
  *   resulting half fails to compile as a regex on its own
@@ -156,8 +161,7 @@ function splitRawRegexUrl(
   const pathStart = hostStart + pathSep.index;
 
   const hostPart = regex.slice(hostStart, pathStart);
-  const colonIdx = hostPart.indexOf(":");
-  const hostOnly = colonIdx === -1 ? hostPart : hostPart.slice(0, colonIdx);
+  const { domain: hostOnly } = splitDomainFromPortPattern(hostPart);
 
   const hostRegex = `^${hostPart}$`;
   const authorityRegex = `^${hostOnly}$`;

--- a/src/core/lib/acl/url-rules.ts
+++ b/src/core/lib/acl/url-rules.ts
@@ -40,7 +40,8 @@ import {
   wildcardToRegexPartial,
 } from "./partial-wildcard.ts";
 
-const DEFAULT_PORT: Record<string, string> = { http: "80", https: "443" };
+/** The scheme's own port, tried without being spelled out at all in a `~` URL rule's host half. */
+export const DEFAULT_PORT: Record<"https" | "http", string> = { https: "443", http: "80" };
 
 export interface UrlRule {
   /** Uppercased HTTP methods, or null when the rule allows any method (`*`). */
@@ -105,14 +106,17 @@ export function parseMethods(spec: string, rule: string): string[] | null {
  *
  * @throws {Error} if the pattern is not an http(s) URL
  */
-function splitUrl(url: string, rule: string): { scheme: string; authority: string; path: string } {
+function splitUrl(
+  url: string,
+  rule: string,
+): { scheme: "https" | "http"; authority: string; path: string } {
   const match = /^(https?):\/\/([^/]+)(\/.*)?$/.exec(url);
   if (!match) {
     throw new Error(
       `Invalid URL in rule "${rule}": expected http:// or https:// followed by a host`,
     );
   }
-  return { scheme: match[1], authority: match[2], path: match[3] ?? "" };
+  return { scheme: match[1] as "https" | "http", authority: match[2], path: match[3] ?? "" };
 }
 
 /** A literal `/`, or its escaped form `\/`. */

--- a/test/Dockerfile.inspect-restrict
+++ b/test/Dockerfile.inspect-restrict
@@ -267,6 +267,20 @@ RUN echo "=== [Direct address] ===" && \
     echo "status=$CODE" && \
     [ "$CODE" = "403" ] || (echo "FAILED: expected 403" && exit 1)
 
+# [~regex allowed_ip_rules - uninspected passthrough by address]
+# Port 9080, distinct from the :80 the URL rule above allows.
+RUN echo "=== [Regex IP rule] ===" && \
+    OUT=$($S http://10.200.0.100:9080/anything) && \
+    echo "$OUT" && \
+    case "$OUT" in ROOT\ GET*) echo "OK" ;; *) echo "FAILED" && exit 1 ;; esac
+
+# Same address, a port only the URL rule's :80 default would cover -- proves
+# the ~regex ip rule's own literal port (9080) is enforced, not "any port".
+RUN echo "=== [Regex IP rule - other port not covered] ===" && \
+    CODE=$($C http://10.200.0.100:8080/anything) && \
+    echo "status=$CODE" && \
+    [ "$CODE" = "403" ] || (echo "FAILED: expected 403" && exit 1)
+
 # [UDP is dropped]
 # The cage forwards nothing, so a build cannot leave over UDP: no QUIC, no
 # HTTP/3, no DNS to a resolver of its own choosing. assert-inspect-restrict.sh

--- a/test/Dockerfile.inspect-restrict
+++ b/test/Dockerfile.inspect-restrict
@@ -212,6 +212,13 @@ RUN echo "=== [TLS passthrough] ===" && \
     echo "$OUT" && \
     case "$OUT" in PUBLIC\ GET*) echo "OK" ;; *) echo "FAILED" && exit 1 ;; esac
 
+# [~regex TLS rule - host and its own literal port]
+# Same host as [TLS passthrough], a second port only the ~regex rule names.
+RUN echo "=== [Regex TLS rule] ===" && \
+    OUT=$($S --insecure https://tlspass.example.com:8443/public/x) && \
+    echo "$OUT" && \
+    case "$OUT" in PUBLIC\ GET*) echo "OK" ;; *) echo "FAILED" && exit 1 ;; esac
+
 # [DNS-only exfiltration]
 # No connection is ever made, so the resolver's log is the only record. The
 # lookup is expected to fail; what matters is that it was refused and recorded.

--- a/test/Dockerfile.inspect-restrict
+++ b/test/Dockerfile.inspect-restrict
@@ -131,6 +131,21 @@ RUN echo "=== [Regex URL rule - default port not covered by the literal-port rul
     echo "status=$CODE" && \
     [ "$CODE" = "403" ] || (echo "FAILED: expected 403" && exit 1)
 
+# [~regex URL rule - no port names, so only the scheme's default port matches]
+# A separate ~regex rule on blocked.example.com, /defaultport/ this time,
+# names no port at all. It must match the default port (443) and nothing
+# else: a bare/full check that always resolved "true" would wrongly let
+# 9443 through too.
+RUN echo "=== [Regex URL rule - no port names the default port only] ===" && \
+    OUT=$($S https://blocked.example.com/defaultport/pkg.tgz) && \
+    echo "$OUT" && \
+    case "$OUT" in ROOT\ GET*) echo "OK" ;; *) echo "FAILED" && exit 1 ;; esac
+
+RUN echo "=== [Regex URL rule - portless rule does not also grant a non-default port] ===" && \
+    CODE=$($C https://blocked.example.com:9443/defaultport/pkg.tgz) && \
+    echo "status=$CODE" && \
+    [ "$CODE" = "403" ] || (echo "FAILED: expected 403" && exit 1)
+
 # [Host rule - any path, any method]
 RUN echo "=== [Host rule] ===" && \
     OUT=$($S -X DELETE https://sub.wildcard.example.com/anything/at/all) && \

--- a/test/assert-inspect-restrict.sh
+++ b/test/assert-inspect-restrict.sh
@@ -35,6 +35,7 @@ assert_logged DELETE "https://sub.wildcard.example.com/anything/at/all" 200
 assert_logged GET "http://allowed.example.com/public/pkg.tgz" 200
 assert_logged GET "https://attacker.wildcard.example.com/public/pkg.tgz" 200
 assert_logged GET "https://blocked.example.com:9443/public/pkg.tgz" 200
+assert_logged GET "https://blocked.example.com/defaultport/pkg.tgz" 200
 echo ""
 
 echo "[refused] recorded with the method and the full URL, before any origin was contacted:"
@@ -44,6 +45,7 @@ assert_logged GET "https://absent.example.com/" 502
 assert_logged GET "https://attacker.wildcard.example.com/private/secret" 403
 assert_logged GET "https://blocked.example.com:9443/private/secret" 403
 assert_logged GET "https://blocked.example.com/public/pkg.tgz" 403
+assert_logged GET "https://blocked.example.com:9443/defaultport/pkg.tgz" 403
 echo ""
 
 echo "[traversal] the path is normalised before the rules see it:"

--- a/test/assert-inspect-restrict.sh
+++ b/test/assert-inspect-restrict.sh
@@ -134,11 +134,22 @@ if grep -qE "^buildcage [0-9]+ https? [A-Z]+ \S*tlspass\.example\.com" <<< "$PRO
 else
   pass "no request-level record, so nothing was decrypted"
 fi
+echo ""
+
+echo "[Regex IP rule] a ~regex allowed_ip_rules entry passes through, on its own port:"
+if grep -qE "^buildcage [0-9]+ pass tcp sni=- [0-9]+ ts=\S+ dst=10\.200\.0\.100:9080$" <<< "$PROXY_LOG"; then
+  pass "recorded as an undecrypted tcp passthrough, on the rule's own port"
+else
+  fail "no tcp passthrough was recorded on the ~regex ip rule's port 9080"
+fi
+echo ""
+
 # Everything not passed through is recorded by the frontend that terminates it,
 # so nothing else may appear at the tcp stage or it would be counted twice.
 # The count is not asserted: a reused container's log spans several builds.
 OTHER=$(grep -E "^buildcage [0-9]+ pass " <<< "$PROXY_LOG" \
-  | grep -cv "sni=tlspass\.example\.com" || true)
+  | grep -v "sni=tlspass\.example\.com" \
+  | grep -cv "dst=10\.200\.0\.100:9080" || true)
 if [ "$OTHER" -eq 0 ]; then
   pass "only the passthrough is logged at the tcp stage"
 else
@@ -192,7 +203,8 @@ REPORT_MARKDOWN=$(GITHUB_STEP_SUMMARY= node report/src/main.ts 2>&1 || true)
 echo "[report] Allowed Hosts:"
 if grep -qF "### ✅ Allowed Hosts" <<< "$REPORT_MARKDOWN" \
   && grep -qF "| allowed.example.com:443 | HTTPS |" <<< "$REPORT_MARKDOWN" \
-  && grep -qF "| allowed.example.com:80 | HTTP |" <<< "$REPORT_MARKDOWN"; then
+  && grep -qF "| allowed.example.com:80 | HTTP |" <<< "$REPORT_MARKDOWN" \
+  && grep -qF "| 10.200.0.100:9080 | IP |" <<< "$REPORT_MARKDOWN"; then
   pass "the table lists the hosts that were reached"
 else
   fail "the Allowed Hosts table is missing expected rows"

--- a/test/assert-inspect-restrict.sh
+++ b/test/assert-inspect-restrict.sh
@@ -120,6 +120,14 @@ if grep -qE "^buildcage [0-9]+ pass tls sni=tlspass\.example\.com [0-9]+ ts=" <<
 else
   fail "the passthrough was not recorded at all"
 fi
+# Only the ~regex rule names port 8443, so reaching it there proves the rule
+# was matched by regex rather than mangled into a wildcard that happens to
+# also match :443.
+if grep -qE "^buildcage [0-9]+ pass tls sni=tlspass\.example\.com [0-9]+ ts=\S+ dst=10\.200\.0\.100:8443$" <<< "$PROXY_LOG"; then
+  pass "the ~regex TLS rule's own port (8443) reached the resolved origin"
+else
+  fail "no passthrough was recorded on the ~regex rule's port 8443"
+fi
 # A request line for it would mean the TLS was terminated after all.
 if grep -qE "^buildcage [0-9]+ https? [A-Z]+ \S*tlspass\.example\.com" <<< "$PROXY_LOG"; then
   fail "a passthrough connection was decrypted and logged as a request"


### PR DESCRIPTION
## Summary
- Fixes the inspect engine's `~` regex rules being effectively broken for `allowed_https_rules`/`allowed_http_rules`/`allow_tls_rules`/`allowed_ip_rules`: the host half was mangled by the wildcard compiler and CoreDNS config generation crashed the container on startup.
- Extends `~` rules to match the port with a full regex (not just a literal number) across all rule kinds, using the same "combine host:port into one string, match with one regex" technique `universal`'s haproxy.cfg.template already uses.
- `allowed_url_rules`' own `~` rules keep the port optional: a bare host-only comparison and a host:port comparison are both tried on the scheme's default port, so a rule naming no port matches only the default rather than any port.
- Also fixes a latent bug where a plain (non-`~`) host rule with no port at all was silently treated as "any port", contradicting the documented "a port is required on every rule" contract.
- Updates `README.md`/`docs/inspect-engine.md` to reflect the new port syntax.

## Test plan
- [x] Integration fixture (`compose.test-inspect.yaml`) extended with a portless `~` URL rule proving the new default-port-only behavior end to end.