### PR TITLE
fix: leave emphasis markers unescaped in report table cells

### DIFF
--- a/src/core/lib/report/render/markdown-table.test.ts
+++ b/src/core/lib/report/render/markdown-table.test.ts
@@ -63,8 +63,15 @@ describe("markdownTable", () => {
       );
     });
 
-    it("escapes backticks, asterisks and underscores", () => {
-      expect(oneCell("a`b`c*d*e_f_")).toBe("| a\\`b\\`c\\*d\\*e\\_f\\_ |");
+    it("escapes backticks", () => {
+      expect(oneCell("a`b`c")).toBe("| a\\`b\\`c |");
+    });
+
+    it("leaves emphasis markers alone, the universal engine's own filler being one", () => {
+      expect(oneCell("x__-__T__buildcage__ALLOWED___HTTPS___f.example.com:443")).toBe(
+        "| x__-__T__buildcage__ALLOWED___HTTPS___f.example.com:443 |",
+      );
+      expect(oneCell("a*b*c")).toBe("| a*b*c |");
     });
 
     it("escapes a backslash without double-escaping what follows", () => {

--- a/src/core/lib/report/render/markdown-table.ts
+++ b/src/core/lib/report/render/markdown-table.ts
@@ -13,8 +13,13 @@ const alignMarker = (align?: Align): string => ALIGN_MARKERS[align ?? "left"] ??
  * A cell's text is attacker-chosen (a host comes from an SNI or a Host header),
  * and an unescaped `|` opens as many extra cells as it likes: a blocked host
  * can push its own "Reason" and "Expected" values into the row. Brackets and
- * angle brackets matter for the same reason, turning a host into a link or raw
- * HTML. `.` and `-` are left alone, being ordinary in a host.
+ * angle brackets do the same to what the cell means, turning a host into a link
+ * or raw HTML.
+ *
+ * Emphasis markers (`*`, `_`) are deliberately not escaped. They change nothing
+ * but weight, and `_` is what the universal engine substitutes for every
+ * character a host may not carry, so escaping it would bury the one row a
+ * reviewer reads closely in backslashes.
  *
  * A newline would split the row itself, which no backslash can prevent, so it
  * collapses to a space instead.
@@ -22,7 +27,7 @@ const alignMarker = (align?: Align): string => ALIGN_MARKERS[align ?? "left"] ??
 function escapeCell(value: string | number | undefined): string {
   if (value === undefined) return "";
   return String(value)
-    .replace(/[\\`*_[\]<>|]/g, "\\$&")
+    .replace(/[\\`[\]<>|]/g, "\\$&")
     .replace(/\r?\n/g, " ");
 }
 


### PR DESCRIPTION
## Summary

Escaping table cells put `*` and `_` in the set alongside the characters that actually change what a cell is. They don't: emphasis changes weight, not the number of cells, and cannot make a link or raw HTML.

`_` is the worse of the two to escape. The universal engine substitutes it for every character a host may not carry, so a forged SNI arrives as a row that is mostly underscores, and escaping turns the one row a reviewer reads closely into `x\_\_-\_\_T\_\_buildcage\_\_ALLOWED\_\_\_HTTPS\_\_\_forged.example.com:443`. GFM would not have rendered the plain form as emphasis anyway, `_` not being emphasis inside a word.

What the cells are still escaped for is unchanged: `|`, `<`, `>`, `[`, `]`, a backtick, and the backslash that carries them.

## Changes

- `*` and `_` are no longer escaped in table cells, with the reason recorded where the escape set is defined.

## Test plan

- [x] The forged-SNI row renders as the sanitized host itself again, with the escaping of `|`, brackets and angle brackets covered by the existing cases
