### PR TITLE
fix: sanitize SNI/Host before writing it into the universal engine's traffic log

### DIFF
--- a/docker/universal/files/haproxy.cfg.template
+++ b/docker/universal/files/haproxy.cfg.template
@@ -51,7 +51,12 @@ frontend outbound_proxy
     # TLS variable extraction
     tcp-request content set-var(sess.sni) req_ssl_sni if is_tls
     tcp-request content set-var-fmt(sess.sni_port) %[req_ssl_sni]:%[dst_port] if is_tls
-    tcp-request content set-var(sess.target) var(sess.sni_port) if is_tls has_sni
+    # The SNI is attacker-chosen raw bytes, and HAProxy copies a %[var()] into
+    # log-format verbatim -- +E would only escape " \ ], never LF. So the copy
+    # that reaches the log is reduced to a hostname charset here; the ACL below
+    # still matches the untouched sess.sni_port.
+    tcp-request content set-var(sess.sni_log) req_ssl_sni,regsub([^A-Za-z0-9._-],_,g) if is_tls has_sni
+    tcp-request content set-var-fmt(sess.target) %[var(sess.sni_log)]:%[dst_port] if is_tls has_sni
 
     # ACL: HTTPS allowlist
     acl is_https_allowed var(sess.sni_port) -m reg -f /etc/haproxy/rules/allowed_https.lst
@@ -128,7 +133,9 @@ backend http_filter_backend
     http-request set-var-fmt(txn.host_port) %[var(txn.host_only)]:%[dst_port]
 
     # Update session target for logging (replace IP with actual hostname)
-    http-request set-var(sess.target) var(txn.host_port)
+    # Same reason as the SNI above: the Host header is attacker-chosen too.
+    http-request set-var(txn.host_log) var(txn.host_only),regsub([^A-Za-z0-9._-],_,g)
+    http-request set-var-fmt(sess.target) %[var(txn.host_log)]:%[dst_port]
 
     # HTTP allowlist check
     acl is_http_allowed var(txn.host_port) -m reg -f /etc/haproxy/rules/allowed_http.lst

--- a/test/Dockerfile.universal-restrict
+++ b/test/Dockerfile.universal-restrict
@@ -86,6 +86,15 @@ RUN echo "=== [HTTP - missing-host-header] ===" && \
     ((printf 'GET / HTTP/1.0\r\n\r\n'; sleep 1) | nc -w 5 allowed.example.com 80 > /dev/null 2>&1 || true) && \
     echo "✓ missing-host-header: request sent (blocked expected in logs)"
 
+# [HTTPS - forged SNI (log-injection attempt via a crafted ClientHello)]
+# SNI = x" -\n[T] buildcage [ALLOWED] (HTTPS) "forged.example.com — an
+# attempt to break the "..." quoting and inject a fake ALLOWED line. Must be
+# BLOCKED as a single sanitized log line; see H-2 in docs/security.md.
+RUN echo "=== [HTTPS - forged SNI] ===" && \
+    echo "Testing crafted SNI log-injection payload (should be blocked)..." && \
+    (printf '\x16\x03\x01\x00\x70\x01\x00\x00\x6c\x03\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xff\x01\x00\x00\x41\x00\x00\x00\x3d\x00\x3b\x00\x00\x38\x78\x22\x20\x2d\x0a\x5b\x54\x5d\x20\x62\x75\x69\x6c\x64\x63\x61\x67\x65\x20\x5b\x41\x4c\x4c\x4f\x57\x45\x44\x5d\x20\x28\x48\x54\x54\x50\x53\x29\x20\x22\x66\x6f\x72\x67\x65\x64\x2e\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d' | nc -w 5 allowed.example.com 443 > /dev/null 2>&1 || true) && \
+    echo "✓ forged-sni: request sent (blocked expected in logs)"
+
 # [npm install - allowed - registry.npmjs.org is in ALLOWED_HTTPS_RULES; no CA
 # workaround needed, unlike the explicit engine]
 COPY files/package.json files/package-lock.json /app/

--- a/test/assert-universal-restrict.sh
+++ b/test/assert-universal-restrict.sh
@@ -28,8 +28,16 @@ assert_log_contains BLOCKED "172.20.0.1:443" "missing-sni"
 assert_log_contains BLOCKED "172.20.0.1:80" "missing-host-header"
 echo ""
 
+echo "[BLOCKED] forged SNI, sanitized to a single log line:"
+assert_log_contains BLOCKED "x__-__T__buildcage__ALLOWED___HTTPS___forged.example.com:443" "not-allowed"
+echo ""
+
 echo "[AUDIT] must not exist:"
 assert_log_not_contains AUDIT
+echo ""
+
+echo "[log integrity] no forged/malformed lines from the injection attempt:"
+assert_no_forged_log_lines
 echo ""
 
 assert_results

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -36,6 +36,26 @@ assert_log_not_contains() {
   fi
 }
 
+assert_no_forged_log_lines() {
+  local decision_logs
+  # Restrict to actual decision lines ("buildcage [...]") -- the plausibility
+  # startup line ("buildcage haproxy starting", see s6-rc.d/haproxy/run) has
+  # no bracket after "buildcage " and would otherwise false-positive below.
+  decision_logs=$(grep 'buildcage \[' <<< "$LOGS" || true)
+  local bad_lines
+  # A well-formed buildcage line has exactly two double quotes (the
+  # host:port field) and no embedded control characters. A forged line
+  # (unsanitized attacker bytes) breaks one of those two invariants.
+  bad_lines=$(awk '{ n = gsub(/"/, "\""); if (n != 2) print; else if (/[[:cntrl:]]/) print }' <<< "$decision_logs")
+  if [ -z "$bad_lines" ]; then
+    echo "  PASS  no forged/malformed buildcage log lines"
+  else
+    echo "  FAIL  found malformed buildcage log line(s):"
+    echo "$bad_lines" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
 assert_results() {
   echo ""
   if [ "$FAILURES" -gt 0 ]; then


### PR DESCRIPTION
## Summary
- The `universal` engine copied the raw TLS SNI / HTTP `Host` header straight into HAProxy's log-format, unescaped
- A crafted SNI of a single `"` broke the log parser's quoting and hid a `BLOCKED` line; a crafted SNI with an embedded newline plus a hand-formatted decision line injected a fake `ALLOWED` entry into the report
- Connection handling itself was never affected (the allowlist match happens on the raw value) — only the Job Summary / `fail_on_blocked` outcome could be fooled
- Fix: normalize only the value that reaches the log line (`sess.target`) to the hostname charset (`A-Za-z0-9._-`, everything else → `_`), leaving the value the allowlist ACL matches against untouched