### PR TITLE
fix: drop fc00::/7 (IPv6 ULA) from the inspect engine's internal-address guard

### DIFF
--- a/src/core/lib/acl/haproxy-rules.ts
+++ b/src/core/lib/acl/haproxy-rules.ts
@@ -21,13 +21,19 @@ export const HOST_IS_ADDRESS = `^${OCTET}\\.${OCTET}\\.${OCTET}\\.${OCTET}$`;
 /**
  * Ranges a resolved name may not point at, refused to stop an allowlisted name
  * resolving to somewhere the proxy can reach but the build cannot -- a cloud
- * metadata endpoint above all. Only never-public ranges; RFC1918 is allowed,
- * since a name pointing at an internal mirror is legitimate. An address named
- * directly in a rule is exempt.
+ * metadata endpoint above all. Only never-public ranges; RFC1918 (and its v6
+ * equivalent, fc00::/7 ULA) is allowed, since a name pointing at an internal
+ * mirror is legitimate. An address named directly in a rule is exempt.
+ *
+ * do-resolve is IPv4-only today (see haproxy-config.ts), so ::1/fe80::/10
+ * can't currently be produced by a resolution -- kept anyway, at zero cost,
+ * for when that changes; fc00::/7 is deliberately absent rather than kept
+ * the same way, since (unlike loopback/link-local) it is never-public but
+ * not never-legitimate.
  *
  *   0.0.0.0/8        this host          169.254.0.0/16  link-local (AWS/GCP/Azure IMDS)
  *   127.0.0.0/8      loopback           100.64.0.0/10   CGNAT (Alibaba IMDS)
- *   192.0.0.0/24     IETF (Oracle IMDS) ::1 fe80::/10 fc00::/7  the v6 equivalents
+ *   192.0.0.0/24     IETF (Oracle IMDS) ::1/128 fe80::/10  the v6 loopback/link-local equivalents
  */
 export const INTERNAL_RANGES = [
   "0.0.0.0/8",
@@ -37,7 +43,6 @@ export const INTERNAL_RANGES = [
   "192.0.0.0/24",
   "::1/128",
   "fe80::/10",
-  "fc00::/7",
 ];
 
 /**


### PR DESCRIPTION
## Summary
- `INTERNAL_RANGES` (the `inspect` engine's guard against a resolved name landing on a never-public range) included `fc00::/7`, the IPv6 ULA block — the v6 equivalent of RFC1918
- The same list's own doc comment says RFC1918 is deliberately exempt, since a name pointing at an internal mirror is a legitimate, intended setup — `fc00::/7` serves the exact same role for IPv6 addressing, so blocking it contradicted that stated intent
- `::1/128` and `fe80::/10` (loopback/link-local) are unaffected and stay blocked — unlike private-use space, there's no legitimate "internal mirror" served by loopback or link-local, so the RFC1918 exemption reasoning doesn't extend to them
- `do-resolve` in this engine is IPv4-only today, so none of the IPv6 entries can currently be produced by a resolution — this has no observable effect yet, but keeps the guard correct for when IPv6 resolution is added