### PR TITLE
ci: verify the committed dist on dist-only PRs and before tagging a release

### DIFF
--- a/.github/actions/verify-dist/action.yml
+++ b/.github/actions/verify-dist/action.yml
@@ -1,0 +1,37 @@
+name: Verify dist
+description: Rebuild the committed dist bundles and confirm they match the source
+# Callers must run actions/checkout and ./.github/actions/setup-vp first.
+
+runs:
+  using: composite
+  steps:
+    - name: Build
+      shell: bash
+      run: vp run build
+
+    - name: Check dist is up to date
+      shell: bash
+      run: git diff --exit-code
+
+    # git diff only sees tracked files, so a build that starts emitting a new
+    # chunk would pass it unnoticed.
+    - name: Check the build emitted no untracked output
+      shell: bash
+      run: |
+        UNTRACKED=$(git status --porcelain -- dist report/dist)
+        if [ -n "$UNTRACKED" ]; then
+          echo "::error::The build produced output that is not committed:"
+          echo "$UNTRACKED"
+          exit 1
+        fi
+
+    - name: Check dist is free of the BUILDCAGE_BUILD_TEST_HOOKS test hooks
+      shell: bash
+      run: |
+        for f in dist/main.cjs dist/post.cjs report/dist/main.cjs; do
+          if grep -q 'process\.env\.BUILDCAGE_BUILD_TEST_HOOKS' "$f"; then
+            echo "::error::$f still contains a live process.env.BUILDCAGE_BUILD_TEST_HOOKS read — rolldown's replacePlugin failed to substitute it (see rolldown.config.js), leaving a test-only hook reachable in a published action. Do not merge until this passes."
+            exit 1
+          fi
+          echo "confirmed: $f has no live BUILDCAGE_BUILD_TEST_HOOKS read — its test hooks are unreachable in this build."
+        done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,24 @@ on:
 permissions: {}
 
 jobs:
+  # A tag can't be moved once consumers pin to it, so the bundles are rebuilt
+  # and compared here rather than trusted from whatever PR landed them.
+  verify_dist:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-vp
+
+      - uses: ./.github/actions/verify-dist
+
   release:
+    needs: verify_dist
     runs-on: ubuntu-slim
     environment: release
     permissions:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -29,6 +29,9 @@ jobs:
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
+          # dist/** and action.yml are listed as what unit_test verifies, not
+          # as inputs to it: this job holds the only check that the committed
+          # bundles match the source.
           filters: |
             unit_test:
               - 'package.json'
@@ -40,12 +43,14 @@ jobs:
               - 'tsconfig.qjs.json'
               - 'vite.config.ts'
               - '.dockerignore'
-              - '.github/actions/setup-vp/**'
+              - '.github/actions/**'
               - '.github/workflows/test-unit.yml'
               - 'src/**'
               - 'docker/**'
               - 'report/**'
               - 'Makefile'
+              - 'dist/**'
+              - 'action.yml'
 
   unit_test:
     needs: changes
@@ -76,21 +81,7 @@ jobs:
       - name: Check (lint/format)
         run: vp check
 
-      - name: Build
-        run: vp run build
-
-      - name: Check dist is up to date
-        run: git diff --exit-code
-
-      - name: Check dist is free of the BUILDCAGE_BUILD_TEST_HOOKS test hooks
-        run: |
-          for f in dist/main.cjs dist/post.cjs report/dist/main.cjs; do
-            if grep -q 'process\.env\.BUILDCAGE_BUILD_TEST_HOOKS' "$f"; then
-              echo "::error::$f still contains a live process.env.BUILDCAGE_BUILD_TEST_HOOKS read — rolldown's replacePlugin failed to substitute it (see rolldown.config.js), leaving a test-only hook reachable in a published action. Do not merge until this passes."
-              exit 1
-            fi
-            echo "confirmed: $f has no live BUILDCAGE_BUILD_TEST_HOOKS read — its test hooks are unreachable in this build."
-          done
+      - uses: ./.github/actions/verify-dist
 
       - name: Run unit tests
         run: make test_unit


### PR DESCRIPTION
## Summary

What consumers actually run is `dist/main.cjs`, `dist/post.cjs` and `report/dist/main.cjs`. The only check that they match the source is the `vp run build` + `git diff --exit-code` pair inside the `unit_test` job, and that job is behind a `paths-filter` that listed neither `dist/**` nor `action.yml`.

So a PR touching only those paths skipped the job. `Unit tests passed`, the required status check, treats a skipped job as a success, and `.gitattributes` marks the bundles `linguist-generated=true`, so the diff is collapsed by default in review too. Everything on the input side of the build (`src/**`, `package.json`, `rolldown.config.js`, `tsconfig*`, and the rest) was already filtered for; only the output side was missing.

Nothing else covers it. The e2e workflow rebuilds `dist/` with `BUILDCAGE_BUILD_TEST_HOOKS=1` before `uses: ./`, so it never looks at the committed bundles.

`release.yml` had no dist check either. A tag can't be moved once anyone pins to it, so it now rebuilds and compares before pushing one rather than trusting whatever PR landed the bundles.

## Changes

- `dist/**` and `action.yml` are in the `unit_test` filter, so a PR touching only the built output runs the check that verifies it. `report/dist/**` and `report/action.yml` were already covered by `report/**`.
- `.github/actions/setup-vp/**` in that filter widened to `.github/actions/**`, so weakening a composite action triggers the job rather than skipping it.
- The build, the diff and the test-hook grep moved into a `verify-dist` composite action, shared by `unit_test` and the new release-time job so the two cannot drift apart.
- `verify-dist` also fails on untracked build output. `git diff` only sees tracked files, so a build that started emitting a new chunk would have passed unnoticed.
- `release.yml` gains a `verify_dist` job that `release` needs, gating the tag push.

## Test plan

- [x] `actionlint` over the workflows reports nothing new (the two shellcheck style notes in `release.yml` and the three in `docker-publish.yml` are pre-existing and untouched)
- [x] Ran the composite action's steps locally against a clean tree: rebuild leaves `dist/` and `report/dist/` byte-identical, with no untracked output

