### PR TITLE
fix: take report-action.js from the builder image, not the running container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,8 @@ test_unit_setup: ## Run setup action unit tests
 	@vp test run src/lib src/main
 
 .PHONY: test_unit_report
-# report/src has no package-local pure functions to unit-test.
 test_unit_report: ## Run report unit tests
-	@vp test run report/src --passWithNoTests
+	@vp test run report/src
 
 # qjs can't execute .ts directly, so compile fresh (vp run build:qjs-test)
 # and bind-mount the output in. qjs itself is identical across images, so one

--- a/docker/explicit/scripts/report-action.node.ts
+++ b/docker/explicit/scripts/report-action.node.ts
@@ -1,11 +1,11 @@
 /**
  * Generates and emits the explicit engine's outbound-traffic report.
- * Baked into the image, fetched fresh via `docker cp` by the `report`
- * action on every run (never staged on the runner — see report/src/main.ts)
- * and run with `node report-action.js <container-id>`. Runs on the runner,
- * not inside the container, reaching in via core/lib/docker/client.ts —
- * including `buildctl` itself, run inside the container via `docker exec`
- * rather than needing buildctl reachable from the runner.
+ * Baked into the image, copied out of it (not out of the running container)
+ * by the `report` action on every run, and run with `node report-action.js
+ * <container-id>`. Runs on the runner, not inside the container, reaching in
+ * via core/lib/docker/client.ts — including `buildctl` itself, run inside the
+ * container via `docker exec` rather than needing buildctl reachable from the
+ * runner.
  */
 import * as core from "@actions/core";
 import { createDocker, type Docker } from "#core/lib/docker/client.ts";

--- a/docker/inspect/scripts/report-action.node.ts
+++ b/docker/inspect/scripts/report-action.node.ts
@@ -1,10 +1,11 @@
 /**
  * Generates and emits the inspect engine's outbound-traffic report.
  *
- * Baked into the image and fetched via `docker cp` by the `report` action,
- * which runs it on the runner as `node report-action.js <container-id>` (see
- * report/src/main.ts). Reads two logs: the proxy's requests and the resolver's
- * refused names, the latter being the only trace of a DNS-only exfiltration.
+ * Baked into the image and copied out of it (not out of the running
+ * container) by the `report` action, which runs it on the runner as
+ * `node report-action.js <container-id>` (see report/src/main.ts). Reads two
+ * logs: the proxy's requests and the resolver's refused names, the latter
+ * being the only trace of a DNS-only exfiltration.
  */
 import * as core from "@actions/core";
 import { createDocker } from "#core/lib/docker/client.ts";

--- a/docker/universal/scripts/report-action.node.ts
+++ b/docker/universal/scripts/report-action.node.ts
@@ -1,11 +1,10 @@
 /**
  * Generates and emits the universal engine's outbound-traffic report.
- * Baked into the image, fetched fresh via `docker cp` by the `report`
- * action on every run (never staged on the runner — see report/src/main.ts)
- * and run with `node report-action.js <container-id>`. Runs on the runner,
- * not inside the container, reaching in via core/lib/docker/client.ts —
- * so `report` itself never needs to know this engine's log path or env
- * var names.
+ * Baked into the image, copied out of it (not out of the running container)
+ * by the `report` action on every run, and run with `node report-action.js
+ * <container-id>`. Runs on the runner, not inside the container, reaching in
+ * via core/lib/docker/client.ts — so `report` itself never needs to know this
+ * engine's log path or env var names.
  */
 import * as core from "@actions/core";
 import { createDocker } from "#core/lib/docker/client.ts";

--- a/docs/development.md
+++ b/docs/development.md
@@ -243,7 +243,7 @@ CA store), `inspect_roundtrip` (learn rules from an audit run, then enforce them
 │   ├── lib/                  # write-step-summary.ts, shared by both engines' report-action.node.ts
 │   ├── universal/            # proxy_engine: universal. Dockerfile + BuildKit/haproxy/dnsmasq/
 │   │                         # s6-overlay config + scripts/report-action.node.ts (runs under Node
-│   │                         # on the runner, `docker cp`'d out by the report action)
+│   │                         # on the runner, copied out of the image by the report action)
 │   ├── inspect/               # proxy_engine: inspect. Dockerfile + HAProxy/CoreDNS/s6-overlay
 │   │                         # config + buildcage-runc/ (Go module: wraps buildkit-runc to inject
 │   │                         # CA trust at exec time) + scripts/report-action.node.ts
@@ -251,7 +251,7 @@ CA store), `inspect_roundtrip` (learn rules from an audit run, then enforce them
 │                             # entrypoint/PID1, supervises buildkitd, injects the source policy
 │                             # into Solve via a gRPC proxy) + scripts/ (gen-source-policy.ts runs
 │                             # under QuickJS; report-action.node.ts runs under Node on the runner,
-│                             # `docker cp`'d out by the report action. TypeScript, rolldown-bundled
+│                             # copied out of the image by the report action. TypeScript, rolldown-bundled
 │                             # at image build time)
 ├── test/                     # Dockerfile.*/assert-*.sh per {engine}-{mode} combination, plus the
 │                             # fixture containers: test-server and test-dns per engine, and

--- a/docs/security.md
+++ b/docs/security.md
@@ -554,8 +554,9 @@ Verification establishes where the image came from. Here is what it leaves uncov
   Buildcage's threat model is malicious code _inside_ a `RUN` step. An untrusted step elsewhere in
   the same job is not: running between `setup` and `report`, it can reach the proxy container
   through `docker exec`/`docker cp`, or the host filesystem directly on a passwordless-sudo runner,
-  and rewrite its traffic log or the script `report` executes. Sigstore proves the image was genuine
-  at startup, not that nothing touched it afterwards.
+  and rewrite its traffic log. Sigstore proves the image was genuine at startup, not that nothing
+  touched it afterwards. The script `report` runs is not part of that gap: it comes from the image,
+  not from the container.
 
   `report` does refuse to pass a log carrying no trace of a real proxy run, which catches wholesale
   erasure but not a format-aware forgery. The effective defense is procedural: don't place an

--- a/report/dist/main.cjs
+++ b/report/dist/main.cjs
@@ -12298,6 +12298,48 @@ function errorMessage(e) {
 	return e instanceof Error ? e.message : String(e);
 }
 //#endregion
+//#region report/src/lib/copy-from-image.ts
+const runDocker = (args) => (0, node_child_process.execFileSync)("docker", args, {
+	encoding: "utf8",
+	stdio: [
+		"ignore",
+		"pipe",
+		"pipe"
+	]
+});
+/**
+* Copies a path out of the image `containerId` was created from, so a `RUN`
+* step that escaped its sandbox and wrote into the container cannot reach the
+* runner through it. The image ID comes from the daemon's record of the
+* container, which nothing inside it can rewrite, and the scratch container is
+* never started, so what comes out is the image's own copy.
+*/
+function copyFromContainerImage(containerId, containerPath, hostPath, run = runDocker) {
+	let imageId = run([
+		"inspect",
+		containerId,
+		"--format",
+		"{{.Image}}"
+	]).trim();
+	if (!imageId) throw Error(`docker inspect reported no image for container ${containerId}`);
+	let scratchId = run(["create", imageId]).trim();
+	try {
+		run([
+			"cp",
+			`${scratchId}:${containerPath}`,
+			hostPath
+		]);
+	} finally {
+		try {
+			run([
+				"rm",
+				"-f",
+				scratchId
+			]);
+		} catch {}
+	}
+}
+//#endregion
 //#region report/src/lib/errors.ts
 /**
 * ReportError — intentional error in the report action's own logic. Invalid
@@ -12305,7 +12347,8 @@ function errorMessage(e) {
 * core/lib/acl/rules.ts).
 *
 * Codes:
-*   DOCKER_UNAVAILABLE   – docker CLI missing from PATH, or `docker ps`/`docker cp` failed
+*   DOCKER_UNAVAILABLE   – docker CLI missing from PATH, or a docker call
+*                          (`ps`, `inspect`, `create`, `cp`) failed
 *   CONTAINER_NOT_FOUND  – `docker ps --filter` didn't find exactly one
 *                          report-source container for this builder_name
 *   REPORT_SCRIPT_FAILED – report-action.js couldn't even be launched (a
@@ -70279,9 +70322,9 @@ async function main() {
 	try {
 		let reportActionPath = (0, node_path.join)(scratchDir, "report-action.js");
 		try {
-			docker.copyFromContainer(containerId, "/opt/buildcage/scripts/report-action.js", reportActionPath);
+			copyFromContainerImage(containerId, "/opt/buildcage/scripts/report-action.js", reportActionPath);
 		} catch (e) {
-			throw new ReportError(describeDockerFailure(e, { operation: "docker cp (fetching report-action.js from the container)" }), "DOCKER_UNAVAILABLE");
+			throw new ReportError(describeDockerFailure(e, { operation: "docker cp (fetching report-action.js from the builder image)" }), "DOCKER_UNAVAILABLE");
 		}
 		let trafficFile = wantsTrafficArtifact() ? (0, node_path.join)(scratchDir, "traffic.json") : void 0;
 		try {

--- a/report/src/lib/copy-from-image.test.ts
+++ b/report/src/lib/copy-from-image.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+import { copyFromContainerImage } from "./copy-from-image.ts";
+import { REPORT_ACTION_SCRIPT_PATH } from "#core/lib/docker/report-source.ts";
+
+const BUILDER_ID = "builder123";
+const IMAGE_ID = "sha256:feedface";
+const SCRATCH_ID = "scratch456";
+const HOST_PATH = "/tmp/report-action.js";
+
+/** Records every invocation's argv and returns a scripted response per call. */
+function fakeRun(responses: string[]): { run: (args: string[]) => string; calls: string[][] } {
+  const calls: string[][] = [];
+  let i = 0;
+  return {
+    calls,
+    run(args: string[]) {
+      calls.push(args);
+      return responses[i++] ?? "";
+    },
+  };
+}
+
+describe("copyFromContainerImage", () => {
+  it("copies from a scratch container made from the builder's image, then removes it", () => {
+    const { run, calls } = fakeRun([`${IMAGE_ID}\n`, `${SCRATCH_ID}\n`, "", ""]);
+
+    copyFromContainerImage(BUILDER_ID, REPORT_ACTION_SCRIPT_PATH, HOST_PATH, run);
+
+    expect(calls).toStrictEqual([
+      ["inspect", BUILDER_ID, "--format", "{{.Image}}"],
+      ["create", IMAGE_ID],
+      ["cp", `${SCRATCH_ID}:${REPORT_ACTION_SCRIPT_PATH}`, HOST_PATH],
+      ["rm", "-f", SCRATCH_ID],
+    ]);
+  });
+
+  it("never reads the running container itself", () => {
+    const { run, calls } = fakeRun([IMAGE_ID, SCRATCH_ID, "", ""]);
+
+    copyFromContainerImage(BUILDER_ID, REPORT_ACTION_SCRIPT_PATH, HOST_PATH, run);
+
+    const cp = calls.find((args) => args[0] === "cp");
+    expect(cp).toBeDefined();
+    expect(cp!.some((arg) => arg.includes(BUILDER_ID))).toBe(false);
+  });
+
+  it("removes the scratch container even when the copy fails", () => {
+    const calls: string[][] = [];
+    const run = (args: string[]) => {
+      calls.push(args);
+      if (args[0] === "inspect") return IMAGE_ID;
+      if (args[0] === "create") return SCRATCH_ID;
+      if (args[0] === "cp") throw new Error("no such file");
+      return "";
+    };
+
+    expect(() =>
+      copyFromContainerImage(BUILDER_ID, REPORT_ACTION_SCRIPT_PATH, HOST_PATH, run),
+    ).toThrow("no such file");
+    expect(calls.at(-1)).toStrictEqual(["rm", "-f", SCRATCH_ID]);
+  });
+
+  it("keeps the copy's failure when the cleanup fails too", () => {
+    const run = (args: string[]) => {
+      if (args[0] === "inspect") return IMAGE_ID;
+      if (args[0] === "create") return SCRATCH_ID;
+      throw new Error(args[0] === "cp" ? "no such file" : "rm failed");
+    };
+
+    expect(() =>
+      copyFromContainerImage(BUILDER_ID, REPORT_ACTION_SCRIPT_PATH, HOST_PATH, run),
+    ).toThrow("no such file");
+  });
+
+  it("throws when docker inspect reports no image", () => {
+    const { run } = fakeRun(["\n"]);
+
+    expect(() =>
+      copyFromContainerImage(BUILDER_ID, REPORT_ACTION_SCRIPT_PATH, HOST_PATH, run),
+    ).toThrow(`docker inspect reported no image for container ${BUILDER_ID}`);
+  });
+});

--- a/report/src/lib/copy-from-image.ts
+++ b/report/src/lib/copy-from-image.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+
+export type RunDocker = (args: string[]) => string;
+
+// stderr is piped, not inherited, so describeDockerFailure can quote it.
+const runDocker: RunDocker = (args) =>
+  execFileSync("docker", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+/**
+ * Copies a path out of the image `containerId` was created from, so a `RUN`
+ * step that escaped its sandbox and wrote into the container cannot reach the
+ * runner through it. The image ID comes from the daemon's record of the
+ * container, which nothing inside it can rewrite, and the scratch container is
+ * never started, so what comes out is the image's own copy.
+ */
+export function copyFromContainerImage(
+  containerId: string,
+  containerPath: string,
+  hostPath: string,
+  run: RunDocker = runDocker,
+): void {
+  const imageId = run(["inspect", containerId, "--format", "{{.Image}}"]).trim();
+  if (!imageId) {
+    throw new Error(`docker inspect reported no image for container ${containerId}`);
+  }
+
+  // No command needed: every buildcage image defines an ENTRYPOINT.
+  const scratchId = run(["create", imageId]).trim();
+  try {
+    run(["cp", `${scratchId}:${containerPath}`, hostPath]);
+  } finally {
+    try {
+      run(["rm", "-f", scratchId]);
+    } catch {
+      // The copy is already done; don't fail the report over a leaked container.
+    }
+  }
+}

--- a/report/src/lib/errors.ts
+++ b/report/src/lib/errors.ts
@@ -6,7 +6,8 @@ import { ActionError } from "#core/lib/errors.ts";
  * core/lib/acl/rules.ts).
  *
  * Codes:
- *   DOCKER_UNAVAILABLE   – docker CLI missing from PATH, or `docker ps`/`docker cp` failed
+ *   DOCKER_UNAVAILABLE   – docker CLI missing from PATH, or a docker call
+ *                          (`ps`, `inspect`, `create`, `cp`) failed
  *   CONTAINER_NOT_FOUND  – `docker ps --filter` didn't find exactly one
  *                          report-source container for this builder_name
  *   REPORT_SCRIPT_FAILED – report-action.js couldn't even be launched (a

--- a/report/src/main.ts
+++ b/report/src/main.ts
@@ -10,6 +10,7 @@ import { resolveProjectName } from "#core/lib/docker/compose-project-name.ts";
 import { createDocker } from "#core/lib/docker/client.ts";
 import { REPORT_ACTION_SCRIPT_PATH, REPORT_SOURCE_LABEL } from "#core/lib/docker/report-source.ts";
 import { ActionError, errorMessage } from "#core/lib/errors.ts";
+import { copyFromContainerImage } from "./lib/copy-from-image.ts";
 import { ReportError } from "./lib/errors.ts";
 
 // Gates the COMPOSE_PROJECT_NAME override to this repo's own CI/dev testing.
@@ -56,11 +57,11 @@ async function main(): Promise<void> {
     const reportActionPath = join(scratchDir, "report-action.js");
 
     try {
-      docker.copyFromContainer(containerId, REPORT_ACTION_SCRIPT_PATH, reportActionPath);
+      copyFromContainerImage(containerId, REPORT_ACTION_SCRIPT_PATH, reportActionPath);
     } catch (e) {
       throw new ReportError(
         describeDockerFailure(e, {
-          operation: "docker cp (fetching report-action.js from the container)",
+          operation: "docker cp (fetching report-action.js from the builder image)",
         }),
         "DOCKER_UNAVAILABLE",
       );


### PR DESCRIPTION
## Summary

The `report` action pulled `/opt/buildcage/scripts/report-action.js` out of the **running** builder container with `docker cp` and ran it on the runner with node, inheriting the step's environment. Sigstore verifies the image at `setup` time, not the container's filesystem at `report` time, and by then the build has run. A `RUN` step that escaped its sandbox into the builder container only had to overwrite that one file to get code execution on the runner in the next step.

Nothing about the script itself was dangerous: it reads `GITHUB_STEP_SUMMARY`, the two `GITHUB_ACTION_*` variables and `fail_on_blocked`, and never touches `ACTIONS_RUNTIME_TOKEN`. The problem was that whatever replaced it would run in its place.

The script now comes from the image the container was created from. `docker inspect` gives the image ID, which is the daemon's own record and not something inside the container can rewrite, and a scratch container created from it (never started) is what `docker cp` reads, so the bytes are the image's own.

Bundling the script into `report/dist/` instead was the obvious alternative and was rejected: each engine has its own log paths and log format, so `report` would have to know all three, and `setup` and `report` could no longer be pinned to different versions.

## Changes

- `report` copies `report-action.js` out of the builder image rather than out of the running container. A rewrite of the container's copy no longer has any effect.
- Nothing under `src/core/` changed, so `client.ts` and `args.ts` stay byte-identical with `buildcage/isolated-run`, which has no equivalent path.
- `docs/security.md` no longer lists the script `report` executes among what a co-located step can rewrite. Traffic-log forgery is unchanged and stays out of scope.

## Test plan

- [x] Universal audit e2e on a real builder: report renders as before and leaves no scratch container behind
- [x] Overwrote `/opt/buildcage/scripts/report-action.js` in the running container with `process.exit(9)`, then ran `report`: the report renders normally. Running the old path against the same container (`docker cp` from the container, then node) executes the planted script and exits 9
- [x] `make test_integration_buildkit_inspect_restrict`, which also covers the assert scripts that fetch the script from the container themselves
