### PR TITLE
refactor: rename the CNI bridge interface to buildcage0

### DIFF
--- a/docker/inspect/files/cni.conflist
+++ b/docker/inspect/files/cni.conflist
@@ -4,7 +4,7 @@
   "plugins": [
     {
       "type": "bridge",
-      "bridge": "buildkit0",
+      "bridge": "buildcage0",
       "isGateway": true,
       "ipMasq": false,
       "ipam": {

--- a/docker/inspect/files/s6-scripts/init-iptables
+++ b/docker/inspect/files/s6-scripts/init-iptables
@@ -10,7 +10,7 @@ PORT=10024
 # Port 53 is excluded, or a resolver falling back to TCP (a truncated answer,
 # a large TXT or DNSSEC record) would be rewritten to the listener and handed
 # to the TLS/HTTP classifier, which cannot read a DNS query.
-iptables -t nat -A PREROUTING -i buildkit0 -p tcp ! --dport 53 -j REDIRECT --to-ports "$PORT"
+iptables -t nat -A PREROUTING -i buildcage0 -p tcp ! --dport 53 -j REDIRECT --to-ports "$PORT"
 
 # Reaching the proxy and the resolver is all a step may do with the gateway.
 # lo carries the services' own readiness checks, and without the conntrack rule
@@ -18,15 +18,15 @@ iptables -t nat -A PREROUTING -i buildkit0 -p tcp ! --dport 53 -j REDIRECT --to-
 # Policy last, so nothing is dropped while the ACCEPTs are still going in.
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-iptables -A INPUT -i buildkit0 -p tcp --dport "$PORT" -j ACCEPT
-iptables -A INPUT -i buildkit0 -p udp --dport 53 -j ACCEPT
-iptables -A INPUT -i buildkit0 -p tcp --dport 53 -j ACCEPT
+iptables -A INPUT -i buildcage0 -p tcp --dport "$PORT" -j ACCEPT
+iptables -A INPUT -i buildcage0 -p udp --dport 53 -j ACCEPT
+iptables -A INPUT -i buildcage0 -p tcp --dport 53 -j ACCEPT
 iptables -P INPUT DROP
 
 # Nothing is routed onward, so a packet that escaped redirection goes nowhere.
 iptables -P FORWARD DROP
 
-# No gateway ports here: buildkit0 is IPv4-only, so nothing may reach
+# No gateway ports here: buildcage0 is IPv4-only, so nothing may reach
 # the listeners over IPv6. ICMPv6 stays open for neighbour discovery.
 if [ -e /proc/net/if_inet6 ]; then
     ip6tables -A INPUT -i lo -j ACCEPT

--- a/docker/universal/files/cni.conflist
+++ b/docker/universal/files/cni.conflist
@@ -4,7 +4,7 @@
   "plugins": [
     {
       "type": "bridge",
-      "bridge": "buildkit0",
+      "bridge": "buildcage0",
       "isGateway": true,
       "ipMasq": true,
       "ipam": {

--- a/docker/universal/files/dnsmasq.conf
+++ b/docker/universal/files/dnsmasq.conf
@@ -9,7 +9,7 @@ no-resolv
 # Do not use upstream DNS servers
 no-poll
 
-# Redirect all domains to buildkit0 gateway (this container)
+# Redirect all domains to the proxy gateway (this container)
 address=/#/172.20.0.1
 
 # Disable IPv6

--- a/docker/universal/files/s6-scripts/init-iptables
+++ b/docker/universal/files/s6-scripts/init-iptables
@@ -3,19 +3,19 @@ set -e
 
 echo "init-iptables: configuring isolation..."
 
-iptables -t nat -A PREROUTING -i buildkit0 -p tcp \
+iptables -t nat -A PREROUTING -i buildcage0 -p tcp \
   -j REDIRECT --to-ports 10024
 
-# The listeners can't bind 172.20.0.1: that address only exists once buildkit0
+# The listeners can't bind 172.20.0.1: that address only exists once buildcage0
 # is wired in, well after this service runs. Filter on INPUT instead.
 # lo carries the services' own readiness checks, and without the conntrack rule
 # the proxy's own outbound connections never see their replies.
 # Policy last, so nothing is dropped while the ACCEPTs are still going in.
 iptables -A INPUT -i lo -j ACCEPT
 iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-iptables -A INPUT -i buildkit0 -p tcp --dport 10024 -j ACCEPT
-iptables -A INPUT -i buildkit0 -p udp --dport 53 -j ACCEPT
-iptables -A INPUT -i buildkit0 -p tcp --dport 53 -j ACCEPT
+iptables -A INPUT -i buildcage0 -p tcp --dport 10024 -j ACCEPT
+iptables -A INPUT -i buildcage0 -p udp --dport 53 -j ACCEPT
+iptables -A INPUT -i buildcage0 -p tcp --dport 53 -j ACCEPT
 iptables -P INPUT DROP
 
 # Nothing is routed onward, so a packet that escaped redirection goes nowhere.
@@ -26,7 +26,7 @@ iptables -P FORWARD DROP
 # ip6tables is safe. If it's present, ip6tables must succeed -- set -e keeps
 # this fail-closed rather than silently leaving IPv6 unfiltered.
 #
-# No gateway ports here: buildkit0 is IPv4-only, so nothing may reach
+# No gateway ports here: buildcage0 is IPv4-only, so nothing may reach
 # the listeners over IPv6. ICMPv6 stays open for neighbour discovery.
 if [ -e /proc/net/if_inet6 ]; then
   ip6tables -A INPUT -i lo -j ACCEPT
@@ -34,7 +34,7 @@ if [ -e /proc/net/if_inet6 ]; then
   ip6tables -A INPUT -p icmpv6 -j ACCEPT
   ip6tables -P INPUT DROP
   ip6tables -P FORWARD DROP
-  echo "init-iptables: REDIRECT configured, INPUT default-deny except lo and buildkit0 :10024/:53, no forwarding (IPv4/IPv6)"
+  echo "init-iptables: REDIRECT configured, INPUT default-deny except lo and buildcage0 :10024/:53, no forwarding (IPv4/IPv6)"
 else
-  echo "init-iptables: REDIRECT configured, INPUT default-deny except lo and buildkit0 :10024/:53, no forwarding (IPv4); kernel has no IPv6 support, skipping ip6tables"
+  echo "init-iptables: REDIRECT configured, INPUT default-deny except lo and buildcage0 :10024/:53, no forwarding (IPv4); kernel has no IPv6 support, skipping ip6tables"
 fi

--- a/docs/security.md
+++ b/docs/security.md
@@ -192,7 +192,7 @@ at the front of it, then checks that against the allowlist.
 <img src="../assets/diagram-architecture-universal.png" alt="Universal proxy engine architecture" width="611" height="490">
 
 Every container BuildKit spawns for a `RUN` step is placed on an isolated CNI network (the
-`buildkit0` bridge, 172.20.0.0/24). An iptables `PREROUTING REDIRECT` rule sends all TCP from that
+`buildcage0` bridge, 172.20.0.0/24). An iptables `PREROUTING REDIRECT` rule sends all TCP from that
 bridge to the proxy whatever its destination, so DNS-resolved and direct-IP connections both arrive
 there, and a `FORWARD` rule drops everything else, so no other protocol has a way out and
 buildkitd's own API is unreachable from a step. An `INPUT` rule likewise restricts the proxy's own


### PR DESCRIPTION
## Summary
Renames the CNI bridge from `buildkit0` to `buildcage0`, so the interface carries the product's name in logs, in `ip link` output inside the builder, and in the firewall rules.

Nothing else changes. `cni.conflist` creates the bridge and `init-iptables` matches on it, both inside the same image, so the two can never disagree.

## Changes
- Both engines' `cni.conflist` name the bridge `buildcage0`, and their `init-iptables` match `-i buildcage0`
- `docs/security.md` and the comments follow
- `dnsmasq.conf`'s comment now says "the proxy gateway" rather than naming the interface, which is the wording that stays correct wherever this file is used

## Test plan
- [x] `make test_integration_buildkit_universal_restrict`
- [x] `make test_integration_buildkit_inspect_restrict`
- [x] A build through a freshly built builder: CNI creates the bridge as `buildcage0`, and `iptables -S INPUT` shows the rules keyed on that name. A mismatch here would not be subtle, since the `PREROUTING REDIRECT` would stop matching and every request would be dropped by the `FORWARD` policy
- [x] The `explicit` engine has no CNI config of its own and is untouched
