### PR TITLE
test: replace the npm fixture with @hono/node-server, which has no open advisory

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -107,6 +107,10 @@ jobs:
       # carry reliably, so it's built here instead. *, not **, so each rule
       # only matches its one path shape (package metadata / tarball) rather
       # than falling back to matching any path under the host.
+      #
+      # A scoped package needs its own pair: `*` does not cross a `/`, and
+      # `@hono/node-server` puts a second segment where the unscoped shape has
+      # one, both in the metadata path and before the `/-/` in the tarball.
       - name: Choose allowed_url_rules for this engine
         id: url_rules
         run: |
@@ -115,6 +119,8 @@ jobs:
               echo "value<<EOF"
               echo "GET|HEAD https://registry.npmjs.org/*"
               echo "GET|HEAD https://registry.npmjs.org/*/-/*"
+              echo "GET|HEAD https://registry.npmjs.org/@*/*"
+              echo "GET|HEAD https://registry.npmjs.org/@*/*/-/*"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           else
@@ -153,7 +159,7 @@ jobs:
           # MITMs TLS); harmless for universal. inspect also terminates TLS
           # but needs nothing here, because its runc wrapper points
           # NODE_EXTRA_CA_CERTS at a store carrying the CA.
-          RUN npm init -y && NODE_USE_SYSTEM_CA=1 npm install --ignore-scripts --no-audit h3@2.0.0
+          RUN npm init -y && NODE_USE_SYSTEM_CA=1 npm install --ignore-scripts --no-audit @hono/node-server@2.1.1
           # Refused by the rules above, so the report shows the full URL, not
           # just the host. Engines differ in exactly how the refusal shows up
           # (a proxy-level HTTP error under inspect, a rejected connection

--- a/test/files/package-lock.json
+++ b/test/files/package-lock.json
@@ -6,14 +6,30 @@
     "": {
       "name": "buildcage-network-isolation-probe",
       "dependencies": {
-        "h3": "2.0.0"
+        "@hono/node-server": "2.1.1"
       }
     },
-    "node_modules/h3": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.0.tgz",
-      "integrity": "sha512-3INyyEir2VkWXD3auY+uUL/mqrgYX5ejRdUjtjyd4AOZcoijIyvf6PkBPsn+NFGE5rks2nCcMIOLZGTxpp/A7w==",
-      "deprecated": "please use 1.x or beta"
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
     }
   }
 }

--- a/test/files/package.json
+++ b/test/files/package.json
@@ -1,8 +1,8 @@
 {
   "name": "buildcage-network-isolation-probe",
   "private": true,
-  "description": "Fixture installed by test/Dockerfile.* to exercise a real npm install through buildcage's network isolation. h3 is a well-known HTTP framework with no dependencies of its own: what this has to prove is that a package manager completes a real install over the proxy, which one metadata+tarball fetch shows as well as a deep tree does, without the deep tree's exposure to registry latency.",
+  "description": "Fixture installed by test/Dockerfile.* to exercise a real npm install through buildcage's network isolation. Scoped on purpose: its registry paths carry a segment the unscoped shape does not.",
   "dependencies": {
-    "h3": "2.0.0"
+    "@hono/node-server": "2.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Dependabot flagged the `h3@2.0.0` the fixture had just moved to: it carries a high-severity advisory, and every fix for the v2 line landed in a `2.0.1-rc.*` prerelease, so there is no non-vulnerable stable v2 to move to. `npm audit` agrees, offering only `2.0.1-rc.31`. A fixture is never run as a server here, so nothing is exploitable, but leaving an alert standing that has no fix to apply is not worth the one package it saved.

The fixture is now `@hono/node-server`, the adapter that runs Hono on Node, which pulls `hono` itself with it. Two packages, clean on `npm audit`, and the one people actually install when they run Hono on Node.

Its scope earns its keep. `*` does not cross a `/`, so a scoped package puts a segment where the unscoped shape has none, both in the metadata path and before the `/-/` in the tarball. `url-rules.ts` documents exactly this case in its own header, and nothing exercised it end to end until now.

## Changes
- The npm fixture is `@hono/node-server@2.1.1`, resolving to it and `hono`. `test-e2e.yml`'s inline Dockerfile installs the same
- The inspect engine's `allowed_url_rules` in `test-e2e.yml` gain `@*/*` and `@*/*/-/*` for the scoped path shapes, alongside the unscoped pair already there

## Test plan
- [x] `make test_integration_buildkit_universal_audit` and `..._explicit_audit`: the fixture installs over both the non-cooperative CA store and `NODE_USE_SYSTEM_CA=1`
- [x] Compiled the four rules through `buildUrlRules` and matched every path npm actually requests. The scoped metadata path is allowed whether or not the proxy decodes `%2f`, the scoped tarball matches only the new rule, and `POST /some-path` is still refused, which is what the traffic-artifact assertion checks
- [x] `npm audit` on the new lockfile reports no vulnerabilities
