### PR TITLE
fix: escape rule text embedded in the generated haproxy.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ allowed_url_rules: |
 ```
 
 Methods are separated by `|` or `,`, and `*` means any method. The port may be left out when it is
-the scheme's default, and a pattern with no path allows any path on that host.
+the scheme's default, and a pattern with no path allows any path on that host. A `#` fragment is
+refused: it never travels with a request, so a rule carrying one could only match nothing.
 
 | Pattern | In a domain                                       | In a path                     |
 | ------- | ------------------------------------------------- | ----------------------------- |

--- a/compose.test-inspect.yaml
+++ b/compose.test-inspect.yaml
@@ -47,6 +47,14 @@ services:
         # No port at all: matches only the scheme's default (443), not 9443
         # above -- a ~ URL rule's port is optional, unlike the other kinds.
         GET ~^https://blocked\.example\.com/defaultport/.*$
+
+        # Never requested: this is here so real HAProxy sees a path pattern
+        # carrying the characters its own config parser folds. Unescaped, the
+        # `#` would comment the line short and leave the regex as `^/frag(x`,
+        # and the `'` would open a quoted string -- either way haproxy refuses
+        # the config and this job fails, which is the point. A pattern that
+        # stayed valid when cut short would regress in silence.
+        GET ~^https://blocked\.example\.com/frag(x#y|'z)$
     volumes:
       - ./test/test-server-inspect/cert.pem:/test-fixtures/test-server-cert.pem:ro
     networks:

--- a/dist/main.cjs
+++ b/dist/main.cjs
@@ -626,11 +626,12 @@ function parseMethods(spec, rule) {
 /**
 * Split a URL pattern into scheme, authority (host:port) and path.
 *
-* @throws {Error} if the pattern is not an http(s) URL
+* @throws {Error} if the pattern is not an http(s) URL, or carries a fragment
 */
 function splitUrl(url, rule) {
 	let match = /^(https?):\/\/([^/]+)(\/.*)?$/.exec(url);
 	if (!match) throw Error(`Invalid URL in rule "${rule}": expected http:// or https:// followed by a host`);
+	if (url.includes("#")) throw Error(`Invalid URL in rule "${rule}": a "#" fragment is never sent with a request, so this rule would match nothing. Drop it, or write the rule as a "~" regex if the "#" is meant literally.`);
 	return {
 		scheme: match[1],
 		authority: match[2],

--- a/src/core/lib/acl/haproxy-config.test.ts
+++ b/src/core/lib/acl/haproxy-config.test.ts
@@ -318,7 +318,7 @@ describe("rules", () => {
   it("matches a host case-insensitively, as a name is", () => {
     // do-resolve already lowercases the name it looks up, so a case-sensitive
     // acl refuses `Host: Registry.NPMJS.org` despite an explicit allow rule.
-    expect(gen({ httpsRules: ["a.com:443"] }).includes("-m reg -i ^a\\.com$")).toBe(true);
+    expect(gen({ httpsRules: ["a.com:443"] }).includes("-m reg -i ^a\\\\.com$")).toBe(true);
   });
 
   it("strips a trailing dot from the Host header before matching, resolving or verifying it", () => {
@@ -326,7 +326,7 @@ describe("rules", () => {
     // write it that way to skip resolv.conf's search-list expansion. Without
     // this, `Host: a.com.` would refuse an explicit allow rule for a.com.
     const config = gen({ httpsRules: ["a.com:443"] });
-    expect(config.includes("hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$")).toBe(true);
+    expect(config.includes("hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\\\.com$")).toBe(true);
   });
 
   it("takes the port from the connection, not from the Host header", () => {
@@ -335,7 +335,7 @@ describe("rules", () => {
     // :9443 also permit :443 on the same host. Found by the round-trip test.
     const config = gen({ urlRules: buildUrlRules("GET https://a.com:9443/private/x") });
     expect(
-      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$"),
+      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\\\.com$"),
     ).toBe(true);
     expect(config.includes("acl s0_port dst_port 9443")).toBe(true);
     expect(config.includes("(:9443)?")).toBe(false);
@@ -347,7 +347,7 @@ describe("rules", () => {
   it("gives a host rule the same treatment", () => {
     const config = gen({ httpsRules: ["a.com:8443"] });
     expect(
-      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$"),
+      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\\\.com$"),
     ).toBe(true);
     expect(config.includes("acl s0_port dst_port 8443")).toBe(true);
   });
@@ -360,7 +360,9 @@ describe("rules", () => {
       ),
     ).toBe(true);
     expect(
-      config.includes("acl s0_host var(txn.host_port) -m reg -i ^.*\\.example\\.com:(443|8443)$"),
+      config.includes(
+        "acl s0_host var(txn.host_port) -m reg -i ^.*\\\\.example\\\\.com:(443|8443)$",
+      ),
     ).toBe(true);
     // The pattern's own port coverage replaces dst_port entirely.
     expect(config.includes("s0_port")).toBe(false);
@@ -376,7 +378,7 @@ describe("rules", () => {
   it("matches the host and the path separately", () => {
     const config = gen({ urlRules: buildUrlRules("GET https://a.com/pub/**") });
     expect(
-      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$"),
+      config.includes("acl s0_host hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\\\.com$"),
     ).toBe(true);
     expect(config.includes("acl s0_path path -m reg ^/pub/.*$")).toBe(true);
     expect(config.includes("acl s0_method method GET")).toBe(true);
@@ -387,7 +389,7 @@ describe("rules", () => {
 
   it("accepts a Host header with or without the port, since only the name is compared", () => {
     const config = gen({ httpsRules: ["a.com:443"] });
-    expect(config.includes("hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\.com$")).toBe(true);
+    expect(config.includes("hdr(host),host_only,regsub(\\.$,) -m reg -i ^a\\\\.com$")).toBe(true);
     expect(config.includes("acl s0_port dst_port 443")).toBe(true);
   });
 
@@ -434,7 +436,9 @@ describe("passthrough", () => {
   });
 
   it("routes tls rules by SNI, and by the port the rule names", () => {
-    expect(config.includes("acl tls0_sni req.ssl_sni -m reg -i ^db\\.example\\.com$")).toBe(true);
+    expect(config.includes("acl tls0_sni req.ssl_sni -m reg -i ^db\\\\.example\\\\.com$")).toBe(
+      true,
+    );
     // The port used to be dropped, so db.example.com:443 was permitted too.
     expect(config.includes("acl tls0_port dst_port 443")).toBe(true);
     expect(
@@ -449,7 +453,7 @@ describe("passthrough", () => {
     );
     expect(
       result.config.includes(
-        "acl tls0_sni var(txn.sni_port) -m reg -i ^.*\\.example\\.com:(5432|5433)$",
+        "acl tls0_sni var(txn.sni_port) -m reg -i ^.*\\\\.example\\\\.com:(5432|5433)$",
       ),
     ).toBe(true);
     // The pattern's own port coverage replaces dst_port entirely.
@@ -515,7 +519,7 @@ describe("passthrough", () => {
     expect(result.config.includes("set-var-fmt(txn.dst_str) %[dst]:%[dst_port]")).toBe(true);
     expect(
       result.config.includes(
-        "acl ip0_dst var(txn.dst_str) -m reg ^192\\.168\\.1\\.\\d+:(8080|8081)$",
+        "acl ip0_dst var(txn.dst_str) -m reg ^192\\\\.168\\\\.1\\\\.\\\\d+:(8080|8081)$",
       ),
     ).toBe(true);
     // The pattern's own port coverage replaces dst_port entirely.
@@ -578,12 +582,12 @@ describe("regex url rules", () => {
     expect(segment.includes("set-var(txn.s0_ok) bool(false)")).toBe(true);
     expect(
       segment.includes(
-        "set-var(txn.s0_ok) bool(true) if is_default_port { var(txn.host_bare) -m reg -i ^a\\.com$ }",
+        "set-var(txn.s0_ok) bool(true) if is_default_port { var(txn.host_bare) -m reg -i ^a\\\\.com$ }",
       ),
     ).toBe(true);
     expect(
       segment.includes(
-        "set-var(txn.s0_ok) bool(true) if { var(txn.host_full) -m reg -i ^a\\.com$ }",
+        "set-var(txn.s0_ok) bool(true) if { var(txn.host_full) -m reg -i ^a\\\\.com$ }",
       ),
     ).toBe(true);
     expect(segment.includes("acl s0_host var(txn.s0_ok) -m bool")).toBe(true);
@@ -599,7 +603,52 @@ describe("regex url rules", () => {
     });
     expect(result.warnings.length).toBe(0);
     const segment = frontendSegment(result.config, "https_in");
-    expect(segment.includes("-m reg -i ^a\\.com:(443|8443)$")).toBe(true);
+    expect(segment.includes("-m reg -i ^a\\\\.com:(443|8443)$")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Escaping for HAProxy's own config parser
+// ---------------------------------------------------------------------------
+describe("escaping rule text for the config parser", () => {
+  it("escapes a '#' in a path, which would otherwise comment the ACL short", () => {
+    // Verified against haproxy 3.2 by generating this config with the escape
+    // removed: it reports `regex '^/pkg(x' is invalid` for `^/pkg(x#y)$`, so
+    // everything from the `#` really is dropped. With a pattern that stays
+    // valid when cut short, nothing would report anything and the rule would
+    // quietly allow every path merely starting with `/pkg`.
+    const result = generateHaproxyConfig({
+      urlRules: buildUrlRules("GET ~^https://a\\.com/pkg#frag$"),
+    });
+    const segment = frontendSegment(result.config, "https_in");
+    expect(segment.includes("path -m reg ^/pkg\\#frag$")).toBe(true);
+    expect(segment.includes("path -m reg ^/pkg#frag$")).toBe(false);
+  });
+
+  it("escapes quotes, which the parser would otherwise read as opening a string", () => {
+    const result = generateHaproxyConfig({
+      urlRules: buildUrlRules(`GET ~^https://a\\.com/['"]$`),
+    });
+    const segment = frontendSegment(result.config, "https_in");
+    expect(segment.includes(`path -m reg ^/[\\'\\"]$`)).toBe(true);
+  });
+
+  it("doubles a backslash, since that is the one escape the parser folds", () => {
+    // `\.` reaches the regex engine as written, but `\\` collapses to `\`, so
+    // every backslash has to be doubled for the pair to survive together.
+    const result = generateHaproxyConfig({ httpsRules: ["a.com:443"] });
+    expect(result.config.includes("-m reg -i ^a\\\\.com$")).toBe(true);
+  });
+
+  it("escapes a '#' in an SNI rule and in a regex ip rule too", () => {
+    const result = generateHaproxyConfig({
+      tlsRules: ["~^a#b\\.com:443$"],
+      ipRules: ["~^10\\.0\\.0\\.1#x:443$"],
+    });
+    expect(result.config.includes("acl tls0_sni var(txn.sni_port) -m reg -i ^a\\#b")).toBe(true);
+    expect(
+      result.config.includes("acl ip0_dst var(txn.dst_str) -m reg ^10\\\\.0\\\\.0\\\\.1\\#x"),
+    ).toBe(true);
   });
 });
 

--- a/src/core/lib/acl/haproxy-config.ts
+++ b/src/core/lib/acl/haproxy-config.ts
@@ -71,6 +71,24 @@ export interface GeneratedHaproxyConfig {
   warnings: string[];
 }
 
+/**
+ * Escape a rule-derived value for HAProxy's config word parser.
+ *
+ * Unquoted, the parser drops everything from a `#` to the end of the line, so a
+ * rule carrying one would silently shorten the ACL it belongs to rather than
+ * fail: `^/pkg#frag$` reaches the regex engine as `^/pkg`, allowing every path
+ * that merely starts with `/pkg`. A quote opens a quoted string and breaks the
+ * config outright.
+ *
+ * Only ` `, `#`, `\`, `'` and `"` are folded by the parser, and `\` is folded
+ * only before one of those: `\.` and `$` arrive at the regex engine as written,
+ * which is why every backslash is doubled here. One pass over the original
+ * string, so an escape this adds is never escaped again.
+ */
+export function escapeForHaproxy(value: string): string {
+  return value.replace(/[\\#'" ]/g, "\\$&");
+}
+
 /** Emit the rule ACLs and the single deny that enforces them. */
 function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"): string[] {
   const lines: string[] = [];
@@ -104,26 +122,27 @@ function ruleBlock(rules: CompiledRule[], mode: string, scheme: "https" | "http"
   }
 
   for (const rule of rules) {
+    const hostRegex = escapeForHaproxy(rule.hostRegex);
     lines.push(`    # ${rule.raw}`);
     if (rule.hostMatch === "hostPort") {
-      lines.push(`    acl ${rule.id}_host var(txn.host_port) -m reg -i ${rule.hostRegex}`);
+      lines.push(`    acl ${rule.id}_host var(txn.host_port) -m reg -i ${hostRegex}`);
     } else if (rule.hostMatch === "hostBareFull") {
       lines.push(
         `    http-request set-var(txn.${rule.id}_ok) bool(false)`,
         `    http-request set-var(txn.${rule.id}_ok) bool(true) if is_default_port ` +
-          `{ var(txn.host_bare) -m reg -i ${rule.hostRegex} }`,
+          `{ var(txn.host_bare) -m reg -i ${hostRegex} }`,
         `    http-request set-var(txn.${rule.id}_ok) bool(true) if ` +
-          `{ var(txn.host_full) -m reg -i ${rule.hostRegex} }`,
+          `{ var(txn.host_full) -m reg -i ${hostRegex} }`,
         `    acl ${rule.id}_host var(txn.${rule.id}_ok) -m bool`,
       );
     } else {
       // -i, since a name is case-insensitive and do-resolve lowercases anyway.
-      lines.push(`    acl ${rule.id}_host hdr(host),${HOST_ONLY} -m reg -i ${rule.hostRegex}`);
+      lines.push(`    acl ${rule.id}_host hdr(host),${HOST_ONLY} -m reg -i ${hostRegex}`);
       if (rule.port) {
         lines.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
       }
     }
-    lines.push(`    acl ${rule.id}_path path -m reg ${rule.pathRegex}`);
+    lines.push(`    acl ${rule.id}_path path -m reg ${escapeForHaproxy(rule.pathRegex)}`);
     if (rule.methods) {
       lines.push(`    acl ${rule.id}_method method ${rule.methods.join(" ")}`);
     }
@@ -241,7 +260,7 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
       l.push(`    # ${rule.raw}`);
       l.push(
         rule.hostMatch === "hostPort"
-          ? `    acl ${rule.id}_dst var(txn.dst_str) -m reg ${rule.address}`
+          ? `    acl ${rule.id}_dst var(txn.dst_str) -m reg ${escapeForHaproxy(rule.address)}`
           : `    acl ${rule.id}_dst dst ${rule.address}`,
       );
       if (rule.port) l.push(`    acl ${rule.id}_port dst_port ${rule.port}`);
@@ -250,8 +269,8 @@ export function generateHaproxyConfig(options: HaproxyConfigOptions = {}): Gener
       l.push(`    # ${host.raw}`);
       l.push(
         host.hostMatch === "hostPort"
-          ? `    acl ${host.id}_sni var(txn.sni_port) -m reg -i ${host.hostRegex}`
-          : `    acl ${host.id}_sni req.ssl_sni -m reg -i ${host.hostRegex}`,
+          ? `    acl ${host.id}_sni var(txn.sni_port) -m reg -i ${escapeForHaproxy(host.hostRegex)}`
+          : `    acl ${host.id}_sni req.ssl_sni -m reg -i ${escapeForHaproxy(host.hostRegex)}`,
       );
       if (host.port) l.push(`    acl ${host.id}_port dst_port ${host.port}`);
     }

--- a/src/core/lib/acl/url-rules.test.ts
+++ b/src/core/lib/acl/url-rules.test.ts
@@ -167,6 +167,12 @@ describe("buildUrlRules", () => {
     const rules = buildUrlRules("GET ~^https://a\\.com/x#frag$");
     expect(rules[0].raw).toBe("GET ~^https://a\\.com/x#frag$");
   });
+
+  it("refuses a fragment in a literal URL, which no request ever carries", () => {
+    // Easy to paste in from a documentation link, and it could only ever match
+    // nothing: the fragment stays in the browser.
+    expect(() => convertUrlRule("GET https://a.com/pkg#frag")).toThrow(/fragment/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/lib/acl/url-rules.ts
+++ b/src/core/lib/acl/url-rules.ts
@@ -104,7 +104,7 @@ export function parseMethods(spec: string, rule: string): string[] | null {
 /**
  * Split a URL pattern into scheme, authority (host:port) and path.
  *
- * @throws {Error} if the pattern is not an http(s) URL
+ * @throws {Error} if the pattern is not an http(s) URL, or carries a fragment
  */
 function splitUrl(
   url: string,
@@ -114,6 +114,17 @@ function splitUrl(
   if (!match) {
     throw new Error(
       `Invalid URL in rule "${rule}": expected http:// or https:// followed by a host`,
+    );
+  }
+  // A fragment stays in the browser, so it is never part of the path a request
+  // carries and a rule naming one could only ever match nothing. Easy to copy
+  // in from a documentation link, so it is refused rather than left to fail
+  // silently.
+  if (url.includes("#")) {
+    throw new Error(
+      `Invalid URL in rule "${rule}": a "#" fragment is never sent with a request, so this rule ` +
+        `would match nothing. Drop it, or write the rule as a "~" regex if the "#" is meant ` +
+        `literally.`,
     );
   }
   return { scheme: match[1] as "https" | "http", authority: match[2], path: match[3] ?? "" };


### PR DESCRIPTION
## Summary

The `inspect` engine writes its rules straight into `haproxy.cfg`, and HAProxy's config parser folds five characters before anything else reads the line: a space, `#`, `\`, `'` and `"`. Nothing escaped them.

`#` is the one that matters. Everything from an unescaped `#` to the end of the line is dropped, so `GET https://reg.example.com/pkg#frag` emitted `acl s0_path path -m reg ^/pkg#frag$` and HAProxy compiled `^/pkg`. The rule then allowed `/pkganything` and `/pkg/...`, everything the author wrote the `#frag` to exclude, with nothing logged and no error. A fragment is easy to pick up by copying a URL out of a documentation page.

Confirmed against haproxy 3.2 rather than inferred. Generating this branch's own config with the escape removed makes HAProxy report `regex '^/pkg(x' is invalid (error=missing closing parenthesis)` for the pattern `^/pkg(x#y)$`, which is the truncation happening in the open. A pattern that stays valid when cut short, which is the ordinary case, produces no message at all.

A quote is less dangerous but not harmless: it opens a quoted string and the config fails to load.

## Changes

- A `#`, `'`, `"`, backslash or space in a rule is now escaped for HAProxy's config parser, so an ACL matches what the rule actually says. This covers host, path, SNI and `~` ip rules alike.
- A literal URL rule carrying a `#` fragment is now refused with an error, instead of compiling to a rule that matches nothing. A `~` regex rule may still contain a `#`.
- A rule using none of those characters compiles to exactly the same ACL as before.

## Test plan
- [x] `compose.test-inspect.yaml` gains a never-requested rule, `GET ~^https://blocked\.example\.com/frag(x#y|'z)$`, chosen so the truncated form is an invalid regex: if the escaping regresses, haproxy refuses the config and the inspect e2e jobs fail rather than passing with a widened ACL
- [x] Ran the real inspect image from this branch: the container comes up healthy and `/etc/haproxy/haproxy.cfg` holds `acl s9_path path -m reg ^/frag(x\#y|\'z)$`
- [x] Probed haproxy 3.2 directly for each character, since the escaping rules are asymmetric: `\#` `\'` `\"` reach the regex engine as `#` `'` `"`, `\\.` arrives as `\.`, and `\.` `$y` `\$y` pass through untouched
