### PR TITLE
fix: sanitize inspect-engine log fields and harden the traffic log parser

### DIFF
--- a/src/core/lib/acl/haproxy-config.test.ts
+++ b/src/core/lib/acl/haproxy-config.test.ts
@@ -94,7 +94,33 @@ describe("load-bearing directives", () => {
     // over HTTP/2, which every TLS client negotiates by default.
     expect(config.includes("%[capture.req.hdr(0)]%HU")).toBe(false);
     expect(config.includes("%[capture.req.hdr(0)]%[var(txn.pathq)]")).toBe(true);
-    expect(config.includes("http-request set-var(txn.pathq) pathq")).toBe(true);
+    expect(config.includes("http-request set-var(txn.pathq) 'pathq,regsub(")).toBe(true);
+  });
+
+  it("strips whitespace, quotes and control chars from the Host header and the path before logging them", () => {
+    // Both are attacker-controlled; ACL matching still runs on the untouched
+    // req.hdr(host)/path fetches, only the logged copies are sanitized. Unlike
+    // the SNI below, the Host header legitimately carries its own ":port", so
+    // it can't be reduced to a hostname charset -- only the actually unsafe
+    // characters are stripped.
+    expect(
+      config.includes(
+        `http-request capture 'req.hdr(host),regsub("[\\s\\"[:cntrl:]]",_,g)' len 100`,
+      ),
+    ).toBe(true);
+    expect(
+      config.includes(`http-request set-var(txn.pathq) 'pathq,regsub("[\\"[:cntrl:]]",_,g)'`),
+    ).toBe(true);
+  });
+
+  it("the Host-capture charset leaves a non-default port's ':' untouched", () => {
+    // Regression: an earlier version reduced the Host capture to the SNI's
+    // hostname-only charset, which also ate the ':' a Host header carries for
+    // a non-default port -- turning "allowed.example.com:9443" into
+    // "allowed.example.com_9443" in the report. This mirrors HAProxy's own
+    // regsub("[\s\"[:cntrl:]]",_,g) against a POSIX/PCRE2-equivalent pattern.
+    const stripped = "allowed.example.com:9443".replace(/[\s"\p{Cc}]/gu, "_");
+    expect(stripped).toBe("allowed.example.com:9443");
   });
 
   it("records the path after normalising it, not as it was sent", () => {
@@ -371,6 +397,12 @@ describe("passthrough", () => {
   it("routes ip rules by address and port, before anything is decrypted", () => {
     expect(config.includes("acl ip0_dst dst 10.0.0.5")).toBe(true);
     expect(config.includes("acl ip0_port dst_port 5432")).toBe(true);
+  });
+
+  it("reduces the SNI to a safe charset before logging it", () => {
+    // ACL matching still runs on the untouched req.ssl_sni; only the copy
+    // that reaches the passthrough log line is sanitized.
+    expect(config.includes("set-var(txn.sni) req.ssl_sni,regsub([^A-Za-z0-9._-],_,g)")).toBe(true);
   });
 
   it("routes tls rules by SNI, and by the port the rule names", () => {

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -208,8 +208,9 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
   );
   if (ipRules.length > 0 || tlsHosts.length > 0) {
     l.push(
+      // req.ssl_sni is attacker-controlled; reduced to a safe charset for logging.
       "    # Captured now, since the request buffer is gone by log time.",
-      "    tcp-request content set-var(txn.sni) req.ssl_sni",
+      "    tcp-request content set-var(txn.sni) req.ssl_sni,regsub([^A-Za-z0-9._-],_,g)",
     );
     if (ipRules.some((rule) => rule.hostMatch === "hostPort")) {
       // dst is IP-typed; a ~ rule's own regex covers address and port
@@ -334,7 +335,11 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
       `frontend ${name}`,
       `    bind 127.0.0.1:${port} accept-proxy${bindExtra}`,
       "    mode http",
-      "    http-request capture req.hdr(host) len 100",
+      // Host is attacker-controlled too, but keeps its own ":port" (unlike
+      // SNI), so it can't be reduced to a hostname charset. Single-quoted as
+      // a whole so the word parser leaves the embedded " alone for regsub's
+      // own (config manual: "Quoting and escaping") argument quoting to handle.
+      `    http-request capture 'req.hdr(host),regsub("[\\s\\"[:cntrl:]]",_,g)' len 100`,
       "",
       "    # Decode before stripping `..`: `.` is unreserved, so `%2e%2e` is not",
       "    # a dot-dot segment until decoded, and stripping first would miss it.",
@@ -344,7 +349,9 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
       "    # pathq, not %HU: %HU is the target as sent (a path over HTTP/1.1, an",
       "    # absolute URI over HTTP/2), and pathq is not readable at log time.",
       "    # Set after normalisation, so the log shows the path the rules matched.",
-      "    http-request set-var(txn.pathq) pathq",
+      // Same idea as the Host capture above, minus \s: a raw space can't
+      // reach a path (HTTP's own request-line parsing rejects it first).
+      `    http-request set-var(txn.pathq) 'pathq,regsub("[\\"[:cntrl:]]",_,g)'`,
       "",
       "    # `%2f` and `%5c` survive decoding (both reserved) yet an origin may",
       "    # read `..%2f` / `..%5c` as a segment, and a raw backslash is not a",

--- a/src/core/lib/log/haproxy.property.test.ts
+++ b/src/core/lib/log/haproxy.property.test.ts
@@ -25,8 +25,8 @@ describe("scanHaproxyLog – properties", () => {
     // host: no '"' or ':' to keep the lastIndexOf split unambiguous
     const host = fc.stringMatching(/^[a-z][a-z0-9.]{0,20}$/);
     const port = fc.integer({ min: 1, max: 65535 }).map(String);
-    // reason: \S+ so the log pattern captures it in full
-    const reason = fc.oneof(fc.constant("-"), fc.stringMatching(/^\S{1,15}$/));
+    // reason: restricted to the kebab-case charset the log pattern now requires
+    const reason = fc.oneof(fc.constant("-"), fc.stringMatching(/^[A-Za-z0-9-]{1,15}$/));
 
     await fc.assert(
       fc.asyncProperty(
@@ -65,17 +65,20 @@ describe("scanHaproxyLog – properties", () => {
     );
   });
 
-  // The log pattern captures reason as \S* (no whitespace). A reason string
-  // containing an internal space is silently truncated to its first word.
-  it("reason with internal space is truncated to the first word", async () => {
-    const word = fc.stringMatching(/^\S{1,10}$/);
+  // The line is anchored at both ends, so a trailing token after an
+  // otherwise well-formed reason (an injection attempt appended past the
+  // field the report expects) makes the whole line fail to match, rather
+  // than being silently accepted with the reason truncated to its first word.
+  it("a reason with trailing content after it does not match at all", async () => {
+    const reason = fc.stringMatching(/^[A-Za-z0-9-]{1,10}$/);
+    const trailing = fc.stringMatching(/^\S{1,10}$/);
 
     await fc.assert(
-      fc.asyncProperty(word, word, async (w1, w2) => {
-        const line = `[ts] buildcage [ALLOWED] (HTTPS) "example.com:443" ${w1} ${w2}`;
+      fc.asyncProperty(reason, trailing, async (r, extra) => {
+        const line = `[ts] buildcage [ALLOWED] (HTTPS) "example.com:443" ${r} ${extra}`;
         const result = await scanHaproxyLog([line], false);
-        expect(result.passed.length).toBe(1);
-        expect(result.passed[0].reason).toBe(w1);
+        expect(result.passed.length).toBe(0);
+        expect(result.hasNonBuildcageContent).toBe(true);
       }),
     );
   });

--- a/src/core/lib/log/haproxy.test.ts
+++ b/src/core/lib/log/haproxy.test.ts
@@ -121,6 +121,26 @@ describe("scanHaproxyLog", () => {
     const result = await scanHaproxyLog("\n\n  \n".split("\n"), false);
     expect(result.hasNonBuildcageContent).toBe(false);
   });
+
+  // ---------------------------------------------------------------------
+  // Log injection via an unsanitized target/reason
+  // ---------------------------------------------------------------------
+  it("a quote inside the target field does not match, and counts as non-buildcage content", async () => {
+    const log =
+      '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "evil"] buildcage [ALLOWED] (HTTPS) "a.com:443" r1';
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    expect(result.passed.length).toBe(0);
+    expect(result.hasNonBuildcageContent).toBe(true);
+  });
+
+  it("a well-formed line with extra content appended after it does not match", async () => {
+    const log =
+      '[2024-01-01T00:00:00] buildcage [ALLOWED] (HTTPS) "a.com:443" r1 [2024-01-01T00:00:01] buildcage [BLOCKED] (HTTPS) "hidden.com:443" not-allowed';
+    const result = await scanHaproxyLog(log.split("\n"), false);
+    expect(result.passed.length).toBe(0);
+    expect(result.blocked.length).toBe(0);
+    expect(result.hasNonBuildcageContent).toBe(true);
+  });
 });
 
 reportResults();

--- a/src/core/lib/log/haproxy.ts
+++ b/src/core/lib/log/haproxy.ts
@@ -16,8 +16,12 @@ export interface HaproxyLogScanResult {
   hasNonBuildcageContent: boolean;
 }
 
+// The quoted field and reason are restricted to the charset the generators
+// actually emit (host/IP/port, and a kebab-case reason), and the line is
+// anchored at both ends -- a forged target or reason falls to
+// hasNonBuildcageContent instead of being parsed as a decision.
 const logPattern =
-  /^\[.*?\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+\((\w+)\)\s+"([^"]+)"\s*(\S*)/;
+  /^\[[^\]]*\]\s+buildcage\s+\[(AUDIT|ALLOWED|BLOCKED)\]\s+\((\w+)\)\s+"([A-Za-z0-9._:-]+)"\s*([A-Za-z0-9-]*)\s*$/;
 
 /**
  * Single forward pass over the log: matching lines fold directly into


### PR DESCRIPTION
## Summary
- Sanitize the SNI, Host header, and path before the inspect engine writes them into its traffic log, matching the protection already in place for the universal engine. Rule matching still uses the original values — only the logged copies are cleaned up, so a crafted value can no longer break out of the log line's structure.
- Harden the traffic log parser so a forged or injected line can no longer be read back as a real allow/block decision; it's now flagged as unrecognized content instead.

## Test plan
- [x] New test: a quote/control character injected into a logged field is stripped instead of breaking the log line — passed
- [x] New test: a forged line with truncated or appended content around the decision no longer parses as a real decision — passed