### PR TITLE
fix: support release-candidate tags in the release pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,7 @@ jobs:
             if [ -n "$INPUT_TAG" ]; then
               TAG="$INPUT_TAG"
             else
-              TAG=$(git tag --sort=-version:refname --list 'v*.*' | head -1)
+              TAG=$(git tag --sort=-version:refname --list 'v*.*' | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+-' | head -1)
               if [ -z "$TAG" ]; then
                 echo "::error::No version tag found"
                 exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Invalid semver format: $TAG (expected vX.Y.Z)"
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$'; then
+            echo "::error::Invalid semver format: $TAG (expected vX.Y.Z or vX.Y.Z-prerelease)"
             exit 1
           fi
 
@@ -49,10 +49,15 @@ jobs:
           TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          PRERELEASE_FLAG=""
+          case "$TAG" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
           gh release create "$TAG" \
             --draft \
             --title "$TAG" \
-            --generate-notes
+            --generate-notes \
+            $PRERELEASE_FLAG
 
       - name: Push tag
         env:
@@ -95,4 +100,11 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Review and publish: $RELEASE_URL" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Tick **Publish this Action to the GitHub Marketplace** on that page before publishing — the release API has no field for it, so it has to be set by hand every time." >> "$GITHUB_STEP_SUMMARY"
+          case "$TAG" in
+            *-*)
+              echo "This is a **prerelease** tag — do NOT tick **Publish this Action to the GitHub Marketplace**. Marketplace publishing is for stable releases only." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              echo "Tick **Publish this Action to the GitHub Marketplace** on that page before publishing — the release API has no field for it, so it has to be set by hand every time." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+          esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PRERELEASE_FLAG=""
+          NOTES_ARGS=()
           case "$TAG" in
-            *-*) PRERELEASE_FLAG="--prerelease" ;;
+            *-*)
+              PRERELEASE_FLAG="--prerelease"
+              # GitHub's --generate-notes picks the wrong previous tag for a
+              # prerelease (skips the actual latest release, e.g. compares
+              # against v3.1.4 instead of v3.1.5 for v3.1.6-rc1) — pin it to
+              # the latest non-prerelease tag ourselves.
+              PREV_TAG=$(git tag --sort=-version:refname --list 'v*.*.*' | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+-' | head -1)
+              if [ -n "$PREV_TAG" ]; then
+                NOTES_ARGS=(--notes-start-tag "$PREV_TAG")
+              fi
+              ;;
           esac
           gh release create "$TAG" \
             --draft \
             --title "$TAG" \
             --generate-notes \
-            $PRERELEASE_FLAG
+            $PRERELEASE_FLAG \
+            "${NOTES_ARGS[@]}"
 
       - name: Push tag
         env:

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -28,31 +28,42 @@ jobs:
           ref: ${{ env.TAG }}
           persist-credentials: false
 
+      - name: Guard against prerelease tags
+        id: guard
+        env:
+          IS_RELEASE_EVENT: ${{ github.event_name == 'release' }}
+          EVENT_PRERELEASE: ${{ github.event.release.prerelease }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$IS_RELEASE_EVENT" = "true" ]; then
+            IS_PRERELEASE="$EVENT_PRERELEASE"
+          else
+            IS_PRERELEASE=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')
+          fi
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "::notice::$TAG is a prerelease — skipping major/minor/latest tag updates"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract major version
         id: version
+        if: steps.guard.outputs.skip != 'true'
         run: |
           MAJOR="${TAG%%.*}"
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
 
-      - name: Update major version tag
-        env:
-          MAJOR: ${{ steps.version.outputs.major }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
-          git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
-          git push origin "$MAJOR" --force
-
       - name: Login to GHCR
+        if: steps.guard.outputs.skip != 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update Docker major/minor/latest tags
+      - name: Update major/minor/latest git and Docker tags
+        if: steps.guard.outputs.skip != 'true'
         env:
           MAJOR: ${{ steps.version.outputs.major }}
           REPO: ghcr.io/${{ github.repository }}
@@ -67,6 +78,14 @@ jobs:
           LATEST_IN_MAJOR=$(echo "$TAGS" | grep -E "^v${MAJOR#v}\.[0-9]+\.[0-9]+$" | sort -V | tail -1)
           LATEST_IN_MINOR=$(echo "$TAGS" | grep -E "^v${MINOR}\.[0-9]+$" | sort -V | tail -1)
           LATEST_OVERALL=$(echo "$TAGS" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+
+          if [ "$TAG" = "$LATEST_IN_MAJOR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
+            git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
+            git push origin "$MAJOR" --force
+          fi
 
           for ENGINE in universal explicit inspect; do
             SUFFIX=""

--- a/src/core/lib/provenance/image-tag.test.ts
+++ b/src/core/lib/provenance/image-tag.test.ts
@@ -22,6 +22,14 @@ describe("imageTagFromRef", () => {
     expect(imageTagFromRef("v2.1.0")).toBe("2.1.0");
   });
 
+  it("strips leading 'v' from a prerelease tag", () => {
+    expect(imageTagFromRef("v3.1.6-rc1")).toBe("3.1.6-rc1");
+  });
+
+  it("appends the engine suffix after a prerelease tag", () => {
+    expect(imageTagFromRef("v3.1.6-rc1", "explicit")).toBe("3.1.6-rc1-explicit");
+  });
+
   it("strips 'v' from a major-only tag", () => {
     expect(imageTagFromRef("v2")).toBe("2");
   });

--- a/src/core/lib/provenance/verify-policy.test.ts
+++ b/src/core/lib/provenance/verify-policy.test.ts
@@ -92,6 +92,28 @@ describe("buildVerifyOptions — version tag", () => {
     const opts = getOpts("v2.1.0");
     expect(opts.certificateOIDs).toBe(undefined);
   });
+
+  // ── prerelease tags ─────────────────────────────────────────────────────────
+  it("matches exact prerelease @v3.1.6-rc1 against cert SAN v3.1.6-rc1", () => {
+    const opts = getOpts("v3.1.6-rc1");
+    expect(matchesSAN(opts, makeSAN("refs/tags/v3.1.6-rc1"))).toBeTruthy();
+  });
+
+  it("does NOT match @v3.1.6-rc1 against cert SAN v3.1.6 (base release, boundary check)", () => {
+    const opts = getOpts("v3.1.6-rc1");
+    expect(
+      !matchesSAN(opts, makeSAN("refs/tags/v3.1.6")),
+      "@v3.1.6-rc1 must not match the base release v3.1.6",
+    ).toBeTruthy();
+  });
+
+  it("does NOT match @v3.1.6-rc1 against cert SAN v3.1.6-rc10 (boundary check)", () => {
+    const opts = getOpts("v3.1.6-rc1");
+    expect(
+      !matchesSAN(opts, makeSAN("refs/tags/v3.1.6-rc10")),
+      "@v3.1.6-rc1 must not match v3.1.6-rc10",
+    ).toBeTruthy();
+  });
 });
 
 describe("buildVerifyOptions — SHA pin", () => {


### PR DESCRIPTION
## Summary
- `release.yml`: accept semver prerelease tags (e.g. `v3.1.6-rc1`) and mark the draft release as `--prerelease`; skip the Marketplace-publish reminder for prerelease tags.
- `release.yml`: pin `--generate-notes` to the latest non-prerelease tag via `--notes-start-tag` for prerelease tags — GitHub's own previous-tag auto-detection skips the actual latest release for any hyphenated tag name (verified against the live `releases/generate-notes` API: `v3.1.6-rc1` compared against `v3.1.4` instead of `v3.1.5` with no override).
- `docker-publish.yml`: the no-tag-input `workflow_dispatch` fallback no longer picks an RC over the latest stable tag.
- `update-major-tag.yml`: the floating major git tag (what `@vN` Action pins resolve against) was force-moved unconditionally on every release publish, with no check that the release was actually the latest in that major line — publishing an RC would have moved it onto the RC commit. Gated behind the same `LATEST_IN_MAJOR` check already used for the Docker major/minor/latest tags, plus an explicit prerelease early-exit as a second guard.
- Added regression tests confirming `image-tag.ts`/`verify-policy.ts` (Sigstore identity matching) already handled prerelease refs correctly — no source change needed there.
