### PR TITLE
fix: re-resolve the CA write-back target and report a failure in the build log

### DIFF
--- a/docker/inspect/buildcage-runc/inject.go
+++ b/docker/inspect/buildcage-runc/inject.go
@@ -231,6 +231,7 @@ func inject(bundle string, ca []byte) (func() error, error) {
 			names[i] = filepath.Base(f)
 		}
 		b := &dirBind{
+			rootfs:       s.rootfs,
 			hostDir:      hostDir,
 			containerDir: containerDir,
 			scratchDir:   scratch,

--- a/docker/inspect/buildcage-runc/main.go
+++ b/docker/inspect/buildcage-runc/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -28,8 +29,11 @@ import (
 const (
 	realRunc = "/usr/bin/buildkit-runc"
 	caFile   = "/opt/buildcage/ca.pem"
-	logFile  = "/var/log/buildcage/runc.log"
 )
+
+// logFile is a var, not a const, so tests can point it at a temp file
+// instead of the real host path.
+var logFile = "/var/log/buildcage/runc.log"
 
 // Subcommands runc accepts. Only those carrying a bundle are acted on; the
 // rest are passed through untouched.
@@ -48,6 +52,35 @@ func logf(format string, a ...any) {
 	}
 	defer f.Close()
 	fmt.Fprintf(f, format+"\n", a...)
+}
+
+func logSize() int64 {
+	info, err := os.Stat(logFile)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+// dumpLogSince copies this invocation's own lines onto w. Nothing collects
+// the log from the builder container, so without this a failure reaches the
+// build log as a bare non-zero exit. from bounds the dump to this step: one
+// file carries every step of every build.
+func dumpLogSince(w io.Writer, from int64) {
+	f, err := os.Open(logFile)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	if _, err := f.Seek(from, io.SeekStart); err != nil {
+		return
+	}
+	lines, err := io.ReadAll(f)
+	if err != nil || len(lines) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "buildcage: %s for this step:\n", logFile)
+	_, _ = w.Write(lines)
 }
 
 // parseArgs returns the runc subcommand and the --bundle value, if any.
@@ -80,7 +113,9 @@ func main() {
 	// but `runc create` returns before the process runs, so the CA would be gone
 	// by `runc start`. BuildKit's runcexecutor uses `run`.
 	var restore func() error
+	var logStart int64
 	if sub == "run" && bundle != "" {
+		logStart = logSize()
 		ca, err := os.ReadFile(caFile)
 		if err != nil {
 			// Without a CA there is nothing to trust and nothing to undo; the
@@ -128,6 +163,7 @@ func main() {
 	if restore != nil {
 		if err := restore(); err != nil {
 			logf("CA write-back failed, failing the build: %v", err)
+			dumpLogSince(os.Stderr, logStart)
 			if code == 0 {
 				code = 1
 			}

--- a/docker/inspect/buildcage-runc/main_test.go
+++ b/docker/inspect/buildcage-runc/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// useTempLog points logf and the dump at a file the test owns, since a test
+// process usually can't write the real host path.
+func useTempLog(t *testing.T) {
+	t.Helper()
+	old := logFile
+	logFile = filepath.Join(t.TempDir(), "runc.log")
+	t.Cleanup(func() { logFile = old })
+}
+
+// One file carries every step of every build, so a failure must report the
+// failing step's lines and no one else's.
+func TestDumpLogSinceCoversOnlyThisInvocation(t *testing.T) {
+	useTempLog(t)
+	logf("an earlier step on this builder")
+	from := logSize()
+	logf("CA write-back failed for %s: %v", "/etc/ssl/certs", "rsync exit status 23")
+
+	var out strings.Builder
+	dumpLogSince(&out, from)
+
+	got := out.String()
+	if strings.Contains(got, "an earlier step") {
+		t.Errorf("the dump reached back into an earlier step:\n%s", got)
+	}
+	if !strings.Contains(got, "rsync exit status 23") {
+		t.Errorf("the dump left out this step's own failure:\n%s", got)
+	}
+	if !strings.Contains(got, logFile) {
+		t.Errorf("the dump does not say where the lines came from:\n%s", got)
+	}
+}
+
+// Nothing to report means no output at all, not a bare header.
+func TestDumpLogSinceWithNothingToReport(t *testing.T) {
+	useTempLog(t)
+
+	var out strings.Builder
+	dumpLogSince(&out, logSize())
+	if out.String() != "" {
+		t.Errorf("expected no output before the log exists, got %q", out.String())
+	}
+
+	logf("an earlier step on this builder")
+	out.Reset()
+	dumpLogSince(&out, logSize())
+	if out.String() != "" {
+		t.Errorf("a step that logged nothing should report nothing, got %q", out.String())
+	}
+}
+
+func TestLogSizeIgnoresAMissingLog(t *testing.T) {
+	useTempLog(t)
+	if got := logSize(); got != 0 {
+		t.Errorf("logSize() = %d for a log that does not exist yet, want 0", got)
+	}
+	logf("first line")
+	info, err := os.Stat(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := logSize(); got != info.Size() {
+		t.Errorf("logSize() = %d, want %d", got, info.Size())
+	}
+}

--- a/docker/inspect/buildcage-runc/mount.go
+++ b/docker/inspect/buildcage-runc/mount.go
@@ -42,6 +42,7 @@ var runRsync = func(args []string) ([]byte, error) {
 // separate sources over the same destination would let the second shadow
 // the first.
 type dirBind struct {
+	rootfs       string // so finish can re-resolve containerDir
 	hostDir      string
 	containerDir string
 	scratchDir   string
@@ -290,6 +291,10 @@ func (b *dirBind) prepare(ca []byte) error {
 
 // finish diffs the scratch mirror against its post-injection baseline and
 // only touches the real rootfs directory when the step actually changed it.
+//
+// The write-back is not atomic, so a failure leaves hostDir half-written.
+// That is only safe because the error fails the step, and BuildKit then
+// releases the mutable snapshot instead of committing it.
 func (b *dirBind) finish() error {
 	current, err := captureManifest(b.scratchDir)
 	if err != nil {
@@ -316,6 +321,18 @@ func (b *dirBind) finish() error {
 	}
 	if err := restoreUnchangedMtimes(b.original, stripped, b.scratchDir); err != nil {
 		return err
+	}
+
+	// Nothing in the step can move a mounted directory or its ancestors, so
+	// this cannot legitimately differ. Checking anyway keeps the write-back's
+	// confinement to the rootfs a property of this code rather than of how
+	// runc applied the mounts.
+	resolved, err := resolveInRoot(b.rootfs, b.containerDir)
+	if err != nil {
+		return fmt.Errorf("re-resolving the write-back target %s: %w", b.containerDir, err)
+	}
+	if resolved != b.hostDir {
+		return fmt.Errorf("write-back target %s now resolves to %s, not %s", b.containerDir, resolved, b.hostDir)
 	}
 
 	return writeBack(b.scratchDir, b.hostDir)

--- a/docker/inspect/buildcage-runc/mount_test.go
+++ b/docker/inspect/buildcage-runc/mount_test.go
@@ -296,3 +296,113 @@ func mustStatMtime(t *testing.T, path string) time.Time {
 	}
 	return info.ModTime()
 }
+
+// newCAStoreBind lays out a rootfs holding one CA bundle and prepares a
+// dirBind over its directory, the way inject does.
+func newCAStoreBind(t *testing.T) (*dirBind, string) {
+	t.Helper()
+	rootfs := t.TempDir()
+	mustMkdirAll(t, filepath.Join(rootfs, "etc/ssl/certs"))
+	mustWriteFile(t, filepath.Join(rootfs, "etc/ssl/certs/ca-certificates.crt"), "ORIGINAL-ROOTS\n")
+
+	store, _, err := findSystemStore(rootfs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostDir := filepath.Dir(store)
+	scratch, err := newScratchDir("bundle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b := &dirBind{
+		rootfs:       rootfs,
+		hostDir:      hostDir,
+		containerDir: containerPathOf(rootfs, hostDir),
+		scratchDir:   scratch,
+		bundleFiles:  []string{filepath.Base(store)},
+	}
+	if err := b.prepare([]byte("BUILDCAGE-CA")); err != nil {
+		t.Fatal(err)
+	}
+	return b, rootfs
+}
+
+// redirectStoreDir repoints /etc/ssl, so containerDir no longer resolves to
+// where injection left it.
+func redirectStoreDir(t *testing.T, rootfs string) {
+	t.Helper()
+	elsewhere := filepath.Join(rootfs, "elsewhere")
+	mustMkdirAll(t, filepath.Join(elsewhere, "certs"))
+	if err := os.RemoveAll(filepath.Join(rootfs, "etc/ssl")); err != nil {
+		t.Fatal(err)
+	}
+	mustSymlink(t, "/elsewhere", filepath.Join(rootfs, "etc/ssl"))
+}
+
+// countRsync counts from the call it is installed on, leaving out a bind's
+// own mirroring during prepare.
+func countRsync(t *testing.T) *int {
+	t.Helper()
+	var calls int
+	orig := runRsync
+	runRsync = func(args []string) ([]byte, error) {
+		calls++
+		return orig(args)
+	}
+	t.Cleanup(func() { runRsync = orig })
+	return &calls
+}
+
+// A destination that no longer resolves where injection left it fails the
+// step rather than being written to.
+func TestFinishRefusesARedirectedWriteBackTarget(t *testing.T) {
+	useFakeRsync(t)
+	b, rootfs := newCAStoreBind(t)
+	mustWriteFile(t, filepath.Join(b.scratchDir, "ca-certificates.crt"), "REGENERATED\n")
+	redirectStoreDir(t, rootfs)
+
+	calls := countRsync(t)
+	if err := b.finish(); err == nil {
+		t.Fatal("expected finish to refuse the redirected target")
+	}
+	if *calls != 0 {
+		t.Errorf("got %d rsync invocations, want none before the target is verified", *calls)
+	}
+}
+
+func TestFinishWritesBackWhenTheTargetStillResolves(t *testing.T) {
+	useFakeRsync(t)
+	b, rootfs := newCAStoreBind(t)
+	mustWriteFile(t, filepath.Join(b.scratchDir, "ca-certificates.crt"), "REGENERATED\n")
+
+	calls := countRsync(t)
+	if err := b.finish(); err != nil {
+		t.Fatal(err)
+	}
+	if *calls != 2 {
+		t.Errorf("got %d rsync invocations, want 2 (dry run, then apply)", *calls)
+	}
+	got, err := os.ReadFile(filepath.Join(rootfs, "etc/ssl/certs/ca-certificates.crt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "REGENERATED\n" {
+		t.Errorf("write-back did not reach the real store: %q", got)
+	}
+}
+
+// An untouched store returns before the check, so a build that never writes
+// to the store cannot start failing on it.
+func TestFinishSkipsTheCheckWhenTheStoreIsUnchanged(t *testing.T) {
+	useFakeRsync(t)
+	b, rootfs := newCAStoreBind(t)
+	redirectStoreDir(t, rootfs)
+
+	calls := countRsync(t)
+	if err := b.finish(); err != nil {
+		t.Fatalf("an unchanged store must not fail: %v", err)
+	}
+	if *calls != 0 {
+		t.Errorf("got %d rsync invocations, want none for an unchanged store", *calls)
+	}
+}


### PR DESCRIPTION
## Summary

The `inspect` engine's runc wrapper mirrors a step's CA store into a scratch directory, bind-mounts it over the real one, and writes back only what the step changed. The write-back destination was resolved once, at injection time, and reused verbatim when the step ended.

Nothing in a step can actually move it. The destination is a mount point and so is every ancestor holding a submount, so the kernel refuses the rename or the rmdir, and by the time the write-back runs the step's processes are gone. But none of that is written down in the wrapper: reading it, you have to reconstruct the argument from how runc applied the mounts to see that the write-back stays inside the rootfs. The destination is now resolved again, from the rootfs, immediately before anything is written, so that property lives in this code rather than in the reasoning around it.

The second commit is about what a failure looks like. It is fail-closed and takes the build down with exit 1, but the reason only ever reached `/var/log/buildcage/runc.log` inside the builder container, which nothing collects and nothing rotates.

## Changes

`mount.go` / `inject.go` — `dirBind` keeps the rootfs, and `finish` re-resolves `containerDir` with `resolveInRoot` before `writeBack`, failing the step when it no longer lands on the `hostDir` injection chose. `resolveInRoot` follows symlinks only from the rootfs and refuses `..` above it, so a component swapped mid-step either resolves elsewhere or errors outright.

The check sits after the early return for an unchanged store, not before it: a build that never writes to the store still writes nothing, and cannot start failing on this.

`finish`'s doc comment also records why a half-written `hostDir` is survivable, since that is the premise the whole fail-closed design rests on: an error fails the step, so BuildKit releases the mutable snapshot instead of committing it. The write-back is not atomic and does not need to be.

`main.go` — on a write-back failure only, the lines this invocation added to the log go to stderr, where the build log picks them up:

```
buildcage: /var/log/buildcage/runc.log for this step:
CA store write-back for /etc/ssl/certs:
>f.st...... ca-certificates.crt
CA write-back failed for /etc/ssl/certs: rsync write-back to /rootfs/etc/ssl/certs: exit status 23: ...
CA write-back failed, failing the build: rsync write-back to /rootfs/etc/ssl/certs: exit status 23
```

Bounded to this invocation by the file's size before it started, because one log file carries every RUN step of every build on that builder. A step that logged nothing prints nothing, not a bare header.

## Test plan
- [x] With the guard removed, `TestFinishRefusesARedirectedWriteBackTarget` fails on the rsync it then reaches, so the test pins the behaviour rather than just the error
- [x] `src/core` and both engine build contexts diffed against `isolated-run`: only the differences CLAUDE.md documents, no new drift. `buildcage-runc` exists in this repo alone, so nothing here ports. Nothing in CI compares the two repos
