### PR TITLE
fix: restrict universal proxy's :10024 to the buildkit0 interface

### DIFF
--- a/docker/universal/files/s6-scripts/init-iptables
+++ b/docker/universal/files/s6-scripts/init-iptables
@@ -6,11 +6,18 @@ echo "init-iptables: configuring isolation..."
 iptables -t nat -A PREROUTING -i buildkit0 -p tcp \
   -j REDIRECT --to-ports 10024
 
+# Can't bind :10024 to 172.20.0.1 directly -- it doesn't exist until CNI
+# creates buildkit0, after this service starts. Restrict via INPUT instead.
+iptables -A INPUT -p tcp --dport 10024 -i buildkit0 -j ACCEPT
+iptables -A INPUT -p tcp --dport 10024 -j DROP
+
 iptables -A FORWARD -i buildkit0 -j DROP
 
 if [ -e /proc/net/if_inet6 ]; then
+  ip6tables -A INPUT -p tcp --dport 10024 -i buildkit0 -j ACCEPT
+  ip6tables -A INPUT -p tcp --dport 10024 -j DROP
   ip6tables -A FORWARD -i buildkit0 -j DROP
-  echo "init-iptables: REDIRECT configured, FORWARD from buildkit0 blocked (IPv4/IPv6)"
+  echo "init-iptables: REDIRECT configured, :10024 restricted to buildkit0, FORWARD from buildkit0 blocked (IPv4/IPv6)"
 else
-  echo "init-iptables: REDIRECT configured, FORWARD from buildkit0 blocked (IPv4); kernel has no IPv6 support, skipping ip6tables"
+  echo "init-iptables: REDIRECT configured, :10024 restricted to buildkit0, FORWARD from buildkit0 blocked (IPv4); kernel has no IPv6 support, skipping ip6tables"
 fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -243,9 +243,7 @@ CA store), `inspect_roundtrip` (learn rules from an audit run, then enforce them
 │   ├── lib/                  # write-step-summary.ts, shared by both engines' report-action.node.ts
 │   ├── universal/            # proxy_engine: universal. Dockerfile + BuildKit/haproxy/dnsmasq/
 │   │                         # s6-overlay config + scripts/report-action.node.ts (runs under Node
-│   │                         # on the runner, `docker cp`'d out by the report action). HAProxy
-│   │                         # binds *:10024, but init-iptables restricts inbound :10024 to the
-│   │                         # buildkit0 interface
+│   │                         # on the runner, `docker cp`'d out by the report action)
 │   ├── inspect/               # proxy_engine: inspect. Dockerfile + HAProxy/CoreDNS/s6-overlay
 │   │                         # config + buildcage-runc/ (Go module: wraps buildkit-runc to inject
 │   │                         # CA trust at exec time) + scripts/report-action.node.ts

--- a/docs/development.md
+++ b/docs/development.md
@@ -243,7 +243,9 @@ CA store), `inspect_roundtrip` (learn rules from an audit run, then enforce them
 │   ├── lib/                  # write-step-summary.ts, shared by both engines' report-action.node.ts
 │   ├── universal/            # proxy_engine: universal. Dockerfile + BuildKit/haproxy/dnsmasq/
 │   │                         # s6-overlay config + scripts/report-action.node.ts (runs under Node
-│   │                         # on the runner, `docker cp`'d out by the report action)
+│   │                         # on the runner, `docker cp`'d out by the report action). HAProxy
+│   │                         # binds *:10024, but init-iptables restricts inbound :10024 to the
+│   │                         # buildkit0 interface
 │   ├── inspect/               # proxy_engine: inspect. Dockerfile + HAProxy/CoreDNS/s6-overlay
 │   │                         # config + buildcage-runc/ (Go module: wraps buildkit-runc to inject
 │   │                         # CA trust at exec time) + scripts/report-action.node.ts

--- a/docs/security.md
+++ b/docs/security.md
@@ -195,7 +195,8 @@ Every container BuildKit spawns for a `RUN` step is placed on an isolated CNI ne
 `buildkit0` bridge, 172.20.0.0/24). An iptables `PREROUTING REDIRECT` rule sends all TCP from that
 bridge to the proxy whatever its destination, so DNS-resolved and direct-IP connections both arrive
 there, and a `FORWARD` rule drops everything else, so no other protocol has a way out and
-buildkitd's own API is unreachable from a step.
+buildkitd's own API is unreachable from a step. An `INPUT` rule likewise restricts the proxy's own
+listening port to that same bridge, so nothing else on the container's network can reach it.
 
 - **HTTPS**: the SNI from the TLS ClientHello, read without terminating the connection, so the build
   validates the origin's own certificate itself. Checked against `allowed_https_rules`.

--- a/test/assert-universal-audit.sh
+++ b/test/assert-universal-audit.sh
@@ -30,5 +30,9 @@ echo "[ALLOWED] must not exist:"
 assert_log_not_contains ALLOWED
 echo ""
 
+echo "[reachability] :10024 must not be reachable from the compose network:"
+assert_no_tcp_connect test-server builder 10024
+echo ""
+
 assert_results
 echo ""

--- a/test/assert-universal-restrict.sh
+++ b/test/assert-universal-restrict.sh
@@ -47,5 +47,9 @@ echo "[log integrity] no forged/malformed lines from the injection attempt:"
 assert_no_forged_log_lines
 echo ""
 
+echo "[reachability] :10024 must not be reachable from the compose network:"
+assert_no_tcp_connect test-server builder 10024
+echo ""
+
 assert_results
 echo ""

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -56,6 +56,19 @@ assert_log_not_contains() {
   fi
 }
 
+assert_no_tcp_connect() {
+  local from_service="$1"
+  local target="$2"
+  local port="$3"
+  local label="[unreachable] $target:$port from $from_service"
+  if docker compose exec -T "$from_service" nc -w 3 -z "$target" "$port" 2>/dev/null; then
+    echo "  FAIL  $label -- connection succeeded"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  PASS  $label"
+  fi
+}
+
 assert_no_forged_log_lines() {
   local decision_logs
   # Restrict to actual decision lines ("buildcage [...]") -- the plausibility


### PR DESCRIPTION
## Summary
- HAProxy's frontend binds `*:10024`, so the proxy container's port is reachable from any container on the same compose/Docker network, not just build steps on `buildkit0` (L-6, LOW).
- Binding to `172.20.0.1` directly isn't possible: that address belongs to the CNI-created `buildkit0` bridge, which doesn't exist until buildkitd starts, and HAProxy starts before it (`s6-rc.d/buildkitd/dependencies.d/haproxy`).
- Instead, `init-iptables` now restricts inbound `:10024` to traffic arriving on `buildkit0` via an `INPUT` ACCEPT/DROP pair (IPv4 and IPv6), leaving the existing `PREROUTING REDIRECT`/`FORWARD DROP` rules untouched.

## Test plan
- [x] `make test_integration_buildkit_universal_restrict` — new reachability assertion passes, no regressions
- [x] `make test_integration_buildkit_universal_audit` — new reachability assertion passes, no regressions
- [x] `make test_integration_buildkit_universal_restrict_no_traffic` — no regressions