### PR TITLE
docs: shrink and de-emphasize the inspect restrict-mode example's footnote

### DIFF
--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -198,8 +198,7 @@ export function buildInspectRestrictExample(
   md += "```yaml\n";
   md += yaml;
   md += "```\n\n";
-  md += "These rules permit exactly what this build did, so read them before using them: a URL\n";
-  md += "that carried a version or a date will not match the next run.\n\n";
+  md += "<sub>*Permits exactly what this build did; a versioned or dated URL may drift.*</sub>\n\n";
   md += "</details>\n";
   return md;
 }


### PR DESCRIPTION
## Summary
- Shrinks the footnote under the `inspect`-mode restrict-mode YAML example and wraps it in `<sub>` so it renders smaller, matching the styling of the report's other footnotes.
- Ports the same change already applied on `buildcage/isolated-run`.
