### PR TITLE
fix: reject an allowlisted name that resolves to an internal address (universal engine)

### DIFF
--- a/docker/universal/files/haproxy.cfg.template
+++ b/docker/universal/files/haproxy.cfg.template
@@ -91,6 +91,11 @@ frontend outbound_proxy
     tcp-request content do-resolve(sess.actual_ip,my_dns,ipv4) var(sess.sni) if is_tls has_sni
     tcp-request content set-var(sess.reason) str(dns-failed) if is_tls has_sni ! { var(sess.actual_ip) -m found }
     tcp-request content reject if is_tls has_sni ! { var(sess.actual_ip) -m found }
+    # Block the resolved address from landing on a never-public range, e.g.
+    # cloud metadata. Keep in sync with INTERNAL_RANGES in haproxy-rules.ts.
+    acl dst_internal var(sess.actual_ip) -m ip 0.0.0.0/8 127.0.0.0/8 169.254.0.0/16 100.64.0.0/10 192.0.0.0/24 ::1/128 fe80::/10 172.20.0.1
+    tcp-request content set-var(sess.reason) str(internal-address) if is_tls has_sni dst_internal
+    tcp-request content reject if is_tls has_sni dst_internal
     tcp-request content set-dst var(sess.actual_ip) if is_tls has_sni
     tcp-request content set-var(sess.decision) str(${HAPROXY_DECISION_LABEL}) if is_tls has_sni
     tcp-request content accept if is_tls has_sni
@@ -146,6 +151,11 @@ backend http_filter_backend
     http-request do-resolve(txn.actual_ip,my_dns,ipv4) var(txn.host_only)
     http-request set-var(sess.reason) str(dns-failed) if ! { var(txn.actual_ip) -m found }
     http-request deny deny_status 503 content-type "text/plain" string "DNS Resolution Failed" if ! { var(txn.actual_ip) -m found }
+
+    # Same guard as the TLS path above.
+    acl dst_internal_http var(txn.actual_ip) -m ip 0.0.0.0/8 127.0.0.0/8 169.254.0.0/16 100.64.0.0/10 192.0.0.0/24 ::1/128 fe80::/10 172.20.0.1
+    http-request set-var(sess.reason) str(internal-address) if dst_internal_http
+    http-request deny deny_status 403 content-type "text/plain" string "Blocked by egress proxy" if dst_internal_http
 
     http-request set-dst var(txn.actual_ip)
     http-request set-var(sess.decision) str(${HAPROXY_DECISION_LABEL})

--- a/src/core/lib/acl/haproxy-cfg-template.test.ts
+++ b/src/core/lib/acl/haproxy-cfg-template.test.ts
@@ -1,0 +1,67 @@
+// haproxy.cfg.template isn't generated from INTERNAL_RANGES, so nothing
+// keeps the two lists in sync automatically -- this catches drift.
+import { describe, it, expect, reportResults } from "../test/test-shim.ts";
+import { INTERNAL_RANGES } from "./haproxy-rules.ts";
+
+const isNode = typeof (globalThis as { process?: unknown }).process !== "undefined";
+
+/** The proxy's own address in the universal engine's CNI network (172.20.0.0/24). */
+const PROXY_GATEWAY = "172.20.0.1";
+
+async function readUniversalTemplate(): Promise<string> {
+  if (isNode) {
+    // Non-literal specifiers, same trick as test-shim.ts, so the qjs
+    // tsconfig never tries to resolve Node's types for this branch.
+    const fsSpecifier = "node:fs";
+    const urlSpecifier = "node:url";
+    const pathSpecifier = "node:path";
+    const { readFileSync } = await import(fsSpecifier);
+    const { fileURLToPath } = await import(urlSpecifier);
+    const { dirname, join } = await import(pathSpecifier);
+    const here = dirname(fileURLToPath(import.meta.url));
+    return readFileSync(
+      join(here, "../../../../docker/universal/files/haproxy.cfg.template"),
+      "utf8",
+    );
+  }
+  // Under qjs, tests run inside the actual universal engine image, which
+  // has this same file at this same path.
+  const stdSpecifier = "qjs:std";
+  const std = await import(stdSpecifier);
+  const f = std.open("/etc/haproxy/haproxy.cfg.template", "r");
+  if (f === null) throw new Error("cannot open /etc/haproxy/haproxy.cfg.template");
+  const content = f.readAsString();
+  f.close();
+  return content;
+}
+
+/** The address list of one `acl dst_internal... var(...) -m ip <addrs>` line. */
+function extractGuardAddresses(template: string, aclName: string): string[] {
+  const line = template.split("\n").find((l) => l.trim().startsWith(`acl ${aclName} `));
+  if (line === undefined) {
+    throw new Error(`template has no "acl ${aclName}" line`);
+  }
+  const marker = "-m ip ";
+  const idx = line.indexOf(marker);
+  if (idx === -1) {
+    throw new Error(`"acl ${aclName}" line has no "-m ip" address list: ${line}`);
+  }
+  return line
+    .slice(idx + marker.length)
+    .trim()
+    .split(/\s+/);
+}
+
+const TEMPLATE = await readUniversalTemplate();
+
+describe("universal engine's internal-address guard stays in sync with INTERNAL_RANGES", () => {
+  for (const aclName of ["dst_internal", "dst_internal_http"]) {
+    it(`${aclName}'s address list is exactly INTERNAL_RANGES plus the proxy gateway`, () => {
+      const addrs = extractGuardAddresses(TEMPLATE, aclName);
+      const expected = [...INTERNAL_RANGES, PROXY_GATEWAY].slice().sort();
+      expect(addrs.slice().sort()).toStrictEqual(expected);
+    });
+  }
+});
+
+reportResults();

--- a/test/Dockerfile.universal-audit
+++ b/test/Dockerfile.universal-audit
@@ -29,6 +29,15 @@ RUN echo "=== [Direct IP - audit mode] ===" && \
     echo "Testing direct IP access to 10.200.0.100 (routed through haproxy via TPROXY)..." && \
     (wget -q -O /dev/null --timeout=5 http://10.200.0.100/ && echo "✓ 10.200.0.100: OK") || (echo "✗ 10.200.0.100: FAILED" && exit 1)
 
+# [SSRF - internal address, blocked even though audit otherwise allows everything]
+RUN echo "=== [HTTPS - SSRF via internal address] ===" && \
+    echo "Testing internal.wildcard.example.com (HTTPS, should be blocked even in audit mode)..." && \
+    (wget --no-check-certificate -q -O /dev/null --timeout=5 https://internal.wildcard.example.com/ && echo "✗ internal.wildcard.example.com: ALLOWED (unexpected)" && exit 1) || echo "✓ internal.wildcard.example.com: BLOCKED (expected)"
+
+RUN echo "=== [HTTP - SSRF via internal address] ===" && \
+    echo "Testing internal.wildcard.example.com (HTTP, should be blocked even in audit mode)..." && \
+    (wget -q -O /dev/null --timeout=5 http://internal.wildcard.example.com/ && echo "✗ internal.wildcard.example.com HTTP: ALLOWED (unexpected)" && exit 1) || echo "✓ internal.wildcard.example.com HTTP: BLOCKED (expected)"
+
 # [HTTPS - dns-failed (NXDOMAIN)]
 RUN echo "=== [HTTPS - dns-failed] ===" && \
     echo "Testing nxdomain.wildcard.example.com (HTTPS, should be blocked by dns failure)..." && \

--- a/test/Dockerfile.universal-restrict
+++ b/test/Dockerfile.universal-restrict
@@ -74,6 +74,15 @@ RUN echo "=== [HTTP - dns-failed] ===" && \
     echo "Testing nxdomain.wildcard.example.com (HTTP, should be blocked by dns failure)..." && \
     (wget -q -O /dev/null --timeout=5 http://nxdomain.wildcard.example.com/ && echo "✗ nxdomain.wildcard.example.com HTTP: ALLOWED (unexpected)" && exit 1) || echo "✓ nxdomain.wildcard.example.com HTTP: BLOCKED (expected)"
 
+# [SSRF - allowlisted name resolving to an internal address (169.254.169.254)]
+RUN echo "=== [HTTPS - SSRF via allowlisted name] ===" && \
+    echo "Testing internal.wildcard.example.com (HTTPS, should be blocked)..." && \
+    (wget --no-check-certificate -q -O /dev/null --timeout=5 https://internal.wildcard.example.com/ && echo "✗ internal.wildcard.example.com: ALLOWED (unexpected)" && exit 1) || echo "✓ internal.wildcard.example.com: BLOCKED (expected)"
+
+RUN echo "=== [HTTP - SSRF via allowlisted name] ===" && \
+    echo "Testing internal.wildcard.example.com (HTTP, should be blocked)..." && \
+    (wget -q -O /dev/null --timeout=5 http://internal.wildcard.example.com/ && echo "✗ internal.wildcard.example.com HTTP: ALLOWED (unexpected)" && exit 1) || echo "✓ internal.wildcard.example.com HTTP: BLOCKED (expected)"
+
 # [HTTPS - missing-sni (TLS ClientHello without SNI extension)]
 RUN echo "=== [HTTPS - missing-sni] ===" && \
     echo "Testing TLS connection without SNI (should be blocked)..." && \

--- a/test/assert-universal-audit.sh
+++ b/test/assert-universal-audit.sh
@@ -21,6 +21,11 @@ assert_log_contains BLOCKED "172.20.0.1:443" "missing-sni"
 assert_log_contains BLOCKED "172.20.0.1:80" "missing-host-header"
 echo ""
 
+echo "[BLOCKED] expected (internal-address guard, unconditional even in audit):"
+assert_log_contains BLOCKED "internal.wildcard.example.com:443" "internal-address"
+assert_log_contains BLOCKED "internal.wildcard.example.com:80" "internal-address"
+echo ""
+
 echo "[ALLOWED] must not exist:"
 assert_log_not_contains ALLOWED
 echo ""

--- a/test/assert-universal-restrict.sh
+++ b/test/assert-universal-restrict.sh
@@ -26,6 +26,8 @@ assert_log_contains BLOCKED "nxdomain.wildcard.example.com:443" "dns-failed"
 assert_log_contains BLOCKED "nxdomain.wildcard.example.com:80" "dns-failed"
 assert_log_contains BLOCKED "172.20.0.1:443" "missing-sni"
 assert_log_contains BLOCKED "172.20.0.1:80" "missing-host-header"
+assert_log_contains BLOCKED "internal.wildcard.example.com:443" "internal-address"
+assert_log_contains BLOCKED "internal.wildcard.example.com:80" "internal-address"
 echo ""
 
 echo "[BLOCKED] forged SNI, sanitized to a single log line:"

--- a/test/test-dns/dnsmasq.conf
+++ b/test/test-dns/dnsmasq.conf
@@ -6,6 +6,8 @@ address=/wildcard.example.com/10.200.0.100
 # Return NXDOMAIN for this domain (no IP = NXDOMAIN in dnsmasq 2.86+). More
 # specific than the wildcard.example.com rule above, so it takes precedence.
 address=/nxdomain.wildcard.example.com/
+# Allowlisted name resolving to a link-local address (AWS/GCP/Azure IMDS).
+address=/internal.wildcard.example.com/169.254.169.254
 # Forward everything else to a real upstream resolver, needed for the npm
 # install test's registry.npmjs.org lookup.
 server=1.1.1.1


### PR DESCRIPTION
## Summary
- The universal engine's HAProxy template resolved an allowlisted name and connected to it (`set-dst`) with no check on the resolved address, unlike the `inspect` engine's own internal-range guard.
- A name that passes the allowlist (an attacker-controlled DNS answer, or a broad wildcard rule) could resolve to loopback/link-local/CGNAT/the IETF protocol block/the proxy's own address, reaching e.g. cloud metadata (`169.254.169.254`) through an otherwise-legitimate request. Applies to `audit` mode's direct-IP passthrough case too, since `audit` doesn't gate the rule ACLs but this guard is unconditional.
- Adds a `dst_internal`/`dst_internal_http` ACL (same ranges as `inspect`'s `INTERNAL_RANGES`, minus `fc00::/7`) on both the TLS and HTTP paths, rejecting with reason `internal-address`.
- Adds a unit test (`src/core/lib/acl/haproxy-cfg-template.test.ts`) that reads the static template and asserts its guard's address list matches `INTERNAL_RANGES` exactly, to catch future drift between the two — the template isn't generated from that constant the way `inspect`'s config is.
- Adds e2e coverage in both `restrict` and `audit` mode: an allowlisted wildcard name resolving to `169.254.169.254` is now blocked with `internal-address`, over both HTTP and HTTPS.

## Test plan
- [x] `make test_integration_buildkit_universal_restrict` — new SSRF-via-allowlisted-name case blocked with `internal-address`; all existing assertions pass (no regression)
- [x] `make test_integration_buildkit_universal_audit` — same guard enforced even though `audit` otherwise passes everything