### PR TITLE
fix: inspect engine ignores a trailing dot on the Host header

### DIFF
--- a/src/core/lib/acl/haproxy-config.test.ts
+++ b/src/core/lib/acl/haproxy-config.test.ts
@@ -60,13 +60,17 @@ describe("load-bearing directives", () => {
   it("takes an address in the Host header as it stands, asking no resolver", () => {
     // No resolver can answer an address, so asking would fail and refuse the
     // request, leaving a rule that names an address impossible to satisfy.
-    expect(config.includes("acl host_is_address req.hdr(host),host_only -m reg ^(25[0-5]")).toBe(
-      true,
-    );
     expect(
-      config.includes("http-request set-var(txn.dst) req.hdr(host),host_only if host_is_address"),
+      config.includes("acl host_is_address req.hdr(host),host_only,regsub(\\.$,) -m reg ^(25[0-5]"),
     ).toBe(true);
-    expect(config.includes("req.hdr(host),lower,host_only unless host_is_address")).toBe(true);
+    expect(
+      config.includes(
+        "http-request set-var(txn.dst) req.hdr(host),host_only,regsub(\\.$,) if host_is_address",
+      ),
+    ).toBe(true);
+    expect(
+      config.includes("req.hdr(host),lower,host_only,regsub(\\.$,) unless host_is_address"),
+    ).toBe(true);
   });
 
   it("is strict about the octets, since what matches is never checked again", () => {
@@ -309,12 +313,22 @@ describe("rules", () => {
     expect(gen({ httpsRules: ["a.com:443"] }).includes("-m reg -i ^a\\.com$")).toBe(true);
   });
 
+  it("strips a trailing dot from the Host header before matching, resolving or verifying it", () => {
+    // "a.com." is the same DNS name as "a.com" (RFC 1035), and some tools
+    // write it that way to skip resolv.conf's search-list expansion. Without
+    // this, `Host: a.com.` would refuse an explicit allow rule for a.com.
+    const config = gen({ httpsRules: ["a.com:443"] });
+    expect(config.includes("hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$")).toBe(true);
+  });
+
   it("takes the port from the connection, not from the Host header", () => {
     // A Host header omits the port only for a default one, so a matcher built
     // from it has to accept the port being absent -- which made a rule for
     // :9443 also permit :443 on the same host. Found by the round-trip test.
     const config = gen({ urlRules: buildUrlRules("GET https://a.com:9443/private/x") });
-    expect(config.includes("acl s0_host hdr(host),host_only -m reg -i ^a\\.com$")).toBe(true);
+    expect(
+      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$"),
+    ).toBe(true);
     expect(config.includes("acl s0_port dst_port 9443")).toBe(true);
     expect(config.includes("(:9443)?")).toBe(false);
     expect(config.includes("http-request deny unless s0_host s0_port s0_path s0_method")).toBe(
@@ -324,15 +338,19 @@ describe("rules", () => {
 
   it("gives a host rule the same treatment", () => {
     const config = gen({ httpsRules: ["a.com:8443"] });
-    expect(config.includes("acl s0_host hdr(host),host_only -m reg -i ^a\\.com$")).toBe(true);
+    expect(
+      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$"),
+    ).toBe(true);
     expect(config.includes("acl s0_port dst_port 8443")).toBe(true);
   });
 
   it("matches a ~regex host rule's host and port as one expression", () => {
     const config = gen({ httpsRules: ["~^.*\\.example\\.com:(443|8443)$"] });
-    expect(config.includes("set-var-fmt(txn.host_port) %[hdr(host),host_only]:%[dst_port]")).toBe(
-      true,
-    );
+    expect(
+      config.includes(
+        "set-var-fmt(txn.host_port) %[hdr(host),host_only,regsub(\\.$,)]:%[dst_port]",
+      ),
+    ).toBe(true);
     expect(
       config.includes("acl s0_host var(txn.host_port) -m reg -i ^.*\\.example\\.com:(443|8443)$"),
     ).toBe(true);
@@ -349,7 +367,9 @@ describe("rules", () => {
 
   it("matches the host and the path separately", () => {
     const config = gen({ urlRules: buildUrlRules("GET https://a.com/pub/**") });
-    expect(config.includes("acl s0_host hdr(host),host_only -m reg -i ^a\\.com$")).toBe(true);
+    expect(
+      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$"),
+    ).toBe(true);
     expect(config.includes("acl s0_path path -m reg ^/pub/.*$")).toBe(true);
     expect(config.includes("acl s0_method method GET")).toBe(true);
     expect(config.includes("http-request deny unless s0_host s0_port s0_path s0_method")).toBe(
@@ -359,7 +379,7 @@ describe("rules", () => {
 
   it("accepts a Host header with or without the port, since only the name is compared", () => {
     const config = gen({ httpsRules: ["a.com:443"] });
-    expect(config.includes("hdr(host),host_only -m reg -i ^a\\.com$")).toBe(true);
+    expect(config.includes("hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$")).toBe(true);
     expect(config.includes("acl s0_port dst_port 443")).toBe(true);
   });
 
@@ -536,10 +556,12 @@ describe("regex url rules", () => {
     expect(result.warnings.length).toBe(0);
     const segment = frontendSegment(result.config, "https_in");
     expect(segment.includes("acl is_default_port dst_port 443")).toBe(true);
-    expect(segment.includes("set-var(txn.host_bare) hdr(host),host_only")).toBe(true);
-    expect(segment.includes("set-var-fmt(txn.host_full) %[hdr(host),host_only]:%[dst_port]")).toBe(
-      true,
-    );
+    expect(segment.includes("set-var(txn.host_bare) hdr(host),host_only,regsub(\\.$,)")).toBe(true);
+    expect(
+      segment.includes(
+        "set-var-fmt(txn.host_full) %[hdr(host),host_only,regsub(\\.$,)]:%[dst_port]",
+      ),
+    ).toBe(true);
   });
 
   it("ORs a bare (default-port-only) match with a full (real-port) match per rule", () => {

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -59,6 +59,13 @@ const DEFAULTS = {
 const TLS_STAGE_PORT = 10025;
 const PLAIN_STAGE_PORT = 10026;
 
+/**
+ * `host_only` strips the port a Host header carries; chained onto it here so
+ * every host match, resolution and certificate check also treats a trailing
+ * dot (`example.com.`, a valid FQDN form) as the same name it denotes in DNS.
+ */
+const HOST_ONLY = "host_only,regsub(\\.$,)";
+
 export interface GeneratedHaproxyConfig {
   config: string;
   warnings: string[];
@@ -83,7 +90,7 @@ function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"
   if (rules.some((r) => r.hostMatch === "hostPort")) {
     // A ~ rule's own regex covers host and port together, so hdr(host) is
     // stringified with the real port once here for every such rule to match.
-    lines.push("    http-request set-var-fmt(txn.host_port) %[hdr(host),host_only]:%[dst_port]");
+    lines.push(`    http-request set-var-fmt(txn.host_port) %[hdr(host),${HOST_ONLY}]:%[dst_port]`);
   }
   if (rules.some((r) => r.hostMatch === "hostBareFull")) {
     // A ~ URL rule's port is optional, exactly as in a literal URL: tried
@@ -91,8 +98,8 @@ function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"
     // otherwise -- see haproxy-rules.ts's HostMatch doc comment.
     lines.push(
       `    acl is_default_port dst_port ${DEFAULT_PORT[scheme]}`,
-      "    http-request set-var(txn.host_bare) hdr(host),host_only",
-      "    http-request set-var-fmt(txn.host_full) %[hdr(host),host_only]:%[dst_port]",
+      `    http-request set-var(txn.host_bare) hdr(host),${HOST_ONLY}`,
+      `    http-request set-var-fmt(txn.host_full) %[hdr(host),${HOST_ONLY}]:%[dst_port]`,
     );
   }
 
@@ -111,7 +118,7 @@ function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"
       );
     } else {
       // -i, since a name is case-insensitive and do-resolve lowercases anyway.
-      lines.push(`    acl ${rule.id}_host hdr(host),host_only -m reg -i ${rule.hostRegex}`);
+      lines.push(`    acl ${rule.id}_host hdr(host),${HOST_ONLY} -m reg -i ${rule.hostRegex}`);
       if (rule.port) {
         lines.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
       }
@@ -377,9 +384,9 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
         "    # host_only drops the port a header carries, which is not part of the",
         "    # name. An address is taken as-is: no resolver can answer one, and the",
         "    # rules above already decided, so nothing is loosened.",
-        `    acl host_is_address req.hdr(host),host_only -m reg ${HOST_IS_ADDRESS}`,
-        "    http-request set-var(txn.dst) req.hdr(host),host_only if host_is_address",
-        "    http-request do-resolve(txn.dst,buildcage,ipv4) req.hdr(host),lower,host_only " +
+        `    acl host_is_address req.hdr(host),${HOST_ONLY} -m reg ${HOST_IS_ADDRESS}`,
+        `    http-request set-var(txn.dst) req.hdr(host),${HOST_ONLY} if host_is_address`,
+        `    http-request do-resolve(txn.dst,buildcage,ipv4) req.hdr(host),lower,${HOST_ONLY} ` +
           "unless host_is_address",
         "    http-request deny deny_status 502 unless { var(txn.dst) -m found }",
         "",
@@ -415,7 +422,7 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
     "# certificate is verified against a name, not a name and port.",
     "backend origin_tls",
     "    mode http",
-    `    server origin 0.0.0.0 ssl verify required ca-file ${opts.systemCaFile} sni req.hdr(host),lower,host_only`,
+    `    server origin 0.0.0.0 ssl verify required ca-file ${opts.systemCaFile} sni req.hdr(host),lower,${HOST_ONLY}`,
     "",
     "backend origin_plain",
     "    mode http",


### PR DESCRIPTION
## Summary
- The inspect engine's host matching (`allowed_url_rules`, `allowed_https_rules`, `allowed_http_rules`), DNS resolution, and origin-certificate SNI all read `hdr(host),host_only` directly. None of them ignored a trailing dot (`example.com.`, a valid FQDN form), so a request carrying one — confirmed via a packet capture that curl preserves it verbatim in the Host header for `curl https://example.com./` — was falsely refused despite `example.com` being explicitly allowed.
- Case-insensitivity was already handled everywhere (`-i` on every ACL, plus explicit `lower` on the resolve/SNI paths), so this only adds the trailing-dot normalization, via a single `HOST_ONLY` constant used everywhere `host_only` was fetched, so every match/resolve/cert-check path agrees.
- Out of scope: `allow_tls_rules`'s SNI-based passthrough matching (`req.ssl_sni`). Verified with a live packet capture that curl strips a trailing dot from the SNI before the TLS handshake (RFC 6066 forbids it there), so that path doesn't hit this in practice.

## Test plan
- [x] `vp test run src/core/lib/acl` (updated + new case)
- [x] `qjs --std -m dist/qjs-test/src/core/lib/acl/haproxy-config.test.js` (proxy image runtime)