### PR TITLE
fix: require a port on a universal-engine ~ regex rule too

### DIFF
--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -341,99 +341,6 @@ function errorMessage(e) {
 //#region src/lib/errors.ts
 var SetupError = class extends ActionError {};
 //#endregion
-//#region src/core/lib/acl/wildcard-rules.ts
-/**
-* Rule conversion library for buildcage container.
-* Converts wildcard patterns to regex strings for HAProxy ACLs.
-*/
-/**
-* Split a whitespace-separated rules string into individual rule tokens.
-*/
-function splitRuleTokens(rulesInput) {
-	return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
-}
-/**
-* Split+validate a space-separated rules string, returning the raw
-* (unconverted) rule tokens — for callers that need the original
-* wildcard/~regex syntax preserved, such as known_blocked_rules.
-*
-* @throws {Error} if any rule has invalid wildcard/regex syntax
-*/
-function parseAndValidateRules(rulesInput) {
-	let rules = splitRuleTokens(rulesInput);
-	return rules.forEach(convertRule), rules;
-}
-/**
-* Convert a single rule (wildcard or `~`-prefixed regex) to a regex string.
-*/
-function convertRule(rule) {
-	if (rule.startsWith("~")) {
-		let regex = rule.slice(1);
-		try {
-			new RegExp(regex);
-		} catch (e) {
-			throw Error(`Invalid regex in rule "${rule}": ${e.message}`);
-		}
-		return regex;
-	}
-	return `^${wildcardToRegex(rule)}$`;
-}
-/**
-* Convert a domain wildcard to a regex string (without anchors or port).
-*
-* Supported wildcards:
-*   `**` — matches one or more characters including dots
-*   `*`  — matches one or more characters excluding dots
-*   `?`  — matches a single character excluding dots
-*
-* A dot-separated part containing `*` must be exactly `*` or `**`.
-*/
-function domainToRegex(domain) {
-	return domain.split(".").map((part) => {
-		if (part === "**") return ".+";
-		if (part === "*") return "[^.]+";
-		if (part.includes("*")) throw Error(`Invalid wildcard in "${domain}": part "${part}" mixes "*" with other characters`);
-		return part.replace(/[.+^$()[\]{}|\\]/g, "\\$&").replace(/\?/g, "[^.]");
-	}).join("\\.");
-}
-/**
-* Convert a wildcard pattern (`<domain>:<port|*>`) to a regex string (without anchors).
-*/
-function wildcardToRegex(pattern) {
-	if (!/^[^:]+:(?:\d+|\*)$/.test(pattern)) throw Error(`Invalid pattern "${pattern}"`);
-	let [domain, port] = pattern.split(":"), portRegex = port === "*" ? "\\d+" : port;
-	return `${domainToRegex(domain)}:${portRegex}`;
-}
-//#endregion
-//#region src/core/lib/acl/rules.ts
-/**
-* Thrown when an ACL rule input (allowed_https_rules/allowed_http_rules/
-* allowed_ip_rules/known_blocked_rules) fails to parse — shared by the
-* setup and run actions, which both accept the same rule syntax.
-*/
-var InvalidRulesError = class extends ActionError {};
-/**
-* Rethrow a rule-parser's syntax errors as an InvalidRulesError.
-*/
-function parseRulesOrThrow(rulesInput) {
-	try {
-		return parseAndValidateRules(rulesInput);
-	} catch (e) {
-		throw new InvalidRulesError(errorMessage(e), "INVALID_RULES");
-	}
-}
-/**
-* Build ACL rules from input strings. Rules are passed through as-is
-* (wildcard format), validated eagerly.
-*/
-function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput }) {
-	return {
-		httpsRules: parseRulesOrThrow(httpsRulesInput),
-		httpRules: parseRulesOrThrow(httpRulesInput),
-		ipRules: parseRulesOrThrow(ipRulesInput)
-	};
-}
-//#endregion
 //#region src/core/lib/acl/partial-wildcard.ts
 /**
 * Domain pattern compiler for the `inspect` engine, which allows a wildcard
@@ -543,6 +450,123 @@ function splitDomainFromPortPattern(hostPlusPort) {
 	} : {
 		domain: hostPlusPort,
 		portPattern: null
+	};
+}
+/**
+* Extract the host-only fragment from a `~` host rule's raw regex, for the
+* resolver's allowlist: a DNS query carries no port, so whatever names a port
+* is dropped here regardless of its shape. Enforcement uses the raw regex
+* directly instead (see haproxy-rules.ts), matched as one expression against
+* the connection, so this function exists only for coredns-config.ts.
+*
+* @throws {Error} if the regex is invalid, it names no port at all (a port is
+*   always required), or the host half does not compile as a regex on its own
+*/
+function splitRawRegexHost(pattern) {
+	let regex = pattern.slice(1);
+	try {
+		new RegExp(regex);
+	} catch (e) {
+		throw Error(`Invalid regex in rule "${pattern}": ${e.message}`);
+	}
+	let { domain, portPattern } = splitDomainFromPortPattern(regex);
+	if (portPattern === null) throw Error(`Invalid regex in rule "${pattern}": expected ":" separating the host from a port; a port is always required`);
+	let host = domain;
+	host.startsWith("^") && (host = host.slice(1));
+	try {
+		new RegExp(host);
+	} catch (e) {
+		throw Error(`Invalid regex in rule "${pattern}": the host part "${host}" does not compile on its own: ${e.message}`);
+	}
+	return { host };
+}
+//#endregion
+//#region src/core/lib/acl/wildcard-rules.ts
+/**
+* Rule conversion library for buildcage container.
+* Converts wildcard patterns to regex strings for HAProxy ACLs.
+*/
+/**
+* Split a whitespace-separated rules string into individual rule tokens.
+*/
+function splitRuleTokens(rulesInput) {
+	return rulesInput?.trim().split(/\s+/).filter(Boolean) ?? [];
+}
+/**
+* Split+validate a space-separated rules string, returning the raw
+* (unconverted) rule tokens — for callers that need the original
+* wildcard/~regex syntax preserved, such as known_blocked_rules.
+*
+* @throws {Error} if any rule has invalid wildcard/regex syntax
+*/
+function parseAndValidateRules(rulesInput) {
+	let rules = splitRuleTokens(rulesInput);
+	return rules.forEach(convertRule), rules;
+}
+/**
+* Convert a single rule (wildcard or `~`-prefixed regex) to a regex string.
+*
+* The `~` case reuses the `inspect` engine's own validator (a port is always
+* required there too) so both engines reject the same malformed regex the
+* same way, instead of this engine silently accepting a rule that then never
+* matches -- or, absent an anchor, matches more than the author intended.
+*/
+function convertRule(rule) {
+	return rule.startsWith("~") ? (splitRawRegexHost(rule), rule.slice(1)) : `^${wildcardToRegex(rule)}$`;
+}
+/**
+* Convert a domain wildcard to a regex string (without anchors or port).
+*
+* Supported wildcards:
+*   `**` — matches one or more characters including dots
+*   `*`  — matches one or more characters excluding dots
+*   `?`  — matches a single character excluding dots
+*
+* A dot-separated part containing `*` must be exactly `*` or `**`.
+*/
+function domainToRegex(domain) {
+	return domain.split(".").map((part) => {
+		if (part === "**") return ".+";
+		if (part === "*") return "[^.]+";
+		if (part.includes("*")) throw Error(`Invalid wildcard in "${domain}": part "${part}" mixes "*" with other characters`);
+		return part.replace(/[.+^$()[\]{}|\\]/g, "\\$&").replace(/\?/g, "[^.]");
+	}).join("\\.");
+}
+/**
+* Convert a wildcard pattern (`<domain>:<port|*>`) to a regex string (without anchors).
+*/
+function wildcardToRegex(pattern) {
+	if (!/^[^:]+:(?:\d+|\*)$/.test(pattern)) throw Error(`Invalid pattern "${pattern}"`);
+	let [domain, port] = pattern.split(":"), portRegex = port === "*" ? "\\d+" : port;
+	return `${domainToRegex(domain)}:${portRegex}`;
+}
+//#endregion
+//#region src/core/lib/acl/rules.ts
+/**
+* Thrown when an ACL rule input (allowed_https_rules/allowed_http_rules/
+* allowed_ip_rules/known_blocked_rules) fails to parse — shared by the
+* setup and run actions, which both accept the same rule syntax.
+*/
+var InvalidRulesError = class extends ActionError {};
+/**
+* Rethrow a rule-parser's syntax errors as an InvalidRulesError.
+*/
+function parseRulesOrThrow(rulesInput) {
+	try {
+		return parseAndValidateRules(rulesInput);
+	} catch (e) {
+		throw new InvalidRulesError(errorMessage(e), "INVALID_RULES");
+	}
+}
+/**
+* Build ACL rules from input strings. Rules are passed through as-is
+* (wildcard format), validated eagerly.
+*/
+function buildACLRules({ httpsRulesInput, httpRulesInput, ipRulesInput }) {
+	return {
+		httpsRules: parseRulesOrThrow(httpsRulesInput),
+		httpRules: parseRulesOrThrow(httpRulesInput),
+		ipRules: parseRulesOrThrow(ipRulesInput)
 	};
 }
 //#endregion

--- a/src/core/lib/acl/source-policy.test.ts
+++ b/src/core/lib/acl/source-policy.test.ts
@@ -225,7 +225,7 @@ describe("buildSourcePolicy — regex (~) rules", () => {
   it("an anchor-less regex matches as a substring within the domain, but the missing anchors don't reach into the path", () => {
     const policy = buildSourcePolicy({
       proxyMode: "restrict",
-      httpsRulesInput: "~example",
+      httpsRulesInput: "~example(:\\d+)?", // a port pattern is always required, even here
       httpRulesInput: "",
       ipRulesInput: "",
     });
@@ -242,7 +242,7 @@ describe("buildSourcePolicy — regex (~) rules", () => {
   it("only the anchors actually present are stripped — an unanchored end still gets its own [^/]*", () => {
     const policy = buildSourcePolicy({
       proxyMode: "restrict",
-      httpsRulesInput: "~^example",
+      httpsRulesInput: "~^example(:\\d+)?", // a port pattern is always required, even here
       httpRulesInput: "",
       ipRulesInput: "",
     });
@@ -266,7 +266,7 @@ describe("buildSourcePolicy — regex (~) rules", () => {
   it("an escaped literal trailing $ is not mistaken for the end anchor (regression)", () => {
     const policy = buildSourcePolicy({
       proxyMode: "restrict",
-      httpsRulesInput: "~foo\\$",
+      httpsRulesInput: "~foo:443\\$", // a port pattern is always required, even here
       httpRulesInput: "",
       ipRulesInput: "",
     });
@@ -274,8 +274,8 @@ describe("buildSourcePolicy — regex (~) rules", () => {
     // the wrapper's own "(" — see git history for the exact failure): the
     // trailing "$" here is escaped (a literal dollar sign), not an anchor.
     const re = new RegExp(policy.rules[1].selector.identifier);
-    expect(re.test("https://foo$/")).toBeTruthy();
-    expect(!re.test("https://bar$/")).toBeTruthy();
+    expect(re.test("https://foo:443$/")).toBeTruthy();
+    expect(!re.test("https://bar:443$/")).toBeTruthy();
   });
 
   it("an escaped literal '.' followed by a real '*' quantifier is left alone (not confined)", () => {

--- a/src/core/lib/acl/wildcard-rules.test.ts
+++ b/src/core/lib/acl/wildcard-rules.test.ts
@@ -82,6 +82,14 @@ describe("convertRule", () => {
   it("rejects invalid regex (~ prefix)", () => {
     expect(() => convertRule("~^(unclosed")).toThrow(/Invalid regex/);
   });
+
+  it("rejects a regex rule (~ prefix) with no port", () => {
+    expect(() => convertRule("~^example\\.com$")).toThrow(/a port is always required/);
+  });
+
+  it("rejects a regex rule (~ prefix) with no port even without anchors", () => {
+    expect(() => convertRule("~example\\.com")).toThrow(/a port is always required/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/lib/acl/wildcard-rules.ts
+++ b/src/core/lib/acl/wildcard-rules.ts
@@ -3,6 +3,8 @@
  * Converts wildcard patterns to regex strings for HAProxy ACLs.
  */
 
+import { splitRawRegexHost } from "./partial-wildcard.ts";
+
 /**
  * Split a whitespace-separated rules string into individual rule tokens.
  */
@@ -32,16 +34,16 @@ export function parseAndValidateRules(rulesInput: string | undefined): string[] 
 
 /**
  * Convert a single rule (wildcard or `~`-prefixed regex) to a regex string.
+ *
+ * The `~` case reuses the `inspect` engine's own validator (a port is always
+ * required there too) so both engines reject the same malformed regex the
+ * same way, instead of this engine silently accepting a rule that then never
+ * matches -- or, absent an anchor, matches more than the author intended.
  */
 export function convertRule(rule: string): string {
   if (rule.startsWith("~")) {
-    const regex = rule.slice(1);
-    try {
-      new RegExp(regex);
-    } catch (e) {
-      throw new Error(`Invalid regex in rule "${rule}": ${(e as Error).message}`);
-    }
-    return regex;
+    splitRawRegexHost(rule);
+    return rule.slice(1);
   }
   return `^${wildcardToRegex(rule)}$`;
 }


### PR DESCRIPTION
## Summary
- `allowed_https_rules`/`allowed_http_rules`/`allowed_ip_rules` document a port as always required, and the `inspect` engine already enforces that for `~` regex rules — but the `universal` engine's own compiler (`wildcard-rules.ts`) never checked for one, only that the pattern was valid JS regex syntax.
- Matched with HAProxy's unanchored `-m reg` against `host:port`, a portless `~` rule doesn't just fail to match: without an anchor it can match a wider set of hosts than intended (e.g. as a substring of an unrelated domain), silently widening an allowlist entry.
- `convertRule` now reuses the `inspect` engine's own validator (`partial-wildcard.ts`'s `splitRawRegexHost`), so both engines reject the same malformed rule the same way.

## Test plan
- Added `wildcard-rules.test.ts` cases asserting a portless `~` rule (anchored and unanchored) is rejected with "a port is always required".
- Updated `source-policy.test.ts` fixtures that relied on the old portless-`~`-rule permissiveness to include an explicit port, preserving what each test actually exercises (anchor stripping, escaped-`$` handling).