### PR TITLE
feat: rename allow_tls_rules to allowed_tls_rules

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -139,7 +139,7 @@ jobs:
           # wouldn't prove method/path enforcement actually happened.
           allowed_https_rules: ${{ matrix.proxy_engine != 'inspect' && 'registry.npmjs.org:443' || '' }}
           # inspect only; empty is a no-op for the other engines.
-          allow_tls_rules: ${{ matrix.proxy_engine == 'inspect' && 'github.com:443' || '' }}
+          allowed_tls_rules: ${{ matrix.proxy_engine == 'inspect' && 'github.com:443' || '' }}
           allowed_url_rules: ${{ steps.url_rules.outputs.value }}
 
       - name: Set up Docker Buildx

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Each pair builds the same Dockerfile with and without rules:
 - Private registries are ordinary hosts: add the domain like any other.
 - One registry often needs several domains. PyPI, for example, uses both `pypi.org` and
   `files.pythonhosted.org`. The audit report lists every one of them, so start from that.
-- The generated allowlist covers only what the engine decrypted. `allow_tls_rules` and
+- The generated allowlist covers only what the engine decrypted. `allowed_tls_rules` and
   `allowed_ip_rules` come back exactly as the audit run was configured with them.
 - If something in the build pins a certificate or carries its own trust store (the JVM is the usual
   case), use `proxy_engine: universal` instead. See [Engines](#engines).
@@ -155,7 +155,7 @@ All of these are empty by default. Which ones apply depends on the engine:
 | `allowed_https_rules` |    ✅     |     ✅      | A host and port reached over HTTPS: `registry.npmjs.org:443`                        |
 | `allowed_http_rules`  |    ✅     |     ✅      | A host and port reached over plain HTTP: `deb.debian.org:80`                        |
 | `allowed_ip_rules`    |    ✅     |     ✅      | An address and port, for connections made without DNS: `192.168.1.1:443`            |
-| `allow_tls_rules`     |    ✅     |      -      | A TLS destination to pass through undecrypted, judged on SNI: `db.example.com:5432` |
+| `allowed_tls_rules`   |    ✅     |      -      | A TLS destination to pass through undecrypted, judged on SNI: `db.example.com:5432` |
 | `known_blocked_rules` |    ✅     |     ✅      | A host expected to be blocked, so it doesn't fail the [report](#report-action)      |
 
 Setting a rule the engine can't act on is caught before the build starts: `restrict` fails, since a
@@ -181,7 +181,7 @@ destination named, which is why it is worth running `audit` first.
 
 ## Rule syntax
 
-`allowed_url_rules` and `allow_tls_rules` need `proxy_engine: inspect`. The host rules work with
+`allowed_url_rules` and `allowed_tls_rules` need `proxy_engine: inspect`. The host rules work with
 either engine. The inputs are additive: a connection is allowed when any rule in any of them
 matches.
 
@@ -270,13 +270,13 @@ any domain. IPv4 only, and what a rule may hold depends on the engine:
 Either way the connection is tunnelled without inspection: once an `ip:port` pair is allowed, any
 TCP-based protocol can use that path. Prefer a domain rule where the destination has a stable name.
 
-### TLS passthrough: `allow_tls_rules`
+### TLS passthrough: `allowed_tls_rules`
 
 For TLS traffic that isn't HTTPS. The SNI and port are checked and the connection passes through
 undecrypted, so the build validates the origin's own certificate:
 
 ```yaml
-allow_tls_rules: |
+allowed_tls_rules: |
   db.example.com:5432
 ```
 
@@ -353,7 +353,7 @@ only reads its own `cacerts` file. Use `proxy_engine: universal` for those.
 **No system CA store** (`scratch`, distroless, or `debian:*-slim` before `ca-certificates` is
 installed): every variable above still gets set, but only to a dedicated file trusting the proxy's
 own CA, with no public roots. That is enough for ordinary HTTPS, since `inspect` re-signs all of it
-with the same CA. It is not enough for an `allow_tls_rules` or `allowed_ip_rules` passthrough, which
+with the same CA. It is not enough for an `allowed_tls_rules` or `allowed_ip_rules` passthrough, which
 presents its own real certificate and needs a real store already in place to verify against. This is
 decided once, from the rootfs as the step begins, so installing `ca-certificates` partway through a
 step doesn't help a passthrough connection made later in that same step:

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: "URL allow rules, one per line, as '<methods> <url>'. Methods are separated by | or , and * means any. Requires proxy_engine: inspect. e.g., 'GET|HEAD https://registry.npmjs.org/**'"
     required: false
     default: ""
-  allow_tls_rules:
+  allowed_tls_rules:
     description: "TLS destinations passed through undecrypted, judged on SNI alone, separated by whitespace. Port required. Requires proxy_engine: inspect. e.g., 'db.example.com:5432'"
     required: false
     default: ""

--- a/compose.test-inspect.yaml
+++ b/compose.test-inspect.yaml
@@ -19,7 +19,7 @@ services:
       # The ~regex rule reuses tlspass.example.com on a second port, so a
       # host regex that was mangled as a wildcard would break the existing
       # :443 rule too, not just fail to add the new port.
-      ALLOW_TLS_RULES: "tlspass.example.com:443 ~^tlspass\\.example\\.com:8443$"
+      ALLOWED_TLS_RULES: "tlspass.example.com:443 ~^tlspass\\.example\\.com:8443$"
       # 9080 is distinct from the :80 the URL rule below already allows, so
       # reaching it proves this rule's own doing.
       ALLOWED_IP_RULES: "~^10\\.200\\.0\\.\\d+:9080$"

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,7 +35,7 @@ services:
       - ALLOWED_IP_RULES=${ALLOWED_IP_RULES:-}
       # inspect only: it is the one engine that can see a method or a path.
       - ALLOWED_URL_RULES=${ALLOWED_URL_RULES:-}
-      - ALLOW_TLS_RULES=${ALLOW_TLS_RULES:-}
+      - ALLOWED_TLS_RULES=${ALLOWED_TLS_RULES:-}
       - KNOWN_BLOCKED_RULES=${KNOWN_BLOCKED_RULES:-}
       - EXTERNAL_RESOLVER=${EXTERNAL_RESOLVER:-}
       - PROXY_ENGINE=${PROXY_ENGINE:-universal}

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -766,7 +766,7 @@ function buildUrlRules(rulesInput) {
 //#region src/lib/engine-rule-support.ts
 /**
 * Only `inspect` terminates TLS, so it's the only engine that can see an HTTP
-* method or a path — `allowed_url_rules` and `allow_tls_rules` are no-ops on
+* method or a path — `allowed_url_rules` and `allowed_tls_rules` are no-ops on
 * `universal` / `explicit`. Called once at setup, before the container starts,
 * so a mismatch is caught immediately instead of silently not enforcing.
 *
@@ -778,7 +778,7 @@ function buildUrlRules(rulesInput) {
 function checkUrlAndTlsRuleSupport({ proxyEngine, proxyMode, urlRules, tlsRules }, warn) {
 	if (proxyEngine === "inspect") return;
 	let unsupported = [];
-	if (urlRules.length > 0 && unsupported.push("allowed_url_rules"), tlsRules.length > 0 && unsupported.push("allow_tls_rules"), unsupported.length === 0) return;
+	if (urlRules.length > 0 && unsupported.push("allowed_url_rules"), tlsRules.length > 0 && unsupported.push("allowed_tls_rules"), unsupported.length === 0) return;
 	let list = unsupported.join(" and "), reason = `${list} ${unsupported.length > 1 ? "have" : "has"} no effect with proxy_engine: ${proxyEngine} — this engine only sees the host and port, never a method or a path.`;
 	if (proxyMode === "audit") {
 		warn(`${reason} They are ignored for this run. Switch to proxy_engine: inspect if you need to enforce a method or a path.`);
@@ -7928,7 +7928,7 @@ async function main() {
 		httpsRulesInput: getInput("allowed_https_rules"),
 		httpRulesInput: getInput("allowed_http_rules"),
 		ipRulesInput: getInput("allowed_ip_rules")
-	}), knownBlockedRules = parseRulesOrThrow(getInput("known_blocked_rules")), urlRulesInput = getInput("allowed_url_rules"), tlsRules = parseRulesOrThrow(getInput("allow_tls_rules")), urlRules = buildUrlRules(urlRulesInput).map((r) => r.raw);
+	}), knownBlockedRules = parseRulesOrThrow(getInput("known_blocked_rules")), urlRulesInput = getInput("allowed_url_rules"), tlsRules = parseRulesOrThrow(getInput("allowed_tls_rules")), urlRules = buildUrlRules(urlRulesInput).map((r) => r.raw);
 	checkUrlAndTlsRuleSupport({
 		proxyEngine,
 		proxyMode,
@@ -7944,7 +7944,7 @@ async function main() {
 		ALLOWED_HTTP_RULES: rules.httpRules.join("\n"),
 		ALLOWED_IP_RULES: rules.ipRules.join("\n"),
 		ALLOWED_URL_RULES: urlRules.join("\n"),
-		ALLOW_TLS_RULES: tlsRules.join("\n"),
+		ALLOWED_TLS_RULES: tlsRules.join("\n"),
 		KNOWN_BLOCKED_RULES: knownBlockedRules.join("\n"),
 		BUILDCAGE_IMAGE_REF: imageRef
 	};

--- a/docker/compose.action.yaml
+++ b/docker/compose.action.yaml
@@ -31,7 +31,7 @@ services:
       - ALLOWED_IP_RULES=${ALLOWED_IP_RULES:-}
       # inspect only: it is the one engine that can see a method or a path.
       - ALLOWED_URL_RULES=${ALLOWED_URL_RULES:-}
-      - ALLOW_TLS_RULES=${ALLOW_TLS_RULES:-}
+      - ALLOWED_TLS_RULES=${ALLOWED_TLS_RULES:-}
       - KNOWN_BLOCKED_RULES=${KNOWN_BLOCKED_RULES:-}
       - EXTERNAL_RESOLVER=${EXTERNAL_RESOLVER:-}
       - PROXY_ENGINE=${PROXY_ENGINE:-universal}

--- a/docker/inspect/files/s6-scripts/init-inspect-cfg
+++ b/docker/inspect/files/s6-scripts/init-inspect-cfg
@@ -57,7 +57,7 @@ qjs --std -m /opt/buildcage/scripts/gen-configs.js \
     "$HTTPS_RULES" \
     "$HTTP_RULES" \
     "$ALLOWED_IP_RULES" \
-    "$ALLOW_TLS_RULES" \
+    "$ALLOWED_TLS_RULES" \
     "$URL_RULES"
 
 echo "init-inspect-cfg: configuration generated"

--- a/docs/inspect-engine.md
+++ b/docs/inspect-engine.md
@@ -4,7 +4,7 @@ This page holds no content of its own. The `inspect` engine is documented in the
 [README](../README.md) and the guides below, and what follows is a set of links into them.
 
 - [Engines](../README.md#engines): what it enforces on, and when to use `universal` instead
-- [Rule syntax](../README.md#rule-syntax): `allowed_url_rules` and `allow_tls_rules`, which need this engine
+- [Rule syntax](../README.md#rule-syntax): `allowed_url_rules` and `allowed_tls_rules`, which need this engine
 - [CA trust and compatibility](../README.md#ca-trust-and-compatibility): the CA variables it sets, and what it cannot work with
 - [Inspect Proxy Engine](./security.md#inspect-proxy-engine): architecture, threat model, attack resistance
 - [Inspect Engine Internals](./development.md#inspect-engine-internals): HAProxy, CoreDNS, and the runc wrapper

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -8,5 +8,5 @@ follows is a set of links into it.
 - [Host rules](../README.md#host-rules-allowed_https_rules-allowed_http_rules-allowed_ip_rules-known_blocked_rules): `host:port`, shared by four inputs
 - [Wildcards](../README.md#wildcards) and [ports](../README.md#ports): what `*`, `**`, `?` and `:*` match
 - [IP addresses](../README.md#ip-addresses-allowed_ip_rules): what `allowed_ip_rules` takes on each engine
-- [TLS passthrough](../README.md#tls-passthrough-allow_tls_rules): TLS that isn't HTTPS, for `inspect`
+- [TLS passthrough](../README.md#tls-passthrough-allowed_tls_rules): TLS that isn't HTTPS, for `inspect`
 - [Regular expressions](../README.md#regular-expressions): the `~` prefix, and where POSIX ERE applies

--- a/docs/security.md
+++ b/docs/security.md
@@ -90,7 +90,7 @@ What each kind of rule decides, and what stays undecrypted:
 | `allowed_https_rules` | any method and path on the host, over TLS  | Host header          | yes       |
 | `allowed_http_rules`  | any method and path on the host, plaintext | Host header          | n/a       |
 | `allowed_url_rules`   | the named methods on matching URLs         | Host header and path | yes       |
-| `allow_tls_rules`     | TLS to the named host and port             | SNI and port         | **no**    |
+| `allowed_tls_rules`   | TLS to the named host and port             | SNI and port         | **no**    |
 | `allowed_ip_rules`    | TCP to the address and port, any protocol  | address and port     | **no**    |
 
 ### What it actually stops
@@ -170,7 +170,7 @@ What each kind of rule decides, and what stays undecrypted:
   directly, is unaffected by this guard in either mode: blocking it would only hide real
   information about what the build needs, without closing anything DNS could have redirected.
 
-- **`allow_tls_rules` and `allowed_ip_rules` stay uninspected by design.** Each is recorded with a
+- **`allowed_tls_rules` and `allowed_ip_rules` stay uninspected by design.** Each is recorded with a
   byte count and nothing more, since neither carries a name the proxy can re-terminate TLS for.
 - **Query strings are kept in the log**, since that is also where an exfiltration payload would go.
 - **UDP is dropped**, so QUIC and HTTP/3 fall back to TCP or fail. Port 53 to the gateway is the one

--- a/src/core/lib/report/build/explicit.test.ts
+++ b/src/core/lib/report/build/explicit.test.ts
@@ -9,7 +9,7 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
-    allowTlsRules: [],
+    allowedTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/build/inspect.test.ts
+++ b/src/core/lib/report/build/inspect.test.ts
@@ -14,7 +14,7 @@ const PARAMS: GenReportParameters = {
   allowedHttpsRules: [],
   allowedHttpRules: [],
   allowedIpRules: [],
-  allowTlsRules: [],
+  allowedTlsRules: [],
   knownBlockedRules: [],
 };
 

--- a/src/core/lib/report/build/universal.test.ts
+++ b/src/core/lib/report/build/universal.test.ts
@@ -8,7 +8,7 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
-    allowTlsRules: [],
+    allowedTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/outcome/emit.test.ts
+++ b/src/core/lib/report/outcome/emit.test.ts
@@ -21,7 +21,7 @@ function parameters(overrides: Partial<GenReportParameters> = {}): GenReportPara
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
-    allowTlsRules: [],
+    allowedTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/parameters.test.ts
+++ b/src/core/lib/report/parameters.test.ts
@@ -9,7 +9,7 @@ describe("buildReportParameters", () => {
         ALLOWED_HTTPS_RULES: "a.com:443 b.com:443",
         ALLOWED_HTTP_RULES: "c.com:80",
         ALLOWED_IP_RULES: "",
-        ALLOW_TLS_RULES: "d.example.com:8443",
+        ALLOWED_TLS_RULES: "d.example.com:8443",
         KNOWN_BLOCKED_RULES: "noisy.example.com:443",
       }),
     ).toStrictEqual({
@@ -17,7 +17,7 @@ describe("buildReportParameters", () => {
       allowedHttpsRules: ["a.com:443", "b.com:443"],
       allowedHttpRules: ["c.com:80"],
       allowedIpRules: [],
-      allowTlsRules: ["d.example.com:8443"],
+      allowedTlsRules: ["d.example.com:8443"],
       knownBlockedRules: ["noisy.example.com:443"],
     });
   });
@@ -31,7 +31,7 @@ describe("buildReportParameters", () => {
     expect(params.allowedHttpsRules).toStrictEqual([]);
     expect(params.allowedHttpRules).toStrictEqual([]);
     expect(params.allowedIpRules).toStrictEqual([]);
-    expect(params.allowTlsRules).toStrictEqual([]);
+    expect(params.allowedTlsRules).toStrictEqual([]);
     expect(params.knownBlockedRules).toStrictEqual([]);
   });
 });

--- a/src/core/lib/report/parameters.ts
+++ b/src/core/lib/report/parameters.ts
@@ -14,7 +14,7 @@ export function buildReportParameters(
     allowedHttpsRules: splitRuleTokens(env.ALLOWED_HTTPS_RULES),
     allowedHttpRules: splitRuleTokens(env.ALLOWED_HTTP_RULES),
     allowedIpRules: splitRuleTokens(env.ALLOWED_IP_RULES),
-    allowTlsRules: splitRuleTokens(env.ALLOW_TLS_RULES),
+    allowedTlsRules: splitRuleTokens(env.ALLOWED_TLS_RULES),
     knownBlockedRules: splitRuleTokens(env.KNOWN_BLOCKED_RULES),
   };
 }

--- a/src/core/lib/report/render/inspect-example.test.ts
+++ b/src/core/lib/report/render/inspect-example.test.ts
@@ -228,7 +228,7 @@ describe("buildInspectRestrictExample", () => {
     expect(buildInspectRestrictExample(null, "buildcage/docker", "v2")).toBe("");
   });
 
-  it("echoes allow_tls_rules and allowed_ip_rules as configured, not derived from traffic", () => {
+  it("echoes allowed_tls_rules and allowed_ip_rules as configured, not derived from traffic", () => {
     // Neither is ever decrypted, so there is nothing in `requests` to build
     // them from -- they are the same values the audit run was given.
     const md = buildInspectRestrictExample(requests, "buildcage/docker", "v2", undefined, [
@@ -244,7 +244,7 @@ describe("buildInspectRestrictExample", () => {
       [],
       ["db.internal.example.com:8443"],
     );
-    expect(/allow_tls_rules: \|\n\s+db\.internal\.example\.com:8443\n/.test(md2)).toBe(true);
+    expect(/allowed_tls_rules: \|\n\s+db\.internal\.example\.com:8443\n/.test(md2)).toBe(true);
   });
 
   it("still renders a section for tls/ip rules alone, with no observed traffic", () => {
@@ -258,7 +258,7 @@ describe("buildInspectRestrictExample", () => {
     );
     expect(md.includes("allowed_url_rules")).toBe(false);
     expect(/allowed_ip_rules: \|\n\s+10\.0\.0\.5:5432\n/.test(md)).toBe(true);
-    expect(/allow_tls_rules: \|\n\s+db\.internal\.example\.com:8443\n/.test(md)).toBe(true);
+    expect(/allowed_tls_rules: \|\n\s+db\.internal\.example\.com:8443\n/.test(md)).toBe(true);
   });
 
   it("appends the version as a trailing comment when known", () => {

--- a/src/core/lib/report/render/inspect-example.ts
+++ b/src/core/lib/report/render/inspect-example.ts
@@ -148,7 +148,7 @@ export function buildUrlRuleLines(requests: TrafficEvent[]): string[] {
  *
  * `actionRef` is the ref this action was invoked with; `actionVersion`, if
  * known, is appended as a trailing `# 3.1.4` comment. `allowedIpRules` and
- * `allowTlsRules` are not derived from `requests` -- a passthrough is never
+ * `allowedTlsRules` are not derived from `requests` -- a passthrough is never
  * decrypted, so there is nothing in the traffic to build them from -- they
  * are the same values the audit run was configured with, echoed back as-is,
  * since they apply unchanged under `restrict` (only enforcement differs).
@@ -159,10 +159,10 @@ export function buildInspectRestrictExample(
   actionRef?: string,
   actionVersion?: string,
   allowedIpRules: string[] = [],
-  allowTlsRules: string[] = [],
+  allowedTlsRules: string[] = [],
 ): string {
   const lines = buildUrlRuleLines(requests ?? []);
-  if (lines.length === 0 && allowedIpRules.length === 0 && allowTlsRules.length === 0) return "";
+  if (lines.length === 0 && allowedIpRules.length === 0 && allowedTlsRules.length === 0) return "";
 
   let yaml = "- name: Start Buildcage\n";
   yaml += `  uses: ${actionRepo}@${actionRef}${actionVersion ? ` # ${actionVersion}` : ""}\n`;
@@ -175,9 +175,9 @@ export function buildInspectRestrictExample(
     yaml += "    allowed_url_rules: |\n";
     for (const line of lines) yaml += `      ${line}\n`;
   }
-  if (allowTlsRules.length > 0) {
-    yaml += "    allow_tls_rules: |\n";
-    for (const rule of allowTlsRules) yaml += `      ${rule}\n`;
+  if (allowedTlsRules.length > 0) {
+    yaml += "    allowed_tls_rules: |\n";
+    for (const rule of allowedTlsRules) yaml += `      ${rule}\n`;
   }
   if (allowedIpRules.length > 0) {
     yaml += "    allowed_ip_rules: |\n";

--- a/src/core/lib/report/render/render-report-markdown.test.ts
+++ b/src/core/lib/report/render/render-report-markdown.test.ts
@@ -8,7 +8,7 @@ function params(overrides: Partial<GenReportParameters> = {}): GenReportParamete
     allowedHttpsRules: [],
     allowedHttpRules: [],
     allowedIpRules: [],
-    allowTlsRules: [],
+    allowedTlsRules: [],
     knownBlockedRules: [],
     ...overrides,
   };

--- a/src/core/lib/report/render/render-report-markdown.ts
+++ b/src/core/lib/report/render/render-report-markdown.ts
@@ -46,7 +46,7 @@ export function renderReportMarkdown(
             actionRef,
             actionVersion,
             report.parameters.allowedIpRules,
-            report.parameters.allowTlsRules,
+            report.parameters.allowedTlsRules,
           )
         : buildRestrictExample(report.passed, actionRepo, actionRef, actionVersion);
   }

--- a/src/core/lib/report/types.ts
+++ b/src/core/lib/report/types.ts
@@ -10,7 +10,7 @@ export interface GenReportParameters {
   allowedHttpsRules: string[];
   allowedHttpRules: string[];
   allowedIpRules: string[];
-  allowTlsRules: string[];
+  allowedTlsRules: string[];
   /** Also drives whether the "Expected" column is shown (length > 0). */
   knownBlockedRules: string[];
 }

--- a/src/lib/engine-rule-support.test.ts
+++ b/src/lib/engine-rule-support.test.ts
@@ -58,7 +58,7 @@ describe("checkUrlAndTlsRuleSupport", () => {
         },
         vi.fn(),
       ),
-    ).toThrow(/allow_tls_rules/);
+    ).toThrow(/allowed_tls_rules/);
   });
 
   it("mentions both inputs when both are set", () => {
@@ -74,7 +74,7 @@ describe("checkUrlAndTlsRuleSupport", () => {
       );
       expect.unreachable();
     } catch (e) {
-      expect((e as Error).message).toMatch(/allowed_url_rules and allow_tls_rules/);
+      expect((e as Error).message).toMatch(/allowed_url_rules and allowed_tls_rules/);
     }
   });
 

--- a/src/lib/engine-rule-support.ts
+++ b/src/lib/engine-rule-support.ts
@@ -3,7 +3,7 @@ import type { ProxyEngine } from "../main.ts";
 
 /**
  * Only `inspect` terminates TLS, so it's the only engine that can see an HTTP
- * method or a path — `allowed_url_rules` and `allow_tls_rules` are no-ops on
+ * method or a path — `allowed_url_rules` and `allowed_tls_rules` are no-ops on
  * `universal` / `explicit`. Called once at setup, before the container starts,
  * so a mismatch is caught immediately instead of silently not enforcing.
  *
@@ -30,7 +30,7 @@ export function checkUrlAndTlsRuleSupport(
 
   const unsupported: string[] = [];
   if (urlRules.length > 0) unsupported.push("allowed_url_rules");
-  if (tlsRules.length > 0) unsupported.push("allow_tls_rules");
+  if (tlsRules.length > 0) unsupported.push("allowed_tls_rules");
   if (unsupported.length === 0) return;
 
   const list = unsupported.join(" and ");

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ async function main(): Promise<void> {
   // Only inspect can enforce on a method or a path, so these are compiled here
   // purely to fail on a typo at setup rather than inside the container.
   const urlRulesInput = core.getInput("allowed_url_rules");
-  const tlsRules = parseRulesOrThrow(core.getInput("allow_tls_rules"));
+  const tlsRules = parseRulesOrThrow(core.getInput("allowed_tls_rules"));
   const urlRules = buildUrlRules(urlRulesInput).map((r) => r.raw);
   checkUrlAndTlsRuleSupport({ proxyEngine, proxyMode, urlRules, tlsRules }, (message) =>
     console.log(`::warning::${message}`),
@@ -118,7 +118,7 @@ async function main(): Promise<void> {
     ALLOWED_IP_RULES: rules.ipRules.join("\n"),
     // Newline separated because a URL rule contains a space, unlike the others.
     ALLOWED_URL_RULES: urlRules.join("\n"),
-    ALLOW_TLS_RULES: tlsRules.join("\n"),
+    ALLOWED_TLS_RULES: tlsRules.join("\n"),
     KNOWN_BLOCKED_RULES: knownBlockedRules.join("\n"),
     BUILDCAGE_IMAGE_REF: imageRef,
   };

--- a/test/Dockerfile.inspect-restrict
+++ b/test/Dockerfile.inspect-restrict
@@ -25,7 +25,7 @@ ENV C='curl -sS -o /dev/null -w %{http_code} --max-time 10'
 #     GET https://*.wildcard.example.com/public/**
 #   allowed_https_rules: sub.wildcard.example.com:443 absent.example.com:443
 #   allowed_http_rules:  allowed.example.com:80
-#   allow_tls_rules:     tlspass.example.com:443
+#   allowed_tls_rules:   tlspass.example.com:443
 # ---------------------------------------------------------------------------
 
 # [URL rule - path allowed]

--- a/test/assert-inspect-audit.sh
+++ b/test/assert-inspect-audit.sh
@@ -86,11 +86,11 @@ fi
 
 RULES=$(
   awk '
-    # Stops at the next top-level key (allow_tls_rules/allowed_ip_rules are
+    # Stops at the next top-level key (allowed_tls_rules/allowed_ip_rules are
     # now echoed into the same fenced block, see inspect-example.ts) as well
     # as the closing fence, so only the allowed_url_rules value is captured.
     /allowed_url_rules: \|/ { capture=1; next }
-    capture && /^ *(allow_tls_rules|allowed_ip_rules): \|/ { exit }
+    capture && /^ *(allowed_tls_rules|allowed_ip_rules): \|/ { exit }
     capture && /```/ { exit }
     capture { print }
   ' <<< "$REPORT_MARKDOWN" | sed 's/^ *//'

--- a/test/run-inspect-roundtrip.sh
+++ b/test/run-inspect-roundtrip.sh
@@ -45,12 +45,12 @@ build test/Dockerfile.inspect-audit
 
 RULES=$(
   COMPOSE_FILE="$BASE_COMPOSE" GITHUB_STEP_SUMMARY= node report/src/main.ts 2>&1 |
-    # Stops at the next top-level key (allow_tls_rules/allowed_ip_rules are
+    # Stops at the next top-level key (allowed_tls_rules/allowed_ip_rules are
     # now echoed into the same fenced block, see inspect-example.ts) as well
     # as the closing fence, so only the allowed_url_rules value is captured.
     awk '
       /allowed_url_rules: \|/ { capture=1; next }
-      capture && /^ *(allow_tls_rules|allowed_ip_rules): \|/ { exit }
+      capture && /^ *(allowed_tls_rules|allowed_ip_rules): \|/ { exit }
       capture && /```/ { exit }
       capture { print }
     ' | sed 's/^ *//'
@@ -73,7 +73,7 @@ sed 's/^/    /' <<< "$RULES"
   echo "    environment:"
   echo "      - ALLOWED_HTTPS_RULES="
   echo "      - ALLOWED_HTTP_RULES="
-  echo "      - ALLOW_TLS_RULES="
+  echo "      - ALLOWED_TLS_RULES="
   # One YAML scalar with escaped newlines, since a URL rule contains a space.
   # awk rather than `sed -z`, which is GNU-only and silently yields nothing on
   # a BSD sed.


### PR DESCRIPTION
## Summary
Renames `allow_tls_rules` to `allowed_tls_rules`, so it matches the four inputs it sits beside. It was the only rule input spelled `allow_` rather than `allowed_`.

**Breaking.** No alias is kept. A workflow left on the old name gets GitHub's "Unexpected input" warning and an empty value, so under `restrict` the passthrough destinations are blocked and the build fails — the failure is loud and on the safe side, never a silently widened allowlist.

## Changes

The input:

```yaml
- uses: buildcage/docker@v3
  with:
    proxy_engine: inspect
-   allow_tls_rules: db.example.com:5432
+   allowed_tls_rules: db.example.com:5432
```

The snippet an `audit` run writes into the Job Summary, which is meant to be pasted straight into a workflow, now emits `allowed_tls_rules:` too.

The error raised when the input is set on an engine that can't enforce it (`universal`, `explicit`) names the input, so its wording follows.

For anyone driving the engine image directly through compose — the local development loop — the environment variable is `ALLOWED_TLS_RULES`.

Everything else is unchanged: the rule syntax, what a TLS passthrough does, and which engine it needs.

## Test plan
- [x] Engine build contexts diffed against `isolated-run`: `init-inspect-cfg`'s only difference is still the CA-lifetime comment documented in CLAUDE.md — no new drift. Nothing in CI compares the two repos, so this one is by hand
