### PR TITLE
fix: bind-mount the CA store's directory instead of editing it in place

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -187,6 +187,10 @@ jobs:
         if: contains(matrix.mode, 'inspect')
         run: ./test/assert-inspect-no-ca-residue.sh buildcage-test
 
+      - name: Verify no per-layer CA bundle duplication
+        if: contains(matrix.mode, 'inspect')
+        run: ./test/assert-inspect-no-layer-bloat.sh buildcage-test
+
       - name: Show logs
         if: always()
         env:
@@ -247,6 +251,33 @@ jobs:
         env:
           COMPOSE_FILE: compose.yaml:compose.test-inspect.yaml
         run: docker compose down -v --rmi all 2>/dev/null || true
+
+  test_inspect_byte_exact:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.test == 'true'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    name: "integration: test (inspect byte-exact)"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-vp
+
+      # Brings up inspect, then universal, one after the other (both use the
+      # same builder name), so this is one script rather than a matrix entry.
+      - name: Compare inspect and universal layer-for-layer
+        run: make test_integration_buildkit_inspect_byte_exact
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose -p buildcage-project down -v --rmi all 2>/dev/null || true
+          rm -f /tmp/buildcage-byte-exact-inspect.tar /tmp/buildcage-byte-exact-universal.tar
 
   test_multiarch:
     needs: changes
@@ -337,7 +368,7 @@ jobs:
   integration-tests-passed:
     name: Integration tests passed
     runs-on: ubuntu-latest
-    needs: [changes, test, test_inspect_roundtrip, test_multiarch]
+    needs: [changes, test, test_inspect_roundtrip, test_inspect_byte_exact, test_multiarch]
     if: always()
     permissions: {}
     steps:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -58,6 +58,14 @@ jobs:
 
       - uses: ./.github/actions/setup-vp
 
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26"
+
+      - name: Test buildcage-runc (inspect engine)
+        working-directory: docker/inspect/buildcage-runc
+        run: go test ./...
+
       - name: Typecheck
         run: vp run typecheck
 

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ report_buildkit: ## Show the buildcage report for the currently running builder
 # ---------------------------------------------------------------------------
 
 .PHONY: test_integration_buildkit
-test_integration_buildkit: test_integration_buildkit_universal_audit test_integration_buildkit_universal_restrict test_integration_buildkit_universal_restrict_no_traffic test_integration_buildkit_explicit_audit test_integration_buildkit_explicit_restrict test_integration_buildkit_inspect_audit test_integration_buildkit_inspect_restrict test_integration_buildkit_inspect_debian_audit test_integration_buildkit_inspect_debian_restrict test_integration_buildkit_inspect_roundtrip ## Run all buildkit integration tests
+test_integration_buildkit: test_integration_buildkit_universal_audit test_integration_buildkit_universal_restrict test_integration_buildkit_universal_restrict_no_traffic test_integration_buildkit_explicit_audit test_integration_buildkit_explicit_restrict test_integration_buildkit_inspect_audit test_integration_buildkit_inspect_restrict test_integration_buildkit_inspect_debian_audit test_integration_buildkit_inspect_debian_restrict test_integration_buildkit_inspect_byte_exact test_integration_buildkit_inspect_roundtrip ## Run all buildkit integration tests
 
 .PHONY: test_integration_buildkit_universal_audit
 test_integration_buildkit_universal_audit: ## Run universal-engine audit mode tests
@@ -247,6 +247,7 @@ test_integration_buildkit_inspect_audit: ## Run inspect-engine audit mode tests
 	  --progress=plain -f test/Dockerfile.inspect-audit test/ \
 	  --load -t buildcage-test
 	@./test/assert-inspect-no-ca-residue.sh buildcage-test
+	@./test/assert-inspect-no-layer-bloat.sh buildcage-test
 	@node report/src/main.ts || true
 	@./test/assert-inspect-audit.sh
 	@node src/post.ts
@@ -264,6 +265,7 @@ test_integration_buildkit_inspect_restrict: ## Run inspect-engine restrict mode 
 	  --progress=plain -f test/Dockerfile.inspect-restrict test/ \
 	  --load -t buildcage-test
 	@./test/assert-inspect-no-ca-residue.sh buildcage-test
+	@./test/assert-inspect-no-layer-bloat.sh buildcage-test
 	@node report/src/main.ts || true
 	@./test/assert-inspect-restrict.sh
 	@node src/post.ts
@@ -281,6 +283,7 @@ test_integration_buildkit_inspect_debian_audit: ## Run inspect-engine audit mode
 	  --progress=plain -f test/Dockerfile.inspect-debian test/ \
 	  --load -t buildcage-test
 	@./test/assert-inspect-no-ca-residue.sh buildcage-test
+	@./test/assert-inspect-no-layer-bloat.sh buildcage-test
 	@node report/src/main.ts || true
 	@./test/assert-inspect-debian.sh
 	@TEST_COMPOSE_FILE=compose.test-inspect.yaml $(MAKE) clean_buildkit
@@ -296,9 +299,38 @@ test_integration_buildkit_inspect_debian_restrict: ## Run inspect-engine restric
 	  --progress=plain -f test/Dockerfile.inspect-debian test/ \
 	  --load -t buildcage-test
 	@./test/assert-inspect-no-ca-residue.sh buildcage-test
+	@./test/assert-inspect-no-layer-bloat.sh buildcage-test
 	@node report/src/main.ts || true
 	@./test/assert-inspect-debian.sh
 	@TEST_COMPOSE_FILE=compose.test-inspect.yaml $(MAKE) clean_buildkit
+
+.PHONY: test_integration_buildkit_inspect_byte_exact
+test_integration_buildkit_inspect_byte_exact: ## Compare inspect vs universal layer-for-layer, byte for byte
+	@echo "Running inspect-engine byte-exact layer comparison..."
+	@rm -f /tmp/buildcage-byte-exact-inspect.tar /tmp/buildcage-byte-exact-universal.tar
+	@COMPOSE_FILE=compose.yaml:compose.test-inspect.yaml \
+	  $(MAKE) setup_buildkit_inspect_audit
+	@docker buildx build --no-cache \
+	  --builder buildcage \
+	  --platform linux/arm64 \
+	  --build-arg SOURCE_DATE_EPOCH=1700000000 \
+	  --output type=docker,name=buildcage-byte-exact-inspect,rewrite-timestamp=true,unpack=false,dest=/tmp/buildcage-byte-exact-inspect.tar \
+	  --progress=plain -f test/Dockerfile.inspect-byte-exact test/
+	@TEST_COMPOSE_FILE=compose.test-inspect.yaml $(MAKE) clean_buildkit
+	@COMPOSE_FILE=compose.yaml:compose.test-universal.yaml \
+	  $(MAKE) setup_buildkit_universal_audit
+	@docker buildx build --no-cache \
+	  --builder buildcage \
+	  --platform linux/arm64 \
+	  --build-arg SOURCE_DATE_EPOCH=1700000000 \
+	  --output type=docker,name=buildcage-byte-exact-universal,rewrite-timestamp=true,unpack=false,dest=/tmp/buildcage-byte-exact-universal.tar \
+	  --progress=plain -f test/Dockerfile.inspect-byte-exact test/
+	@TEST_COMPOSE_FILE=compose.test-universal.yaml $(MAKE) clean_buildkit
+	@docker load -i /tmp/buildcage-byte-exact-inspect.tar
+	@docker load -i /tmp/buildcage-byte-exact-universal.tar
+	@./test/assert-inspect-byte-exact.sh buildcage-byte-exact-universal buildcage-byte-exact-inspect
+	@docker rmi buildcage-byte-exact-inspect buildcage-byte-exact-universal
+	@rm -f /tmp/buildcage-byte-exact-inspect.tar /tmp/buildcage-byte-exact-universal.tar
 
 .PHONY: test_integration_buildkit_inspect_roundtrip
 test_integration_buildkit_inspect_roundtrip: ## Learn rules from an inspect audit run, then enforce them

--- a/README.md
+++ b/README.md
@@ -372,6 +372,19 @@ RUN curl https://internal.example.com/pkg.tgz -o pkg.tgz   # this step starts wi
                                                               # of the proxy-CA-only fallback
 ```
 
+**The CA store's directory is a mount point for the step's duration**, so removing or renaming the
+directory itself (not files inside it) fails instead of succeeding:
+
+```dockerfile
+RUN rm -rf /etc/ssl/certs        # fails: the directory is a mount point and can't be removed itself
+RUN rm -rf /etc/ssl/certs/*      # fine: removing what's inside it works normally
+```
+
+The same applies to a Dockerfile-chosen custom path (an already-set CA-trust variable pointing
+somewhere of its own), unless its directory is unexpectedly large (more than 20 MiB or 512 files), in
+which case injection is skipped for that variable only, the same graceful degradation as when no CA
+bundle is found at all.
+
 See [Inspect Proxy Engine](./docs/security.md#inspect-proxy-engine) for the threat model and attack
 resistance.
 

--- a/docker/inspect/Dockerfile
+++ b/docker/inspect/Dockerfile
@@ -75,7 +75,8 @@ RUN apk add --no-cache \
       haproxy \
       openssl \
       iptables \
-      quickjs-ng
+      quickjs-ng \
+      rsync
 
 ENV S6_KEEP_ENV=1
 ENV S6_LOGGING=0

--- a/docker/inspect/buildcage-runc/castore.go
+++ b/docker/inspect/buildcage-runc/castore.go
@@ -140,6 +140,22 @@ func removeCA(path string) error {
 	return os.WriteFile(path, append(content[:start:start], content[end:]...), 0o644)
 }
 
+// containerPathOf converts a path already resolved inside rootfs back to how
+// the container itself sees it. The mount destination for a dirBind has to be
+// this, not the candidate path's own directory: on RHEL the candidate is a
+// symlink (/etc/pki/tls/certs/ca-bundle.crt) whose real file lives elsewhere
+// (/etc/pki/ca-trust/extracted/pem/), and binding over the symlink's
+// directory would shadow the wrong place.
+func containerPathOf(rootfs, resolved string) string {
+	if !strings.HasPrefix(resolved, rootfs) {
+		return "/"
+	}
+	if rel := strings.TrimPrefix(resolved, rootfs); rel != "" {
+		return rel
+	}
+	return "/"
+}
+
 // findSystemStore returns the container's own CA bundle, as a path inside the
 // rootfs and as the path the container refers to it by.
 func findSystemStore(rootfs string) (hostPath, containerPath string, err error) {

--- a/docker/inspect/buildcage-runc/inject.go
+++ b/docker/inspect/buildcage-runc/inject.go
@@ -100,14 +100,14 @@ func loadSpec(bundle string) (*spec, error) {
 	return s, nil
 }
 
-// setEnv adds variables to the process spec and writes it back.
-func (s *spec) setEnv(extra map[string]string) error {
+// setEnv adds variables to the process spec in memory; call save to persist.
+func (s *spec) setEnv(extra map[string]string) {
 	if len(extra) == 0 {
-		return nil
+		return
 	}
 	proc, ok := s.raw["process"].(map[string]any)
 	if !ok {
-		return nil
+		return
 	}
 	env, _ := proc["env"].([]any)
 	for key, value := range extra {
@@ -116,6 +116,9 @@ func (s *spec) setEnv(extra map[string]string) error {
 	}
 	proc["env"] = env
 	s.raw["process"] = proc
+}
+
+func (s *spec) save() error {
 	out, err := json.Marshal(s.raw)
 	if err != nil {
 		return err
@@ -123,8 +126,12 @@ func (s *spec) setEnv(extra map[string]string) error {
 	return os.WriteFile(s.path, out, 0o644)
 }
 
-// inject makes the step trust the proxy's CA and returns the undo.
-func inject(bundle string, ca []byte) (func(), error) {
+// inject makes the step trust the proxy's CA and returns a function that
+// finishes the injection once the step has exited: diffing each mirrored
+// directory against its pre-step state and writing back only what changed.
+// A non-nil error from it means the write-back itself failed and the build
+// must not proceed with a possibly half-written layer.
+func inject(bundle string, ca []byte) (func() error, error) {
 	s, err := loadSpec(bundle)
 	if err != nil {
 		return nil, err
@@ -202,31 +209,64 @@ func inject(bundle string, ca []byte) (func(), error) {
 		}
 	}
 
-	appended := make([]string, 0, len(targets))
-	for target := range targets {
-		if err := appendCA(target, ca); err != nil {
-			logf("cannot add the CA to %s: %v", target, err)
+	var binds []*dirBind
+	for hostDir, files := range groupTargetsByDir(targets) {
+		containerDir := containerPathOf(s.rootfs, hostDir)
+		if containerDir == "/" {
+			logf("refusing to bind the container root; skipping CA injection for %v", files)
 			continue
 		}
-		appended = append(appended, target)
+		if mountConflicts(s.raw, containerDir) {
+			logf("a mount already covers %s; skipping CA injection there", containerDir)
+			continue
+		}
+
+		scratch, err := newScratchDir(bundle)
+		if err != nil {
+			logf("cannot create a scratch directory for %s: %v", containerDir, err)
+			continue
+		}
+		names := make([]string, len(files))
+		for i, f := range files {
+			names[i] = filepath.Base(f)
+		}
+		b := &dirBind{
+			hostDir:      hostDir,
+			containerDir: containerDir,
+			scratchDir:   scratch,
+			bundleFiles:  names,
+			custom:       !(haveSystemStore && hostDir == filepath.Dir(systemStore)),
+		}
+		if err := b.prepare(ca); err != nil {
+			logf("cannot prepare CA injection for %s: %v", containerDir, err)
+			b.cleanup()
+			continue
+		}
+		addBindMount(s.raw, containerDir, scratch)
+		binds = append(binds, b)
 	}
 
-	if err := s.setEnv(newEnv); err != nil {
-		logf("cannot update the process environment: %v", err)
+	s.setEnv(newEnv)
+	if err := s.save(); err != nil {
+		logf("cannot update the process spec: %v", err)
 	}
 
-	return func() {
-		// The environment lives only in config.json, which is not part of the
-		// snapshot, so only the files have to be undone.
-		for _, target := range appended {
-			if err := removeCA(target); err != nil {
-				logf("cannot remove the CA from %s: %v", target, err)
+	return func() error {
+		var firstErr error
+		for _, b := range binds {
+			if err := b.finish(); err != nil {
+				logf("CA write-back failed for %s: %v", b.containerDir, err)
+				if firstErr == nil {
+					firstErr = err
+				}
 			}
+			b.cleanup()
 		}
 		if createdOwnCA != "" {
 			if err := os.Remove(createdOwnCA); err != nil && !os.IsNotExist(err) {
 				logf("cannot remove %s: %v", createdOwnCA, err)
 			}
 		}
+		return firstErr
 	}, nil
 }

--- a/docker/inspect/buildcage-runc/inject_test.go
+++ b/docker/inspect/buildcage-runc/inject_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,11 +80,39 @@ func loadEnv(t *testing.T, bundle string) map[string]string {
 	return s.env
 }
 
+func loadMounts(t *testing.T, bundle string) []map[string]any {
+	t.Helper()
+	s, err := loadSpec(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := s.raw["mounts"].([]any)
+	mounts := make([]map[string]any, 0, len(raw))
+	for _, m := range raw {
+		if entry, ok := m.(map[string]any); ok {
+			mounts = append(mounts, entry)
+		}
+	}
+	return mounts
+}
+
+func findMount(t *testing.T, mounts []map[string]any, dest string) map[string]any {
+	t.Helper()
+	for _, m := range mounts {
+		if m["destination"] == dest {
+			return m
+		}
+	}
+	t.Fatalf("no mount for %s", dest)
+	return nil
+}
+
 // Additive variables (NODE_EXTRA_CA_CERTS, DENO_CERT) get their own file
 // holding only the proxy's CA, so a tool's built-in bundle stays intact.
 // Replacing variables (REQUESTS_CA_BUNDLE, PIP_CERT, SSL_CERT_FILE) get
 // pointed at the system store instead, which already carries both.
 func TestInjectSetsEachUnsetVariableAccordingToItsKind(t *testing.T) {
+	useFakeRsync(t)
 	bundle, rootfs := newBundle(t, []string{"PATH=/usr/bin"})
 
 	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
@@ -118,12 +147,24 @@ func TestInjectSetsEachUnsetVariableAccordingToItsKind(t *testing.T) {
 		t.Error("CURL_CA_BUNDLE should be left unset; curl already reads the system store")
 	}
 
+	// The CA goes into the scratch mirror bind-mounted over the store's
+	// directory, never into the real rootfs directly.
+	mount := findMount(t, loadMounts(t, bundle), "/etc/ssl/certs")
+	scratchDir, _ := mount["source"].(string)
+	mirrored, err := os.ReadFile(filepath.Join(scratchDir, "ca-certificates.crt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(mirrored), "BUILDCAGE-CA") || !strings.HasPrefix(string(mirrored), "ORIGINAL-ROOTS") {
+		t.Fatalf("scratch mirror not patched correctly: %q", mirrored)
+	}
+
 	store, err := os.ReadFile(filepath.Join(rootfs, "etc", "ssl", "certs", "ca-certificates.crt"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(store), "BUILDCAGE-CA") || !strings.HasPrefix(string(store), "ORIGINAL-ROOTS") {
-		t.Fatalf("system store not patched correctly: %q", store)
+	if string(store) != "ORIGINAL-ROOTS\n" {
+		t.Fatalf("the real store must stay untouched until the step changes it: %q", store)
 	}
 }
 
@@ -131,6 +172,7 @@ func TestInjectSetsEachUnsetVariableAccordingToItsKind(t *testing.T) {
 // choice; the CA is appended to that file instead of the variable being
 // redirected, so whatever the author put there is not discarded.
 func TestInjectAppendsToAnAlreadySetVariableInstead(t *testing.T) {
+	useFakeRsync(t)
 	bundle, rootfs := newBundle(t, []string{"DENO_CERT=/custom/roots.pem"})
 	if err := os.MkdirAll(filepath.Join(rootfs, "custom"), 0o755); err != nil {
 		t.Fatal(err)
@@ -149,35 +191,124 @@ func TestInjectAppendsToAnAlreadySetVariableInstead(t *testing.T) {
 	if env["DENO_CERT"] != "/custom/roots.pem" {
 		t.Fatalf("DENO_CERT was redirected to %q", env["DENO_CERT"])
 	}
-	custom, err := os.ReadFile(filepath.Join(rootfs, "custom", "roots.pem"))
+
+	mount := findMount(t, loadMounts(t, bundle), "/custom")
+	scratchDir, _ := mount["source"].(string)
+	custom, err := os.ReadFile(filepath.Join(scratchDir, "roots.pem"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(custom), "BUILDCAGE-CA") {
 		t.Fatal("the CA was not appended to the custom file")
 	}
+
+	real, err := os.ReadFile(filepath.Join(rootfs, "custom", "roots.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(real) != "CUSTOM\n" {
+		t.Fatalf("the real file must stay untouched until the step changes it: %q", real)
+	}
 }
 
-// restore removes exactly what inject added, leaving the step's own content
-// (in the system store and in config.json) untouched.
-func TestInjectRestoreUndoesTheFilesOnly(t *testing.T) {
+// A step that never touches the store leaves the real rootfs file alone:
+// finish() finds the scratch mirror unchanged from its post-injection
+// baseline and never writes back.
+func TestInjectFinishLeavesAnUntouchedStoreAlone(t *testing.T) {
+	useFakeRsync(t)
 	bundle, rootfs := newBundle(t, []string{"PATH=/usr/bin"})
 
 	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	restore()
+	if err := restore(); err != nil {
+		t.Fatal(err)
+	}
 
 	store, err := os.ReadFile(filepath.Join(rootfs, "etc", "ssl", "certs", "ca-certificates.crt"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(store) != "ORIGINAL-ROOTS\n" {
-		t.Fatalf("system store not restored: %q", store)
+		t.Fatalf("the real store was written to even though nothing changed: %q", store)
 	}
 	if _, err := os.Stat(filepath.Join(rootfs, strings.TrimPrefix(ownCAPath, "/"))); !os.IsNotExist(err) {
 		t.Fatalf("own CA file still present: %v", err)
+	}
+}
+
+// A step that regenerates the store (e.g. apt-get install --reinstall
+// ca-certificates) gets its change mirrored back onto the real rootfs.
+func TestInjectWritesBackWhenTheStepChangesTheStore(t *testing.T) {
+	useFakeRsync(t)
+	bundle, rootfs := newBundle(t, []string{"PATH=/usr/bin"})
+
+	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mount := findMount(t, loadMounts(t, bundle), "/etc/ssl/certs")
+	scratchDir, _ := mount["source"].(string)
+	if err := os.WriteFile(filepath.Join(scratchDir, "ca-certificates.crt"), []byte("REGENERATED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls int
+	orig := runRsync
+	runRsync = func(args []string) ([]byte, error) {
+		calls++
+		return orig(args)
+	}
+	defer func() { runRsync = orig }()
+
+	if err := restore(); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("got %d rsync invocations for the write-back, want 2 (dry run, then apply)", calls)
+	}
+
+	got, err := os.ReadFile(filepath.Join(rootfs, "etc", "ssl", "certs", "ca-certificates.crt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "REGENERATED\n" {
+		t.Fatalf("write-back did not reach the real store: %q", got)
+	}
+}
+
+// A failure applying the write-back must fail the build rather than ship a
+// half-written layer.
+func TestInjectWriteBackFailurePropagates(t *testing.T) {
+	useFakeRsync(t)
+	bundle, _ := newBundle(t, []string{"PATH=/usr/bin"})
+
+	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mount := findMount(t, loadMounts(t, bundle), "/etc/ssl/certs")
+	scratchDir, _ := mount["source"].(string)
+	if err := os.WriteFile(filepath.Join(scratchDir, "ca-certificates.crt"), []byte("REGENERATED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls int
+	orig := runRsync
+	runRsync = func(args []string) ([]byte, error) {
+		calls++
+		if calls == 2 { // the apply, right after a successful dry run
+			return []byte("boom"), fmt.Errorf("simulated failure")
+		}
+		return orig(args)
+	}
+	defer func() { runRsync = orig }()
+
+	if err := restore(); err == nil {
+		t.Fatal("expected the write-back failure to propagate")
 	}
 }
 

--- a/docker/inspect/buildcage-runc/main.go
+++ b/docker/inspect/buildcage-runc/main.go
@@ -79,7 +79,7 @@ func main() {
 	// `run` only, not `create`: restore is tied to the wrapped process exiting,
 	// but `runc create` returns before the process runs, so the CA would be gone
 	// by `runc start`. BuildKit's runcexecutor uses `run`.
-	var restore func()
+	var restore func() error
 	if sub == "run" && bundle != "" {
 		ca, err := os.ReadFile(caFile)
 		if err != nil {
@@ -126,7 +126,12 @@ func main() {
 		}
 	}
 	if restore != nil {
-		restore()
+		if err := restore(); err != nil {
+			logf("CA write-back failed, failing the build: %v", err)
+			if code == 0 {
+				code = 1
+			}
+		}
 	}
 	os.Exit(code)
 }

--- a/docker/inspect/buildcage-runc/mount.go
+++ b/docker/inspect/buildcage-runc/mount.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// scratchRoot is a var, not a const, so tests can point it at a temp
+// directory instead of the real host path.
+var scratchRoot = "/run/buildcage/ca"
+
+const (
+	// A real CA bundle directory is a few hundred KB across a handful of
+	// files. These bound how far a Dockerfile-chosen custom path (an
+	// already-set env var pointing somewhere of its own) can drag this
+	// mechanism before injection is skipped for it instead of mirroring
+	// something like an application directory wholesale.
+	maxCustomDirBytes = 20 << 20
+	maxCustomDirFiles = 512
+)
+
+// runRsync is the only place this file spawns a process, so tests can
+// replace it to exercise the decision logic without rsync installed.
+var runRsync = func(args []string) ([]byte, error) {
+	return exec.Command("rsync", args...).CombinedOutput()
+}
+
+// dirBind mounts a scratch mirror of one directory over the step's view of
+// it, so the CA can be added without ever opening the real rootfs file for
+// writing. Grouped by directory rather than by file: two variables can
+// resolve to different files in the same store directory, and mounting two
+// separate sources over the same destination would let the second shadow
+// the first.
+type dirBind struct {
+	hostDir      string
+	containerDir string
+	scratchDir   string
+	bundleFiles  []string
+	custom       bool
+
+	original []fileEntry // hostDir's state before mirroring
+	baseline []fileEntry // scratchDir's state right after the CA was appended
+}
+
+func groupTargetsByDir(targets map[string]bool) map[string][]string {
+	groups := make(map[string][]string)
+	for target := range targets {
+		dir := filepath.Dir(target)
+		groups[dir] = append(groups[dir], target)
+	}
+	return groups
+}
+
+func newScratchDir(bundle string) (string, error) {
+	if err := os.MkdirAll(scratchRoot, 0o700); err != nil {
+		return "", err
+	}
+	return os.MkdirTemp(scratchRoot, filepath.Base(bundle)+"-")
+}
+
+func mountConflicts(raw map[string]any, dest string) bool {
+	mounts, _ := raw["mounts"].([]any)
+	for _, m := range mounts {
+		entry, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		existing, _ := entry["destination"].(string)
+		if existing == "" {
+			continue
+		}
+		if existing == dest || strings.HasPrefix(dest, existing+"/") || strings.HasPrefix(existing, dest+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func addBindMount(raw map[string]any, dest, src string) {
+	mounts, _ := raw["mounts"].([]any)
+	raw["mounts"] = append(mounts, map[string]any{
+		"destination": dest,
+		"type":        "bind",
+		"source":      src,
+		"options":     []any{"rbind", "rw"},
+	})
+}
+
+func mirrorDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	_, err := runRsync([]string{"-aHAX", "--numeric-ids", "--", src + "/", dst + "/"})
+	return err
+}
+
+// writeBack mirrors scratchDir onto hostDir. The dry run is logged so a
+// write-back is auditable after the fact; the real failure signal is the
+// second rsync's own exit code; a partial transfer already makes rsync exit
+// non-zero, so this doesn't also diff the two runs' output against each other.
+func writeBack(scratchDir, hostDir string) error {
+	args := []string{"-aHAX", "--checksum", "--delete", "--numeric-ids", "--no-specials", "--no-devices", "--itemize-changes"}
+	src, dst := scratchDir+"/", hostDir+"/"
+
+	planned, err := runRsync(append(append([]string{}, args...), "-n", "--", src, dst))
+	if err != nil {
+		return fmt.Errorf("rsync dry run for %s: %w: %s", hostDir, err, planned)
+	}
+	logf("CA store write-back for %s:\n%s", hostDir, planned)
+
+	if out, err := runRsync(append(append([]string{}, args...), "--", src, dst)); err != nil {
+		return fmt.Errorf("rsync write-back to %s: %w: %s", hostDir, err, out)
+	}
+	return nil
+}
+
+type fileEntry struct {
+	path      string
+	mode      fs.FileMode
+	uid, gid  uint32
+	mtime     time.Time
+	symlinkTo string
+	sha256    [32]byte
+}
+
+func captureManifest(root string) ([]fileEntry, error) {
+	var entries []fileEntry
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || path == root {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		fe := fileEntry{path: rel, mode: info.Mode(), mtime: info.ModTime()}
+		if st, ok := info.Sys().(*syscall.Stat_t); ok {
+			fe.uid, fe.gid = st.Uid, st.Gid
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			fe.symlinkTo = target
+		case info.Mode().IsRegular():
+			sum, err := hashFile(path)
+			if err != nil {
+				return err
+			}
+			fe.sha256 = sum
+		}
+		entries = append(entries, fe)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].path < entries[j].path })
+	return entries, nil
+}
+
+func hashFile(path string) ([32]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return [32]byte{}, err
+	}
+	var sum [32]byte
+	copy(sum[:], h.Sum(nil))
+	return sum, nil
+}
+
+// manifestsEqual ignores mtime: the marker append/strip round trip can leave
+// a file's mtime different even when every byte is back where it started.
+func manifestsEqual(a, b []fileEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		x, y := a[i], b[i]
+		if x.path != y.path || x.mode != y.mode || x.uid != y.uid || x.gid != y.gid ||
+			x.symlinkTo != y.symlinkTo || x.sha256 != y.sha256 {
+			return false
+		}
+	}
+	return true
+}
+
+func sizeAndCount(root string) (bytes int64, files int, err error) {
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		files++
+		bytes += info.Size()
+		return nil
+	})
+	return bytes, files, err
+}
+
+// restoreUnchangedMtimes resets an untouched entry's mtime to what it was
+// before mirroring. Without this, rsync's own mtime-preserving write-back
+// would see a real difference (same content, different mtime) and copy the
+// file up even though the step never touched it.
+func restoreUnchangedMtimes(original, current []fileEntry, scratchDir string) error {
+	byPath := make(map[string]fileEntry, len(original))
+	for _, e := range original {
+		byPath[e.path] = e
+	}
+	for _, c := range current {
+		if c.mode&os.ModeSymlink != 0 {
+			continue // no portable Lutimes in the standard library; harmless to skip
+		}
+		o, ok := byPath[c.path]
+		if !ok || o.mode != c.mode || o.uid != c.uid || o.gid != c.gid || o.sha256 != c.sha256 {
+			continue
+		}
+		if err := os.Chtimes(filepath.Join(scratchDir, c.path), o.mtime, o.mtime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *dirBind) prepare(ca []byte) error {
+	if b.custom {
+		size, count, err := sizeAndCount(b.hostDir)
+		if err != nil {
+			return err
+		}
+		if size > maxCustomDirBytes || count > maxCustomDirFiles {
+			return fmt.Errorf("%s is too large to mirror (%d bytes, %d files)", b.hostDir, size, count)
+		}
+	}
+
+	if err := mirrorDir(b.hostDir, b.scratchDir); err != nil {
+		return fmt.Errorf("mirroring %s: %w", b.hostDir, err)
+	}
+
+	original, err := captureManifest(b.scratchDir)
+	if err != nil {
+		return err
+	}
+	b.original = original
+
+	for _, name := range b.bundleFiles {
+		if err := appendCA(filepath.Join(b.scratchDir, name), ca); err != nil {
+			return err
+		}
+	}
+
+	baseline, err := captureManifest(b.scratchDir)
+	if err != nil {
+		return err
+	}
+	b.baseline = baseline
+	return nil
+}
+
+// finish diffs the scratch mirror against its post-injection baseline and
+// only touches the real rootfs directory when the step actually changed it.
+func (b *dirBind) finish() error {
+	current, err := captureManifest(b.scratchDir)
+	if err != nil {
+		return err
+	}
+	if manifestsEqual(current, b.baseline) {
+		return nil
+	}
+
+	for _, name := range b.bundleFiles {
+		if err := removeCA(filepath.Join(b.scratchDir, name)); err != nil {
+			return err
+		}
+	}
+
+	stripped, err := captureManifest(b.scratchDir)
+	if err != nil {
+		return err
+	}
+	if err := restoreUnchangedMtimes(b.original, stripped, b.scratchDir); err != nil {
+		return err
+	}
+
+	return writeBack(b.scratchDir, b.hostDir)
+}
+
+func (b *dirBind) cleanup() {
+	if err := os.RemoveAll(b.scratchDir); err != nil {
+		logf("cannot remove %s: %v", b.scratchDir, err)
+	}
+}

--- a/docker/inspect/buildcage-runc/mount_rsync_smoke_test.go
+++ b/docker/inspect/buildcage-runc/mount_rsync_smoke_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This is the only test in the package that runs the real rsync binary.
+// Everything else replaces runRsync with a fake so `go test` never depends
+// on rsync being installed; this test instead skips when it isn't, or when
+// it's a variant that doesn't support -aHAX (macOS ships openrsync, which
+// doesn't; the production image installs GNU rsync via apk).
+func TestRealRsyncMirrorsAndWritesBack(t *testing.T) {
+	if out, err := exec.Command("rsync", "--version").CombinedOutput(); err != nil || strings.Contains(string(out), "openrsync") {
+		t.Skip("no GNU-compatible rsync available")
+	}
+
+	hostDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(hostDir, "bundle.pem"), []byte("ORIGINAL\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("bundle.pem", filepath.Join(hostDir, "alias.pem")); err != nil {
+		t.Fatal(err)
+	}
+
+	scratchDir := t.TempDir()
+	if err := mirrorDir(hostDir, scratchDir); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(scratchDir, "bundle.pem")); err != nil || string(got) != "ORIGINAL\n" {
+		t.Fatalf("mirror did not copy the bundle: %q, %v", got, err)
+	}
+	if target, err := os.Readlink(filepath.Join(scratchDir, "alias.pem")); err != nil || target != "bundle.pem" {
+		t.Fatalf("mirror did not preserve the symlink: %q, %v", target, err)
+	}
+
+	if err := os.WriteFile(filepath.Join(scratchDir, "bundle.pem"), []byte("CHANGED\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(scratchDir, "alias.pem")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeBack(scratchDir, hostDir); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(hostDir, "bundle.pem")); err != nil || string(got) != "CHANGED\n" {
+		t.Fatalf("write-back did not apply the change: %q, %v", got, err)
+	}
+	if _, err := os.Lstat(filepath.Join(hostDir, "alias.pem")); !os.IsNotExist(err) {
+		t.Fatalf("write-back did not delete alias.pem: %v", err)
+	}
+}

--- a/docker/inspect/buildcage-runc/mount_test.go
+++ b/docker/inspect/buildcage-runc/mount_test.go
@@ -1,0 +1,298 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// useFakeRsync makes dirBind's filesystem operations hermetic: a fake copy
+// instead of a real rsync process, and a scratch root under the test's own
+// temp directory instead of the real host path (which a test process
+// usually can't create or write to). The one test that needs the real
+// rsync binary and the real scratch root lives in mount_rsync_smoke_test.go.
+func useFakeRsync(t *testing.T) {
+	t.Helper()
+	oldRsync, oldScratchRoot := runRsync, scratchRoot
+	runRsync = fakeRsyncCopy
+	scratchRoot = t.TempDir()
+	t.Cleanup(func() {
+		runRsync = oldRsync
+		scratchRoot = oldScratchRoot
+	})
+}
+
+// fakeRsyncCopy stands in for `rsync -a[HAX] [--checksum] [--delete] ... src/ dst/`:
+// it only looks at the last two arguments and replaces dst wholesale with
+// src's tree, which is close enough to mirror/writeBack's actual usage for
+// unit tests to observe the resulting on-disk state.
+func fakeRsyncCopy(args []string) ([]byte, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("not enough args: %v", args)
+	}
+	src := strings.TrimSuffix(args[len(args)-2], "/")
+	dst := strings.TrimSuffix(args[len(args)-1], "/")
+	if err := os.RemoveAll(dst); err != nil {
+		return nil, err
+	}
+	return nil, copyTree(src, dst)
+}
+
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case d.IsDir():
+			return os.MkdirAll(target, 0o755)
+		case info.Mode()&os.ModeSymlink != 0:
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		default:
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			return os.WriteFile(target, data, info.Mode())
+		}
+	})
+}
+
+func TestGroupTargetsByDir(t *testing.T) {
+	targets := map[string]bool{
+		"/rootfs/etc/ssl/certs/ca-certificates.crt": true,
+		"/rootfs/etc/ssl/certs/extra.pem":           true,
+		"/rootfs/custom/roots.pem":                  true,
+	}
+	groups := groupTargetsByDir(targets)
+	if len(groups["/rootfs/etc/ssl/certs"]) != 2 {
+		t.Errorf("expected 2 files grouped under /rootfs/etc/ssl/certs, got %v", groups["/rootfs/etc/ssl/certs"])
+	}
+	if len(groups["/rootfs/custom"]) != 1 {
+		t.Errorf("expected 1 file grouped under /rootfs/custom, got %v", groups["/rootfs/custom"])
+	}
+}
+
+func TestMountConflicts(t *testing.T) {
+	cases := []struct {
+		name      string
+		mounts    []any
+		dest      string
+		conflicts bool
+	}{
+		{"no mounts", nil, "/etc/ssl/certs", false},
+		{"exact match", []any{map[string]any{"destination": "/etc/ssl/certs"}}, "/etc/ssl/certs", true},
+		{"existing is an ancestor", []any{map[string]any{"destination": "/etc"}}, "/etc/ssl/certs", true},
+		{"existing is a descendant", []any{map[string]any{"destination": "/etc/ssl/certs/sub"}}, "/etc/ssl/certs", true},
+		{"unrelated sibling", []any{map[string]any{"destination": "/etc/ssl/other"}}, "/etc/ssl/certs", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw := map[string]any{"mounts": c.mounts}
+			if got := mountConflicts(raw, c.dest); got != c.conflicts {
+				t.Errorf("mountConflicts(%v, %q) = %v, want %v", c.mounts, c.dest, got, c.conflicts)
+			}
+		})
+	}
+}
+
+func TestAddBindMount(t *testing.T) {
+	raw := map[string]any{}
+	addBindMount(raw, "/etc/ssl/certs", "/run/buildcage/ca/x")
+	mounts, _ := raw["mounts"].([]any)
+	if len(mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1", len(mounts))
+	}
+	entry := mounts[0].(map[string]any)
+	if entry["destination"] != "/etc/ssl/certs" || entry["source"] != "/run/buildcage/ca/x" || entry["type"] != "bind" {
+		t.Errorf("unexpected mount entry: %v", entry)
+	}
+
+	// Appending to an existing mounts array must not drop what was there.
+	raw = map[string]any{"mounts": []any{map[string]any{"destination": "/proc"}}}
+	addBindMount(raw, "/etc/ssl/certs", "/run/buildcage/ca/x")
+	mounts, _ = raw["mounts"].([]any)
+	if len(mounts) != 2 {
+		t.Fatalf("got %d mounts, want 2", len(mounts))
+	}
+}
+
+func TestContainerPathOfResolvesThroughSymlinks(t *testing.T) {
+	// RHEL: the candidate file is a symlink into extracted/pem, sitting in a
+	// different directory than the real store.
+	t.Run("RHEL", func(t *testing.T) {
+		root := t.TempDir()
+		mustMkdirAll(t, filepath.Join(root, "etc/pki/ca-trust/extracted/pem"))
+		mustMkdirAll(t, filepath.Join(root, "etc/pki/tls/certs"))
+		mustWriteFile(t, filepath.Join(root, "etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"), "ROOTS")
+		mustSymlink(t, "../../ca-trust/extracted/pem/tls-ca-bundle.pem", filepath.Join(root, "etc/pki/tls/certs/ca-bundle.crt"))
+
+		resolved, _, err := findSystemStore(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := containerPathOf(root, filepath.Dir(resolved))
+		if want := "/etc/pki/ca-trust/extracted/pem"; got != want {
+			t.Errorf("containerPathOf = %q, want %q", got, want)
+		}
+	})
+
+	// openSUSE: the candidate is a symlink to a different top-level tree
+	// entirely (/var/lib/ca-certificates), not a sibling directory.
+	t.Run("openSUSE", func(t *testing.T) {
+		root := t.TempDir()
+		mustMkdirAll(t, filepath.Join(root, "var/lib/ca-certificates"))
+		mustMkdirAll(t, filepath.Join(root, "etc/ssl"))
+		mustWriteFile(t, filepath.Join(root, "var/lib/ca-certificates/ca-bundle.pem"), "ROOTS")
+		mustSymlink(t, "../../var/lib/ca-certificates/ca-bundle.pem", filepath.Join(root, "etc/ssl/ca-bundle.pem"))
+
+		resolved, _, err := findSystemStore(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := containerPathOf(root, filepath.Dir(resolved))
+		if want := "/var/lib/ca-certificates"; got != want {
+			t.Errorf("containerPathOf = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestContainerPathOfRefusesTheRoot(t *testing.T) {
+	if got := containerPathOf("/rootfs", "/rootfs"); got != "/" {
+		t.Errorf("containerPathOf at the rootfs itself = %q, want %q", got, "/")
+	}
+	if got := containerPathOf("/rootfs", "/somewhere/else"); got != "/" {
+		t.Errorf("containerPathOf outside the rootfs = %q, want %q", got, "/")
+	}
+}
+
+func TestManifestsEqualIgnoresMtimeButNotContent(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a"), "same")
+	a, err := captureManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A later write with identical content still bumps mtime; that alone
+	// must not register as a change.
+	mustWriteFile(t, filepath.Join(dir, "a"), "same")
+	b, err := captureManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifestsEqual(a, b) {
+		t.Error("identical content with a different mtime should compare equal")
+	}
+
+	mustWriteFile(t, filepath.Join(dir, "a"), "different")
+	c, err := captureManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifestsEqual(a, c) {
+		t.Error("different content should not compare equal")
+	}
+}
+
+func TestSizeAndCount(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdirAll(t, filepath.Join(dir, "sub"))
+	mustWriteFile(t, filepath.Join(dir, "a"), "1234567890")
+	mustWriteFile(t, filepath.Join(dir, "sub", "b"), "12345")
+
+	bytes, files, err := sizeAndCount(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes != 15 || files != 2 {
+		t.Errorf("got bytes=%d files=%d, want bytes=15 files=2", bytes, files)
+	}
+}
+
+func TestRestoreUnchangedMtimesLeavesChangedFilesAlone(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "untouched"), "same")
+	mustWriteFile(t, filepath.Join(dir, "changed"), "before")
+
+	// Chtimes to a fixed past time instead of relying on real write timing,
+	// since two writes in quick succession can land in the same mtime tick.
+	past := time.Now().Add(-time.Hour).Truncate(time.Second)
+	for _, name := range []string{"untouched", "changed"} {
+		if err := os.Chtimes(filepath.Join(dir, name), past, past); err != nil {
+			t.Fatal(err)
+		}
+	}
+	original, err := captureManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh mirror gives every file a new mtime regardless of whether the
+	// step actually changed its content.
+	mustWriteFile(t, filepath.Join(dir, "untouched"), "same")
+	mustWriteFile(t, filepath.Join(dir, "changed"), "after")
+	current, err := captureManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restoreUnchangedMtimes(original, current, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := mustStatMtime(t, filepath.Join(dir, "untouched")); !got.Equal(past) {
+		t.Errorf("untouched file's mtime = %v, want restored to %v", got, past)
+	}
+	if got := mustStatMtime(t, filepath.Join(dir, "changed")); got.Equal(past) {
+		t.Error("changed file's mtime should not have been reset")
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	_ = os.Remove(link)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustStatMtime(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.ModTime()
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -302,11 +302,16 @@ behavior, see [Inspect Proxy Engine](./security.md#inspect-proxy-engine) in Secu
 
 - **`buildcage-runc`** (`docker/inspect/buildcage-runc/`) wraps BuildKit's own `buildkit-runc`,
   selected via `[worker.oci] binary` in `buildkitd.toml`. For the subcommands that carry an OCI
-  bundle, it writes the proxy's CA and the CA-trust environment variables (see
-  [CA trust and compatibility](../README.md#ca-trust-and-compatibility)) into the bundle's rootfs,
-  runs the real `runc`, then removes them before BuildKit commits the resulting layer as a
-  snapshot. This happens at exec time, entirely outside LLB, so it cannot affect a cache key: two
-  builds that differ only in `proxy_engine` still share cache.
+  bundle, it sets the CA-trust environment variables (see
+  [CA trust and compatibility](../README.md#ca-trust-and-compatibility)) directly, and for the CA
+  itself, mirrors the step's CA store directory into a scratch copy, appends the CA there, and
+  bind-mounts the copy over the step's view of the real directory for the step's duration. Once the
+  real `runc` exits, that mirror is compared against its state right after the CA was added: if
+  nothing else changed, the real directory was never opened for writing, so BuildKit's layer diff for
+  that step is unaffected; only a step that actually changed the store gets that change synced back.
+  This is what keeps a step that never touches its CA store from producing a different layer than an
+  unmodified build would. Either way this happens at exec time, entirely outside LLB, so it cannot
+  affect a cache key: two builds that differ only in `proxy_engine` still share cache.
 - The `allowed_url_rules` compiler enumerates hosts rather than generalizing them
   (`a.example.com`/`b.example.com` never becomes `*.example.com`), because CoreDNS's own allow/deny
   view is generated from the same host patterns. Widening a host widens what's logged as allowed

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,9 +43,10 @@ Two components, plus a wrapper around runc:
   `abc*.amazonaws.com` be logged accurately instead of collapsing to everything under
   `amazonaws.com`.
 - **`buildcage-runc`** wraps BuildKit's own `buildkit-runc`. For the subcommands that carry a
-  bundle it makes the step trust the proxy's CA, runs the real runc, then undoes that before
-  BuildKit commits the snapshot. Injection happens at exec time, never touches LLB, and so cannot
-  affect a cache key.
+  bundle it makes the step trust the proxy's CA by bind-mounting a scratch copy of the CA store over
+  the step's own view of it, writing back to the real one only if the step actually changed it, so a
+  step that never touches its CA store leaves no trace of the injection in the image layers.
+  Injection happens at exec time, never touches LLB, and so cannot affect a cache key.
 
 Like `universal`, this engine governs `RUN` step traffic only: its iptables rule redirects what
 arrives on the CNI bridge. `FROM` (`docker-image://`) is unaffected, buildkitd's own egress being

--- a/test/Dockerfile.inspect-byte-exact
+++ b/test/Dockerfile.inspect-byte-exact
@@ -1,0 +1,10 @@
+# Fixture for assert-inspect-byte-exact.sh. Neither RUN step needs CA trust
+# (the apt bootstrap here is plain HTTP), so the same Dockerfile should
+# produce byte-identical layers under any engine.
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+
+SHELL ["/bin/sh", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
+RUN echo "no CA use here"

--- a/test/assert-inspect-byte-exact.sh
+++ b/test/assert-inspect-byte-exact.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -euo pipefail
+
+# Builds the same Dockerfile under universal and inspect with a shared
+# SOURCE_DATE_EPOCH, and checks the resulting layers are byte-identical:
+# path, type, mode, owner, size, symlink targets, content, and mtime.
+
+IMAGE_A="${1:?usage: $0 IMAGE_A IMAGE_B}"
+IMAGE_B="${2:?usage: $0 IMAGE_A IMAGE_B}"
+FAILURES=0
+
+pass() { echo "  PASS  $1"; }
+fail() {
+  echo "  FAIL  $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+echo ""
+echo "=== Byte-Exact Layer Comparison ($IMAGE_A vs $IMAGE_B) ==="
+echo ""
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Ordered blob list from a `docker save` tarball, without depending on jq.
+layers_of() {
+  local image="$1" outdir="$2"
+  mkdir -p "$outdir"
+  docker save "$image" -o "$outdir/image.tar"
+  tar -xf "$outdir/image.tar" -C "$outdir"
+  grep -o '"Layers":\[[^]]*\]' "$outdir/manifest.json" \
+    | grep -o '"blobs/sha256/[a-f0-9]*"' | tr -d '"'
+}
+
+# path/type/mode/owner/size/symlink-target/mtime in one line each, from the
+# same tar binary for both images in this run, so the two sides are always
+# comparable even though bsdtar and GNU tar format columns differently.
+listing_of() {
+  tar -tvf "$1" 2>/dev/null | sort
+}
+
+# apt/dpkg/ldconfig write real wall-clock content into these regardless of
+# SOURCE_DATE_EPOCH, which only pins layer timestamps, not file content.
+NONDETERMINISTIC_PATHS='^(var/log/apt/[^ ]*|var/log/dpkg\.log|var/cache/ldconfig/aux-cache) '
+
+# tar -tv has no content hash, only size, so regular files are separately
+# extracted and hashed.
+content_hashes_of() {
+  local layer="$1" dir="$2"
+  mkdir -p "$dir"
+  tar -xf "$layer" -C "$dir" 2>/dev/null || true
+  find "$dir" -type f 2>/dev/null | while IFS= read -r f; do
+    printf '%s %s\n' "${f#"$dir"/}" "$(sha256_of "$f")"
+  done | grep -vE "$NONDETERMINISTIC_PATHS" | sort
+}
+
+DIR_A="$WORKDIR/a"
+DIR_B="$WORKDIR/b"
+
+LAYERS_A=()
+while IFS= read -r layer; do LAYERS_A+=("$layer"); done < <(layers_of "$IMAGE_A" "$DIR_A")
+LAYERS_B=()
+while IFS= read -r layer; do LAYERS_B+=("$layer"); done < <(layers_of "$IMAGE_B" "$DIR_B")
+
+if [ "${#LAYERS_A[@]}" -ne "${#LAYERS_B[@]}" ]; then
+  fail "layer count differs: $IMAGE_A has ${#LAYERS_A[@]}, $IMAGE_B has ${#LAYERS_B[@]}"
+else
+  pass "both images have ${#LAYERS_A[@]} layers"
+fi
+
+count=${#LAYERS_A[@]}
+if [ "${#LAYERS_B[@]}" -lt "$count" ]; then
+  count=${#LAYERS_B[@]}
+fi
+
+i=0
+while [ "$i" -lt "$count" ]; do
+  layer_a="$DIR_A/${LAYERS_A[$i]}"
+  layer_b="$DIR_B/${LAYERS_B[$i]}"
+
+  if diff -q <(listing_of "$layer_a") <(listing_of "$layer_b") >/dev/null; then
+    pass "layer $i: identical path/type/mode/owner/size/mtime listing"
+  else
+    fail "layer $i: listing differs"
+    diff <(listing_of "$layer_a") <(listing_of "$layer_b") || true
+  fi
+
+  extract_a="$WORKDIR/extract-a-$i"
+  extract_b="$WORKDIR/extract-b-$i"
+  if diff -q <(content_hashes_of "$layer_a" "$extract_a") <(content_hashes_of "$layer_b" "$extract_b") >/dev/null; then
+    pass "layer $i: identical file content"
+  else
+    fail "layer $i: file content differs"
+    diff <(content_hashes_of "$layer_a" "$extract_a") <(content_hashes_of "$layer_b" "$extract_b") || true
+  fi
+
+  i=$((i + 1))
+done
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "❌ FAILED: $FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "✅ All assertions passed."
+echo ""

--- a/test/assert-inspect-no-layer-bloat.sh
+++ b/test/assert-inspect-no-layer-bloat.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+# Checks that each CA bundle candidate appears in at most one image layer:
+# it should only ever be introduced once, by whichever RUN step installs it.
+# Appearing in more than one layer means an unrelated step is still
+# rewriting the file, bloating the image without changing its content.
+#
+# CANDIDATES mirrors the system CA store paths inspect looks for.
+
+IMAGE="${1:-buildcage-test}"
+FAILURES=0
+
+CANDIDATES=(
+  "etc/ssl/certs/ca-certificates.crt"
+  "etc/pki/tls/certs/ca-bundle.crt"
+  "etc/ssl/ca-bundle.pem"
+  "etc/pki/tls/cacert.pem"
+  "etc/ssl/cert.pem"
+)
+
+pass() { echo "  PASS  $1"; }
+fail() {
+  echo "  FAIL  $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+echo ""
+echo "=== No Per-Layer CA Bundle Duplication ($IMAGE) ==="
+echo ""
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+docker save "$IMAGE" -o "$WORKDIR/image.tar"
+tar -xf "$WORKDIR/image.tar" -C "$WORKDIR"
+
+# Pull the ordered blob list out of manifest.json without jq or mapfile,
+# since neither is guaranteed to be available (macOS ships bash 3.2).
+LAYERS=()
+while IFS= read -r layer; do
+  LAYERS+=("$layer")
+done < <(grep -o '"Layers":\[[^]]*\]' "$WORKDIR/manifest.json" \
+  | grep -o '"blobs/sha256/[a-f0-9]*"' | tr -d '"')
+
+if [ "${#LAYERS[@]}" -eq 0 ]; then
+  fail "could not read the layer list from manifest.json"
+fi
+
+for candidate in "${CANDIDATES[@]}"; do
+  count=0
+  for layer in "${LAYERS[@]}"; do
+    # grep -c, not -q: -q can exit before tar/sed finish writing, which
+    # under pipefail can drop the match via their resulting SIGPIPE.
+    entries=$(tar -tf "$WORKDIR/$layer" 2>/dev/null | sed 's#^\./##' | grep -cx "$candidate" || true)
+    if [ "${entries:-0}" -gt 0 ]; then
+      count=$((count + 1))
+    fi
+  done
+  if [ "$count" -gt 1 ]; then
+    fail "$candidate appears in $count layers (expected at most 1)"
+  elif [ "$count" -eq 1 ]; then
+    pass "$candidate appears in exactly 1 layer"
+  fi
+done
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "❌ FAILED: $FAILURES assertion(s) failed"
+  exit 1
+fi
+echo "✅ All assertions passed."
+echo ""


### PR DESCRIPTION
## Summary
- Switches the inspect engine's CA-trust injection to a bind-mounted scratch mirror of the CA store's directory, instead of appending to the store file directly: the real directory is only written back to when a step actually changes it, leaving no trace of unrelated steps ever having touched it.
- Because the real directory is left alone unless a step actually changes it, an unrelated step can no longer end up duplicating the store's contents into its own layer under BuildKit's own layer-diff mechanics.
- Adds two regression tests: a per-layer duplication check, and a byte-exact layer comparison against the `universal` engine (using `SOURCE_DATE_EPOCH`). Also wires `buildcage-runc`'s own Go unit tests into CI, which weren't running there at all before this PR.

## Test plan
- [x] `test-integration: test (inspect byte-exact)` passes (new job, compares `inspect` vs `universal` layer-for-layer)
- [x] `test-integration: test (inspect-audit)` / `(inspect-restrict)` / `(inspect-debian-audit)` / `(inspect-debian-restrict)` pass, including the new "Verify no per-layer CA bundle duplication" step
- [x] `unit: test` passes, including the new `buildcage-runc` Go test step