### PR TITLE
fix: escape report table cells so a forged Host cannot rewrite a row

### DIFF
--- a/src/core/lib/report/render/host-table.test.ts
+++ b/src/core/lib/report/render/host-table.test.ts
@@ -50,6 +50,17 @@ describe("renderHostTable", () => {
   });
 });
 
+describe("a host carrying markdown syntax", () => {
+  it("stays one cell, so a forged Host header cannot write the rest of the row", () => {
+    const md = renderHostTable(
+      [{ host: "evil.example|HTTPS|-|1|x|", port: "443", ruleType: "HTTPS", count: 1 }],
+      { showReason: true },
+    );
+    const row = md.split("\n")[2];
+    expect(row).toBe("| evil.example\\|HTTPS\\|-\\|1\\|x\\|:443 | HTTPS |  | 1 |");
+  });
+});
+
 describe("a row with no port", () => {
   it("shows the name alone, since a refused name was never connected to", () => {
     const md = renderHostTable([

--- a/src/core/lib/report/render/markdown-table.test.ts
+++ b/src/core/lib/report/render/markdown-table.test.ts
@@ -29,4 +29,54 @@ describe("markdownTable", () => {
     const table = markdownTable([{ key: "a", title: "A" }], []);
     expect(table).toBe("| A |\n| --- |");
   });
+
+  it('renders an absent cell as empty, not as "undefined"', () => {
+    const table = markdownTable(
+      [
+        { key: "a", title: "A" },
+        { key: "b", title: "B" },
+      ],
+      [{ a: "1" }],
+    );
+    expect(table).toBe("| A | B |\n| --- | --- |\n| 1 |  |");
+  });
+
+  describe("cell escaping", () => {
+    const oneCell = (value: string) =>
+      markdownTable([{ key: "a", title: "A" }], [{ a: value }]).split("\n")[2];
+
+    it("escapes a '|' so a host cannot open cells of its own", () => {
+      // What a forged Host header reaches the log as, verbatim.
+      const row = oneCell("evil.example|HTTPS|-|1|x|:443");
+      expect(row).toBe("| evil.example\\|HTTPS\\|-\\|1\\|x\\|:443 |");
+      // Still one cell: the row's `|` count is the two delimiters and nothing more.
+      expect(row.match(/(?<!\\)\|/g)).toHaveLength(2);
+    });
+
+    it("escapes angle brackets so a host cannot inject raw HTML", () => {
+      expect(oneCell("a<details>b")).toBe("| a\\<details\\>b |");
+    });
+
+    it("escapes brackets so a host cannot render as a link", () => {
+      expect(oneCell("[click](https://evil.example)")).toBe(
+        "| \\[click\\](https://evil.example) |",
+      );
+    });
+
+    it("escapes backticks, asterisks and underscores", () => {
+      expect(oneCell("a`b`c*d*e_f_")).toBe("| a\\`b\\`c\\*d\\*e\\_f\\_ |");
+    });
+
+    it("escapes a backslash without double-escaping what follows", () => {
+      expect(oneCell("a\\|b")).toBe("| a\\\\\\|b |");
+    });
+
+    it("collapses a newline, which no backslash could keep inside the row", () => {
+      expect(oneCell("a\r\nb\nc")).toBe("| a b c |");
+    });
+
+    it("leaves the characters an ordinary host is made of alone", () => {
+      expect(oneCell("sub.example-host.com:9443")).toBe("| sub.example-host.com:9443 |");
+    });
+  });
 });

--- a/src/core/lib/report/render/markdown-table.ts
+++ b/src/core/lib/report/render/markdown-table.ts
@@ -10,6 +10,23 @@ const ALIGN_MARKERS: Record<Align, string> = { left: "---", right: "---:", cente
 const alignMarker = (align?: Align): string => ALIGN_MARKERS[align ?? "left"] ?? ALIGN_MARKERS.left;
 
 /**
+ * A cell's text is attacker-chosen (a host comes from an SNI or a Host header),
+ * and an unescaped `|` opens as many extra cells as it likes: a blocked host
+ * can push its own "Reason" and "Expected" values into the row. Brackets and
+ * angle brackets matter for the same reason, turning a host into a link or raw
+ * HTML. `.` and `-` are left alone, being ordinary in a host.
+ *
+ * A newline would split the row itself, which no backslash can prevent, so it
+ * collapses to a space instead.
+ */
+function escapeCell(value: string | number | undefined): string {
+  if (value === undefined) return "";
+  return String(value)
+    .replace(/[\\`*_[\]<>|]/g, "\\$&")
+    .replace(/\r?\n/g, " ");
+}
+
+/**
  * Render a generic GitHub-flavored markdown table.
  */
 export function markdownTable(
@@ -20,7 +37,7 @@ export function markdownTable(
   const aligns = formats.map((f) => alignMarker(f.align));
   const lines = [`| ${headers.join(" | ")} |`, `| ${aligns.join(" | ")} |`];
   for (const row of rows) {
-    const cells = formats.map((f) => row[f.key]);
+    const cells = formats.map((f) => escapeCell(row[f.key]));
     lines.push(`| ${cells.join(" | ")} |`);
   }
   return lines.join("\n");


### PR DESCRIPTION
## Summary

The Job Summary's host tables are built by joining cells with `| `, and nothing escaped what went into them. A host cell is attacker-chosen: the `inspect` engine logs the Host header with only whitespace, double quotes and control characters folded to `_`, so a `|` in a forged Host reaches the table verbatim and opens as many cells as it likes.

Confirmed against haproxy 3.2 rather than inferred. `curl -H 'Host: evil.example|HTTPS|-|1|x|' https://allowed.example.com/public/x` is refused by the rules with a 403 and logged as:

```
buildcage <ms> https GET https://evil.example|HTTPS|-|1|x|/public/x 403 192 ts=PR dst=...
```

which rendered as a Blocked Hosts row of eight cells, the reader seeing whatever Reason and Count the build chose to write. The exit code never changes, since that comes from the data, but `audit` runs and `fail_on_blocked: false` runs are read rather than acted on.

Probing one character at a time separates what haproxy passes from what it rejects with a 400:

- Reaches the log: `|` `(` `)` `` ` `` `*` `_` `<` `>` `{` `}` `!` `^` `~` `&` `=` `%` `;` `'` `+` `$`
- Refused as a bad request: `[` `]` `\` `#` `?` `@` `,` and anything non-ASCII

So `<details>` and friends inject raw HTML into a cell the same way (`https://a<details>b/public/x` is logged in full), while a `[text](url)` link cannot be built through a Host header. The escaping covers it anyway: the same table renders hosts the `explicit` engine parses out of buildkitd's logs, which do not go through haproxy's request validation at all.

`universal` was never affected. It reduces both SNI and Host to `[A-Za-z0-9._-]` before logging, as does this engine's own passthrough line for the SNI. Only the Host capture keeps its original bytes, because it carries a port that a hostname charset would strip.

## Changes

- Table cells are escaped for `\` `` ` `` `*` `_` `[` `]` `<` `>` `|` before they are joined. The first eight match the escaper already used for the `explicit` engine's list items; `|` is what a table adds. `.` and `-` stay untouched, being ordinary in a host.
- A newline in a cell collapses to a space. No backslash keeps a row intact across one, and nothing else in the table can.
- An absent cell still renders as empty rather than `undefined`, which the previous `Array.join` did implicitly and is now covered by a test.

## Test plan

- [x] With the fix, the same forged Host renders as `| evil.example\|HTTPS\|-\|1\|x\|:443 | HTTPS | not-allowed | 1 |`, one cell, correct Reason and Count. Ran against a locally built inspect image with the request replayed through the real proxy
- [x] Probed haproxy 3.2 character by character for what a Host header can carry into the log (the two lists above)
