### PR TITLE
fix: refuse non-regular files when injecting or restoring the CA store

### DIFF
--- a/docker/inspect/buildcage-runc/castore.go
+++ b/docker/inspect/buildcage-runc/castore.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 // Markers delimit what this wrapper appended, so the removal is exact. A step
@@ -28,6 +30,12 @@ var systemCertFiles = []string{
 }
 
 var errEscapesRoot = errors.New("path escapes the rootfs")
+
+// errNotRegular means appendCA/removeCA found something other than a plain
+// file at the target. The wrapper runs unsandboxed on the host, so opening
+// whatever a step swapped the path for — a symlink, a FIFO — would follow
+// attacker-controlled input outside the directory it's meant to stay in.
+var errNotRegular = errors.New("not a regular file")
 
 // resolveInRoot resolves path as the container would see it, so a symlink
 // cannot be used to reach outside.
@@ -94,16 +102,36 @@ func withinRoot(rootfs, path string) bool {
 	return path == rootfs || strings.HasPrefix(path, rootfs+string(os.PathSeparator))
 }
 
+// asNotRegular folds the open() failures O_NOFOLLOW/O_NONBLOCK produce for a
+// symlink or an unread FIFO into errNotRegular, so callers don't need to
+// distinguish rejection at open() from rejection after Stat.
+func asNotRegular(path string, err error) error {
+	if errors.Is(err, syscall.ELOOP) || errors.Is(err, syscall.ENXIO) {
+		return fmt.Errorf("%s: %w", path, errNotRegular)
+	}
+	return err
+}
+
 // appendCA adds the marked block to path, creating it when missing.
+//
+// O_NOFOLLOW/O_NONBLOCK keep the open from following a symlink or blocking on
+// a FIFO the step may have left at path since injection.
 func appendCA(path string, ca []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0o644)
+	if err != nil {
+		return asNotRegular(path, err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s: %w", path, errNotRegular)
+	}
 	block := fmt.Sprintf("\n%s\n%s\n%s\n", beginMarker, strings.TrimRight(string(ca), "\n"), endMarker)
 	_, err = f.WriteString(block)
 	return err
@@ -112,15 +140,31 @@ func appendCA(path string, ca []byte) error {
 // removeCA deletes the marked block, leaving anything else in place.
 //
 // Returns without error when the block is absent, since the step may have
-// rewritten the file itself.
+// rewritten the file itself. The find and the strip share one handle, opened
+// the same guarded way as appendCA, so they can't land on different files.
 func removeCA(path string) error {
-	content, err := os.ReadFile(path)
+	f, err := os.OpenFile(path, os.O_RDWR|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
+		return asNotRegular(path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
 		return err
 	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s: %w", path, errNotRegular)
+	}
+
+	content := make([]byte, info.Size())
+	if _, err := io.ReadFull(f, content); err != nil {
+		return err
+	}
+
 	start := bytes.Index(content, []byte(beginMarker))
 	if start == -1 {
 		return nil
@@ -137,7 +181,13 @@ func removeCA(path string) error {
 	if end < len(content) && content[end] == '\n' {
 		end++
 	}
-	return os.WriteFile(path, append(content[:start:start], content[end:]...), 0o644)
+	stripped := append(content[:start:start], content[end:]...)
+
+	if err := f.Truncate(int64(len(stripped))); err != nil {
+		return err
+	}
+	_, err = f.WriteAt(stripped, 0)
+	return err
 }
 
 // containerPathOf converts a path already resolved inside rootfs back to how

--- a/docker/inspect/buildcage-runc/castore_test.go
+++ b/docker/inspect/buildcage-runc/castore_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // The rootfs comes from an image the build chose, so a symlink placed at one of
@@ -150,6 +153,103 @@ func TestRemoveCAIsANoOpWhenTheBlockIsGone(t *testing.T) {
 	got, _ := os.ReadFile(path)
 	if string(got) != "REWRITTEN\n" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRemoveCARefusesASymlink(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "host-secret")
+	if err := os.WriteFile(outside, []byte("SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "bundle.pem")
+	if err := os.Symlink(outside, path); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeCA(path); !errors.Is(err, errNotRegular) {
+		t.Fatalf("got %v, want errNotRegular", err)
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "SECRET" {
+		t.Fatalf("the symlink target was modified: %q", got)
+	}
+}
+
+func TestAppendCARefusesASymlink(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "host-secret")
+	if err := os.WriteFile(outside, []byte("SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "bundle.pem")
+	if err := os.Symlink(outside, path); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendCA(path, []byte("CA")); !errors.Is(err, errNotRegular) {
+		t.Fatalf("got %v, want errNotRegular", err)
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "SECRET" {
+		t.Fatalf("the symlink target was modified: %q", got)
+	}
+}
+
+func TestRemoveCARefusesAFIFOWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.pem")
+	if err := syscall.Mkfifo(path, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- removeCA(path) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errNotRegular) {
+			t.Fatalf("got %v, want errNotRegular", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("removeCA blocked opening a FIFO")
+	}
+}
+
+func TestAppendCARefusesAFIFOWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.pem")
+	if err := syscall.Mkfifo(path, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- appendCA(path, []byte("CA")) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errNotRegular) {
+			t.Fatalf("got %v, want errNotRegular", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("appendCA blocked opening a FIFO")
+	}
+}
+
+func TestRemoveCARefusesADirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bundle.pem")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeCA(path); err == nil {
+		t.Fatal("removeCA succeeded on a directory")
 	}
 }
 

--- a/docker/inspect/buildcage-runc/inject_test.go
+++ b/docker/inspect/buildcage-runc/inject_test.go
@@ -312,6 +312,51 @@ func TestInjectWriteBackFailurePropagates(t *testing.T) {
 	}
 }
 
+func TestInjectSkipsRestoreWhenStepSwapsBundleForASymlink(t *testing.T) {
+	useFakeRsync(t)
+	bundle, rootfs := newBundle(t, []string{"PATH=/usr/bin"})
+	outside := filepath.Join(t.TempDir(), "host-secret")
+	if err := os.WriteFile(outside, []byte("SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restore, err := inject(bundle, []byte("BUILDCAGE-CA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mount := findMount(t, loadMounts(t, bundle), "/etc/ssl/certs")
+	scratchDir, _ := mount["source"].(string)
+	target := filepath.Join(scratchDir, "ca-certificates.crt")
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, target); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := restore(); err != nil {
+		t.Fatalf("restore should skip the unrestorable file, not fail the build: %v", err)
+	}
+
+	secret, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(secret) != "SECRET" {
+		t.Fatalf("the symlink target was modified: %q", secret)
+	}
+
+	got := filepath.Join(rootfs, "etc", "ssl", "certs", "ca-certificates.crt")
+	link, err := os.Readlink(got)
+	if err != nil {
+		t.Fatalf("write-back did not mirror the step's own symlink: %v", err)
+	}
+	if link != outside {
+		t.Fatalf("got link %q, want %q", link, outside)
+	}
+}
+
 // A base image with no CA store of its own (node:*-slim before
 // ca-certificates is installed, or a scratch/distroless image) must not lose
 // every variable just because the system store is missing: all six fall back

--- a/docker/inspect/buildcage-runc/mount.go
+++ b/docker/inspect/buildcage-runc/mount.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -271,6 +272,10 @@ func (b *dirBind) prepare(ca []byte) error {
 
 	for _, name := range b.bundleFiles {
 		if err := appendCA(filepath.Join(b.scratchDir, name), ca); err != nil {
+			if errors.Is(err, errNotRegular) {
+				logf("cannot inject the CA into %s: %v; leaving it untouched", name, err)
+				continue
+			}
 			return err
 		}
 	}
@@ -296,6 +301,11 @@ func (b *dirBind) finish() error {
 
 	for _, name := range b.bundleFiles {
 		if err := removeCA(filepath.Join(b.scratchDir, name)); err != nil {
+			if errors.Is(err, errNotRegular) {
+				// Not the wrapper's to open; write-back below mirrors it as-is.
+				logf("cannot restore %s: %v; leaving it as the step left it", name, err)
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- A RUN step's own writable mirror of its CA store lets it swap the bundle file for a symlink or a FIFO between injection and restore; `appendCA`/`removeCA` now open with `O_NOFOLLOW`/`O_NONBLOCK` and check the file is regular before touching it, instead of following the swap from the wrapper's unsandboxed, host-side view.
- `removeCA` now reads and strips through a single file handle instead of `os.ReadFile` + `os.WriteFile`.
- When a target isn't a regular file, `dirBind.prepare`/`finish` log and skip just that target rather than failing the whole build.

## Test plan
- Added unit tests covering a symlinked/FIFO/directory bundle file at both the `castore.go` level and end-to-end through `inject`/`restore`.