### PR TITLE
fix: use txn scope instead of sess for universal engine decision variables

### DIFF
--- a/docker/universal/files/haproxy.cfg.template
+++ b/docker/universal/files/haproxy.cfg.template
@@ -29,87 +29,87 @@ frontend outbound_proxy
     tcp-request inspect-delay 5s
 
     # Default variables
-    # sess.decision defaults to BLOCKED — any reject/deny leaves it unchanged,
+    # txn.decision defaults to BLOCKED — any reject/deny leaves it unchanged,
     # so only connections that pass all checks are overwritten to ALLOWED/AUDIT.
-    tcp-request content set-var(sess.decision) str(BLOCKED)
-    tcp-request content set-var(sess.reason) str(-)
-    tcp-request content set-var-fmt(sess.target) %[dst]:%[dst_port]
-    tcp-request content set-var(sess.rule_type) str(UNKNOWN)
+    tcp-request content set-var(txn.decision) str(BLOCKED)
+    tcp-request content set-var(txn.reason) str(-)
+    tcp-request content set-var-fmt(txn.target) %[dst]:%[dst_port]
+    tcp-request content set-var(txn.rule_type) str(UNKNOWN)
 
     # ACL: DNS-routed vs IP direct
     acl is_dns_routed dst 172.20.0.1
     # Store DNS-routed state in variable (before set-dst may modify dst)
-    tcp-request content set-var(sess.dns_routed) str(true) if is_dns_routed
+    tcp-request content set-var(txn.dns_routed) str(true) if is_dns_routed
 
     # ACL: TLS/SNI
     acl is_tls req.ssl_hello_type 1
     acl has_sni req_ssl_sni -m found
 
     # ACL: IP direct access allowlist
-    acl is_ip_match var(sess.target) -m reg -f /etc/haproxy/rules/allowed_ips.lst
+    acl is_ip_match var(txn.target) -m reg -f /etc/haproxy/rules/allowed_ips.lst
 
     # TLS variable extraction
-    tcp-request content set-var(sess.sni) req_ssl_sni if is_tls
-    tcp-request content set-var-fmt(sess.sni_port) %[req_ssl_sni]:%[dst_port] if is_tls
+    tcp-request content set-var(txn.sni) req_ssl_sni if is_tls
+    tcp-request content set-var-fmt(txn.sni_port) %[req_ssl_sni]:%[dst_port] if is_tls
     # The SNI is attacker-chosen raw bytes, and HAProxy copies a %[var()] into
     # log-format verbatim -- +E would only escape " \ ], never LF. So the copy
     # that reaches the log is reduced to a hostname charset here; the ACL below
-    # still matches the untouched sess.sni_port.
-    tcp-request content set-var(sess.sni_log) req_ssl_sni,regsub([^A-Za-z0-9._-],_,g) if is_tls has_sni
-    tcp-request content set-var-fmt(sess.target) %[var(sess.sni_log)]:%[dst_port] if is_tls has_sni
+    # still matches the untouched txn.sni_port.
+    tcp-request content set-var(txn.sni_log) req_ssl_sni,regsub([^A-Za-z0-9._-],_,g) if is_tls has_sni
+    tcp-request content set-var-fmt(txn.target) %[var(txn.sni_log)]:%[dst_port] if is_tls has_sni
 
     # ACL: HTTPS allowlist
-    acl is_https_allowed var(sess.sni_port) -m reg -f /etc/haproxy/rules/allowed_https.lst
+    acl is_https_allowed var(txn.sni_port) -m reg -f /etc/haproxy/rules/allowed_https.lst
 
     # ---------------------------------------------------------
     # 1. IP direct access (non DNS-routed)
     # ---------------------------------------------------------
-    tcp-request content set-var(sess.rule_type) str(IP) if !is_dns_routed
-    tcp-request content set-var(sess.decision) str(${HAPROXY_DECISION_LABEL}) if !is_dns_routed is_ip_match
+    tcp-request content set-var(txn.rule_type) str(IP) if !is_dns_routed
+    tcp-request content set-var(txn.decision) str(${HAPROXY_DECISION_LABEL}) if !is_dns_routed is_ip_match
     tcp-request content accept if !is_dns_routed is_ip_match
 
     ${HAPROXY_AUDIT_ACCEPT}
-    tcp-request content set-var(sess.reason) str(ip-not-allowed) if !is_dns_routed !is_ip_match
+    tcp-request content set-var(txn.reason) str(ip-not-allowed) if !is_dns_routed !is_ip_match
     tcp-request content reject if !is_dns_routed !is_ip_match
 
     # ---------------------------------------------------------
     # 2. TLS without SNI
     # ---------------------------------------------------------
-    tcp-request content set-var(sess.rule_type) str(HTTPS) if is_tls
-    tcp-request content set-var(sess.reason) str(missing-sni) if is_tls !has_sni
+    tcp-request content set-var(txn.rule_type) str(HTTPS) if is_tls
+    tcp-request content set-var(txn.reason) str(missing-sni) if is_tls !has_sni
     tcp-request content reject if is_tls !has_sni
 
     # ---------------------------------------------------------
     # 3. TLS allowlist check (before DNS to avoid resolving blocked domains)
     # ---------------------------------------------------------
-    tcp-request content set-var(sess.reason) str(not-allowed) if is_tls has_sni !is_https_allowed
+    tcp-request content set-var(txn.reason) str(not-allowed) if is_tls has_sni !is_https_allowed
     tcp-request content reject if is_tls has_sni !is_https_allowed
 
     # ---------------------------------------------------------
     # 4. TLS DNS resolution, destination override & accept
     # ---------------------------------------------------------
-    tcp-request content do-resolve(sess.actual_ip,my_dns,ipv4) var(sess.sni) if is_tls has_sni
-    tcp-request content set-var(sess.reason) str(dns-failed) if is_tls has_sni ! { var(sess.actual_ip) -m found }
-    tcp-request content reject if is_tls has_sni ! { var(sess.actual_ip) -m found }
+    tcp-request content do-resolve(txn.tls_actual_ip,my_dns,ipv4) var(txn.sni) if is_tls has_sni
+    tcp-request content set-var(txn.reason) str(dns-failed) if is_tls has_sni ! { var(txn.tls_actual_ip) -m found }
+    tcp-request content reject if is_tls has_sni ! { var(txn.tls_actual_ip) -m found }
     # Block the resolved address from landing on a never-public range, e.g.
     # cloud metadata. Keep in sync with INTERNAL_RANGES in haproxy-rules.ts.
-    acl dst_internal var(sess.actual_ip) -m ip 0.0.0.0/8 127.0.0.0/8 169.254.0.0/16 100.64.0.0/10 192.0.0.0/24 ::1/128 fe80::/10 172.20.0.1
-    tcp-request content set-var(sess.reason) str(internal-address) if is_tls has_sni dst_internal
+    acl dst_internal var(txn.tls_actual_ip) -m ip 0.0.0.0/8 127.0.0.0/8 169.254.0.0/16 100.64.0.0/10 192.0.0.0/24 ::1/128 fe80::/10 172.20.0.1
+    tcp-request content set-var(txn.reason) str(internal-address) if is_tls has_sni dst_internal
     tcp-request content reject if is_tls has_sni dst_internal
-    tcp-request content set-dst var(sess.actual_ip) if is_tls has_sni
-    tcp-request content set-var(sess.decision) str(${HAPROXY_DECISION_LABEL}) if is_tls has_sni
+    tcp-request content set-dst var(txn.tls_actual_ip) if is_tls has_sni
+    tcp-request content set-var(txn.decision) str(${HAPROXY_DECISION_LABEL}) if is_tls has_sni
     tcp-request content accept if is_tls has_sni
 
     # ---------------------------------------------------------
     # 5. Non-TLS DNS-routed → HTTP backend
     # ---------------------------------------------------------
     # Routing
-    use_backend ip_passthrough if !{ var(sess.dns_routed) -m found }
+    use_backend ip_passthrough if !{ var(txn.dns_routed) -m found }
     use_backend tls_passthrough if is_tls
     default_backend http_filter_backend
 
     # Set log format
-    log-format "[%T] buildcage [%[var(sess.decision)]] (%[var(sess.rule_type)]) \"%[var(sess.target)]\" %[var(sess.reason)]"
+    log-format "[%T] buildcage [%[var(txn.decision)]] (%[var(txn.rule_type)]) \"%[var(txn.target)]\" %[var(txn.reason)]"
 
 # --- IP direct passthrough backend ---
 backend ip_passthrough
@@ -122,42 +122,42 @@ backend tls_passthrough
     server cleartext 0.0.0.0:0
 
 # --- HTTP filter backend (L7) ---
-# deny responses leave sess.decision as BLOCKED (set in frontend).
+# deny responses leave txn.decision as BLOCKED (set in frontend).
 backend http_filter_backend
     mode http
-    http-request set-var(sess.rule_type) str(HTTP)
+    http-request set-var(txn.rule_type) str(HTTP)
 
     # Host header check
     acl has_host hdr(host) -m found
     acl host_not_empty hdr_len(host) gt 0
-    http-request set-var(sess.reason) str(missing-host-header) if !has_host or !host_not_empty
+    http-request set-var(txn.reason) str(missing-host-header) if !has_host or !host_not_empty
     http-request deny deny_status 400 content-type "text/plain" string "Bad Request: Missing Host Header" if !has_host or !host_not_empty
 
     # Build host:port key
     http-request set-var(txn.host_only) hdr(host),regsub(:.*$,)
     http-request set-var-fmt(txn.host_port) %[var(txn.host_only)]:%[dst_port]
 
-    # Update session target for logging (replace IP with actual hostname)
+    # Update target for logging (replace IP with actual hostname)
     # Same reason as the SNI above: the Host header is attacker-chosen too.
     http-request set-var(txn.host_log) var(txn.host_only),regsub([^A-Za-z0-9._-],_,g)
-    http-request set-var-fmt(sess.target) %[var(txn.host_log)]:%[dst_port]
+    http-request set-var-fmt(txn.target) %[var(txn.host_log)]:%[dst_port]
 
     # HTTP allowlist check
     acl is_http_allowed var(txn.host_port) -m reg -f /etc/haproxy/rules/allowed_http.lst
-    http-request set-var(sess.reason) str(not-allowed) if !is_http_allowed
+    http-request set-var(txn.reason) str(not-allowed) if !is_http_allowed
     http-request deny deny_status 403 content-type "text/plain" string "Blocked by egress proxy" if !is_http_allowed
 
     # DNS resolution & destination override
     http-request do-resolve(txn.actual_ip,my_dns,ipv4) var(txn.host_only)
-    http-request set-var(sess.reason) str(dns-failed) if ! { var(txn.actual_ip) -m found }
+    http-request set-var(txn.reason) str(dns-failed) if ! { var(txn.actual_ip) -m found }
     http-request deny deny_status 503 content-type "text/plain" string "DNS Resolution Failed" if ! { var(txn.actual_ip) -m found }
 
     # Same guard as the TLS path above.
     acl dst_internal_http var(txn.actual_ip) -m ip 0.0.0.0/8 127.0.0.0/8 169.254.0.0/16 100.64.0.0/10 192.0.0.0/24 ::1/128 fe80::/10 172.20.0.1
-    http-request set-var(sess.reason) str(internal-address) if dst_internal_http
+    http-request set-var(txn.reason) str(internal-address) if dst_internal_http
     http-request deny deny_status 403 content-type "text/plain" string "Blocked by egress proxy" if dst_internal_http
 
     http-request set-dst var(txn.actual_ip)
-    http-request set-var(sess.decision) str(${HAPROXY_DECISION_LABEL})
+    http-request set-var(txn.decision) str(${HAPROXY_DECISION_LABEL})
 
     server cleartext 0.0.0.0:0

--- a/test/Dockerfile.universal-restrict
+++ b/test/Dockerfile.universal-restrict
@@ -106,15 +106,15 @@ RUN echo "=== [HTTPS - forged SNI] ===" && \
 
 # [HTTP keep-alive - allowed then blocked: a second request on a reused
 # HTTP/1.1 keep-alive connection must be judged on its own merits, not
-# inherit the first request's sess.decision]
+# inherit the first request's txn.decision]
 RUN echo "=== [HTTP keep-alive - allowed then blocked] ===" && \
     ((printf 'GET / HTTP/1.1\r\nHost: allowed.example.com\r\n\r\n'; sleep 1; \
       printf 'GET / HTTP/1.1\r\nHost: blocked.example.com\r\nConnection: close\r\n\r\n'; sleep 1) \
      | nc -w 5 allowed.example.com 80 > /dev/null 2>&1 || true) && \
     echo "✓ keep-alive allowed-then-blocked: requests sent (second request must log BLOCKED, not ALLOWED)"
 
-# [HTTP keep-alive - blocked then allowed: sess.reason must also reset
-# per request, not just sess.decision]
+# [HTTP keep-alive - blocked then allowed: txn.reason must also reset
+# per request, not just txn.decision]
 RUN echo "=== [HTTP keep-alive - blocked then allowed] ===" && \
     ((printf 'GET / HTTP/1.1\r\nHost: blocked.example.com\r\n\r\n'; sleep 1; \
       printf 'GET / HTTP/1.1\r\nHost: allowed.example.com\r\nConnection: close\r\n\r\n'; sleep 1) \

--- a/test/Dockerfile.universal-restrict
+++ b/test/Dockerfile.universal-restrict
@@ -104,6 +104,23 @@ RUN echo "=== [HTTPS - forged SNI] ===" && \
     (printf '\x16\x03\x01\x00\x70\x01\x00\x00\x6c\x03\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xff\x01\x00\x00\x41\x00\x00\x00\x3d\x00\x3b\x00\x00\x38\x78\x22\x20\x2d\x0a\x5b\x54\x5d\x20\x62\x75\x69\x6c\x64\x63\x61\x67\x65\x20\x5b\x41\x4c\x4c\x4f\x57\x45\x44\x5d\x20\x28\x48\x54\x54\x50\x53\x29\x20\x22\x66\x6f\x72\x67\x65\x64\x2e\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d' | nc -w 5 allowed.example.com 443 > /dev/null 2>&1 || true) && \
     echo "✓ forged-sni: request sent (blocked expected in logs)"
 
+# [HTTP keep-alive - allowed then blocked: a second request on a reused
+# HTTP/1.1 keep-alive connection must be judged on its own merits, not
+# inherit the first request's sess.decision]
+RUN echo "=== [HTTP keep-alive - allowed then blocked] ===" && \
+    ((printf 'GET / HTTP/1.1\r\nHost: allowed.example.com\r\n\r\n'; sleep 1; \
+      printf 'GET / HTTP/1.1\r\nHost: blocked.example.com\r\nConnection: close\r\n\r\n'; sleep 1) \
+     | nc -w 5 allowed.example.com 80 > /dev/null 2>&1 || true) && \
+    echo "✓ keep-alive allowed-then-blocked: requests sent (second request must log BLOCKED, not ALLOWED)"
+
+# [HTTP keep-alive - blocked then allowed: sess.reason must also reset
+# per request, not just sess.decision]
+RUN echo "=== [HTTP keep-alive - blocked then allowed] ===" && \
+    ((printf 'GET / HTTP/1.1\r\nHost: blocked.example.com\r\n\r\n'; sleep 1; \
+      printf 'GET / HTTP/1.1\r\nHost: allowed.example.com\r\nConnection: close\r\n\r\n'; sleep 1) \
+     | nc -w 5 allowed.example.com 80 > /dev/null 2>&1 || true) && \
+    echo "✓ keep-alive blocked-then-allowed: requests sent (second request must log ALLOWED with reason -, not not-allowed)"
+
 # [npm install - allowed - registry.npmjs.org is in ALLOWED_HTTPS_RULES; no CA
 # workaround needed, unlike the explicit engine]
 COPY files/package.json files/package-lock.json /app/

--- a/test/assert-universal-restrict.sh
+++ b/test/assert-universal-restrict.sh
@@ -34,7 +34,7 @@ echo "[BLOCKED] forged SNI, sanitized to a single log line:"
 assert_log_contains BLOCKED "x__-__T__buildcage__ALLOWED___HTTPS___forged.example.com:443" "not-allowed"
 echo ""
 
-echo "[keep-alive] sess.decision/sess.reason must not leak across requests on one connection:"
+echo "[keep-alive] txn.decision/txn.reason must not leak across requests on one connection:"
 assert_log_not_matching ALLOWED "blocked.example.com:80"
 assert_log_not_matching ALLOWED "allowed.example.com:80" "not-allowed"
 echo ""

--- a/test/assert-universal-restrict.sh
+++ b/test/assert-universal-restrict.sh
@@ -34,6 +34,11 @@ echo "[BLOCKED] forged SNI, sanitized to a single log line:"
 assert_log_contains BLOCKED "x__-__T__buildcage__ALLOWED___HTTPS___forged.example.com:443" "not-allowed"
 echo ""
 
+echo "[keep-alive] sess.decision/sess.reason must not leak across requests on one connection:"
+assert_log_not_matching ALLOWED "blocked.example.com:80"
+assert_log_not_matching ALLOWED "allowed.example.com:80" "not-allowed"
+echo ""
+
 echo "[AUDIT] must not exist:"
 assert_log_not_contains AUDIT
 echo ""

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -24,6 +24,26 @@ assert_log_contains() {
   fi
 }
 
+assert_log_not_matching() {
+  local marker="$1"
+  local host_port="$2"
+  local reason="${3:-}"
+  local pattern="\[$marker\].*\"$host_port\""
+  local label="[$marker] $host_port"
+  if [ -n "$reason" ]; then
+    pattern="$pattern $reason"
+    label="$label $reason"
+  fi
+  local buildcage_logs
+  buildcage_logs=$(grep buildcage <<< "$LOGS" || true)
+  if grep -q "$pattern" <<< "$buildcage_logs"; then
+    echo "  FAIL  found unexpected $label line"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  PASS  no $label line"
+  fi
+}
+
 assert_log_not_contains() {
   local marker="$1"
   local count


### PR DESCRIPTION
## Summary
- Looked into whether a request could be misjudged on a reused HTTP keep-alive connection — inheriting the previous request's allow/block verdict instead of being evaluated on its own merits.
- Re-verified against a real running proxy and confirmed this doesn't happen today: each request is already judged independently.
- The state that holds the verdict was using HAProxy's `sess` (session) scope, which is nominally shared for the whole connection, so the correctness was resting on incidental proxy behavior rather than a guaranteed property. Switched it to `txn` (transaction) scope, which HAProxy resets per request by design, turning the isolation into an explicit guarantee instead of an implicit one.
- Added regression coverage that sends two requests back-to-back over one keep-alive connection (allow-then-block and block-then-allow), so this guarantee can't silently regress later.

## Test plan
- [x] Full restrict-mode integration suite passes, including the new keep-alive cases
- [x] Audit-mode integration suite passes
- [x] Zero-traffic integration suite passes